### PR TITLE
[codex] Fix Q2RTX launcher recovery

### DIFF
--- a/auto_uv/persistence/unsafe_voltage_cache.py
+++ b/auto_uv/persistence/unsafe_voltage_cache.py
@@ -18,6 +18,9 @@ CONTROLLED_CLOCK_FLOOR_FAILURE_PREFIXES = (
 CONTROLLED_TERMINATION_FAILURE_PREFIXES = (
     "user-stop-requested",
     "cuda-bruteforce-failed exit=-15",
+    # Q2RTX failed to launch (e.g. missing libssl.so.1.1) - an environment error,
+    # not voltage instability. Matches stability.q2rtx Q2RTX_LAUNCHER_ERROR_REASON.
+    "q2rtx-launcher-error",
 )
 
 

--- a/stability/q2rtx/constants.py
+++ b/stability/q2rtx/constants.py
@@ -69,8 +69,16 @@ FATAL_OUTPUT_PATTERNS = (
     "Couldn't open demos/",
     "Couldn't open pics/",
     "Couldn't load pics/",
-    "error while loading shared libraries",
 )
+
+# Dynamic-loader / shared-library failures (e.g. a missing libssl.so.1.1) mean
+# Q2RTX never started: these are environment/launch errors, not GPU instability.
+# They are retried in place (see run_q2rtx_stability_test) and must never blacklist
+# a voltage as unsafe.
+LAUNCHER_ERROR_PATTERNS = ("error while loading shared libraries",)
+
+# Reason assigned to a stability result whose Q2RTX process failed to launch.
+Q2RTX_LAUNCHER_ERROR_REASON = "q2rtx-launcher-error"
 
 TIMEDEMO_LINE_RE = re.compile(
     r"(?P<frames>\d+)\s+frames,\s+(?P<seconds>[0-9.]+)\s+seconds:\s+(?P<fps>[0-9.]+)\s+fps"

--- a/stability/q2rtx/elf_runpath.py
+++ b/stability/q2rtx/elf_runpath.py
@@ -1,128 +1,42 @@
 """Make the bundled Q2RTX binary find its OpenSSL 1.1 libs without LD_LIBRARY_PATH.
 
-NVIDIA's Q2RTX Linux build records an absolute, non-relocatable ``DT_RUNPATH`` that
-points at their build machine (``/mnt/q2rtx/.``), so on an end-user system the
-loader cannot find the bundled ``libssl.so.1.1`` / ``libcrypto.so.1.1`` and falls
-back to ``LD_LIBRARY_PATH`` -- which the dynamic loader strips when the binary is
-launched through a capability-carrying gamescope (``AT_SECURE``).
+NVIDIA's Q2RTX Linux build bakes a non-relocatable RUNPATH pointing at their build
+machine (``/mnt/q2rtx/.``), so on an end-user system the loader cannot find the
+bundled ``libssl.so.1.1`` / ``libcrypto.so.1.1`` and falls back to
+``LD_LIBRARY_PATH`` -- which the loader strips when q2rtx is launched through a
+capability-carrying gamescope (``AT_SECURE``).
 
-Rewriting that RUNPATH string in place to ``$ORIGIN`` makes the loader look next to
-the binary, which is honored even under ``AT_SECURE`` and needs no ``patchelf``:
-``$ORIGIN`` is shorter than the build path, so it fits in the existing string slot.
-The matching OpenSSL libs are copied next to the binary by the caller.
+Rewriting that one known RUNPATH string in place to ``$ORIGIN`` makes the loader
+look next to the binary, honored even under ``AT_SECURE`` and needing no patchelf.
+The replacement is NUL-padded to the original length, so no ``.dynstr`` offsets
+move; the matching OpenSSL libs are copied next to the binary by the caller.
 """
 
 from __future__ import annotations
 
-import struct
 from pathlib import Path
 
-
-_DT_NULL = 0
-_DT_RPATH = 15
-_DT_RUNPATH = 29
 ORIGIN_RUNPATH = "$ORIGIN"
-
-
-def _find_runpath_string(data: bytes) -> tuple[int, str] | None:
-    """Return ``(file_offset, value)`` of the DT_RUNPATH/DT_RPATH string, or None.
-
-    Only 64-bit little-endian ELF files are handled; anything else returns None so
-    the caller falls back to ``LD_LIBRARY_PATH``.
-    """
-    if len(data) < 64 or data[:4] != b"\x7fELF":
-        return None
-    if data[4] != 2 or data[5] != 1:  # ELFCLASS64, ELFDATA2LSB
-        return None
-    e_shoff = struct.unpack_from("<Q", data, 0x28)[0]
-    e_shentsize = struct.unpack_from("<H", data, 0x3A)[0]
-    e_shnum = struct.unpack_from("<H", data, 0x3C)[0]
-    e_shstrndx = struct.unpack_from("<H", data, 0x3E)[0]
-    if e_shoff == 0 or e_shnum == 0 or e_shentsize < 64 or e_shstrndx >= e_shnum:
-        return None
-    if e_shoff + e_shnum * e_shentsize > len(data):
-        return None
-
-    def section(index: int) -> tuple[int, int, int]:
-        base = e_shoff + index * e_shentsize
-        sh_name = struct.unpack_from("<I", data, base)[0]
-        sh_offset = struct.unpack_from("<Q", data, base + 0x18)[0]
-        sh_size = struct.unpack_from("<Q", data, base + 0x20)[0]
-        return sh_name, sh_offset, sh_size
-
-    _name, shstr_off, _shstr_size = section(e_shstrndx)
-
-    def section_name(name_off: int) -> str:
-        start = shstr_off + name_off
-        end = data.find(b"\x00", start)
-        if start >= len(data) or end < 0:
-            return ""
-        return data[start:end].decode("ascii", "replace")
-
-    dynamic: tuple[int, int] | None = None
-    dynstr: tuple[int, int] | None = None
-    for i in range(e_shnum):
-        sh_name, sh_offset, sh_size = section(i)
-        name = section_name(sh_name)
-        if name == ".dynamic":
-            dynamic = (sh_offset, sh_size)
-        elif name == ".dynstr":
-            dynstr = (sh_offset, sh_size)
-    if dynamic is None or dynstr is None:
-        return None
-
-    dyn_off, dyn_size = dynamic
-    dynstr_off, dynstr_size = dynstr
-    # The loader ignores DT_RPATH when DT_RUNPATH is present, so prefer RUNPATH.
-    runpath_val: int | None = None
-    rpath_val: int | None = None
-    for i in range(dyn_size // 16):
-        base = dyn_off + i * 16
-        if base + 16 > len(data):
-            break
-        d_tag, d_val = struct.unpack_from("<qQ", data, base)
-        if d_tag == _DT_NULL:
-            break
-        if d_tag == _DT_RUNPATH:
-            runpath_val = d_val
-        elif d_tag == _DT_RPATH:
-            rpath_val = d_val
-    chosen = runpath_val if runpath_val is not None else rpath_val
-    if chosen is None or chosen >= dynstr_size:
-        return None
-    str_off = dynstr_off + chosen
-    end = data.find(b"\x00", str_off)
-    if str_off >= len(data) or end < 0:
-        return None
-    return str_off, data[str_off:end].decode("ascii", "replace")
+_BUILD_RUNPATH = b"/mnt/q2rtx/.\x00"  # RUNPATH string NVIDIA ships in the q2rtx ELF
 
 
 def patch_runpath_to_origin(binary_path: Path) -> str | None:
-    """Rewrite ``binary_path``'s RUNPATH to ``$ORIGIN`` in place.
+    """Rewrite the binary's vendored RUNPATH to ``$ORIGIN`` in place.
 
-    Returns the previous RUNPATH on success, ``"$ORIGIN"`` if it was already set, or
-    None if the file could not be safely patched (the caller keeps relying on
-    ``LD_LIBRARY_PATH`` in that case).
+    Returns the previous RUNPATH when it was rewritten, ``"$ORIGIN"`` if it was
+    already patched, or None if the known build RUNPATH was not present (the caller
+    then keeps relying on ``LD_LIBRARY_PATH``).
     """
     try:
-        data = bytearray(binary_path.read_bytes())
+        data = binary_path.read_bytes()
     except OSError:
         return None
-    found = _find_runpath_string(bytes(data))
-    if found is None:
-        return None
-    str_off, current = found
-    if current.split(":")[0] == ORIGIN_RUNPATH:
-        return ORIGIN_RUNPATH
-    region_len = len(current.encode("ascii")) + 1  # include the NUL terminator
-    replacement = ORIGIN_RUNPATH.encode("ascii") + b"\x00"
-    if len(replacement) > region_len:
-        return None  # cannot shrink-fit; growing .dynstr would need patchelf
-    data[str_off : str_off + region_len] = replacement + b"\x00" * (
-        region_len - len(replacement)
-    )
+    if _BUILD_RUNPATH not in data:
+        return ORIGIN_RUNPATH if b"$ORIGIN\x00" in data else None
+    # Same-length, NUL-padded replacement keeps every .dynstr offset valid.
+    replacement = b"$ORIGIN\x00".ljust(len(_BUILD_RUNPATH), b"\x00")
     try:
-        binary_path.write_bytes(bytes(data))
+        binary_path.write_bytes(data.replace(_BUILD_RUNPATH, replacement, 1))
     except OSError:
         return None
-    return current
+    return _BUILD_RUNPATH[:-1].decode("ascii")

--- a/stability/q2rtx/elf_runpath.py
+++ b/stability/q2rtx/elf_runpath.py
@@ -1,0 +1,128 @@
+"""Make the bundled Q2RTX binary find its OpenSSL 1.1 libs without LD_LIBRARY_PATH.
+
+NVIDIA's Q2RTX Linux build records an absolute, non-relocatable ``DT_RUNPATH`` that
+points at their build machine (``/mnt/q2rtx/.``), so on an end-user system the
+loader cannot find the bundled ``libssl.so.1.1`` / ``libcrypto.so.1.1`` and falls
+back to ``LD_LIBRARY_PATH`` -- which the dynamic loader strips when the binary is
+launched through a capability-carrying gamescope (``AT_SECURE``).
+
+Rewriting that RUNPATH string in place to ``$ORIGIN`` makes the loader look next to
+the binary, which is honored even under ``AT_SECURE`` and needs no ``patchelf``:
+``$ORIGIN`` is shorter than the build path, so it fits in the existing string slot.
+The matching OpenSSL libs are copied next to the binary by the caller.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+
+_DT_NULL = 0
+_DT_RPATH = 15
+_DT_RUNPATH = 29
+ORIGIN_RUNPATH = "$ORIGIN"
+
+
+def _find_runpath_string(data: bytes) -> tuple[int, str] | None:
+    """Return ``(file_offset, value)`` of the DT_RUNPATH/DT_RPATH string, or None.
+
+    Only 64-bit little-endian ELF files are handled; anything else returns None so
+    the caller falls back to ``LD_LIBRARY_PATH``.
+    """
+    if len(data) < 64 or data[:4] != b"\x7fELF":
+        return None
+    if data[4] != 2 or data[5] != 1:  # ELFCLASS64, ELFDATA2LSB
+        return None
+    e_shoff = struct.unpack_from("<Q", data, 0x28)[0]
+    e_shentsize = struct.unpack_from("<H", data, 0x3A)[0]
+    e_shnum = struct.unpack_from("<H", data, 0x3C)[0]
+    e_shstrndx = struct.unpack_from("<H", data, 0x3E)[0]
+    if e_shoff == 0 or e_shnum == 0 or e_shentsize < 64 or e_shstrndx >= e_shnum:
+        return None
+    if e_shoff + e_shnum * e_shentsize > len(data):
+        return None
+
+    def section(index: int) -> tuple[int, int, int]:
+        base = e_shoff + index * e_shentsize
+        sh_name = struct.unpack_from("<I", data, base)[0]
+        sh_offset = struct.unpack_from("<Q", data, base + 0x18)[0]
+        sh_size = struct.unpack_from("<Q", data, base + 0x20)[0]
+        return sh_name, sh_offset, sh_size
+
+    _name, shstr_off, _shstr_size = section(e_shstrndx)
+
+    def section_name(name_off: int) -> str:
+        start = shstr_off + name_off
+        end = data.find(b"\x00", start)
+        if start >= len(data) or end < 0:
+            return ""
+        return data[start:end].decode("ascii", "replace")
+
+    dynamic: tuple[int, int] | None = None
+    dynstr: tuple[int, int] | None = None
+    for i in range(e_shnum):
+        sh_name, sh_offset, sh_size = section(i)
+        name = section_name(sh_name)
+        if name == ".dynamic":
+            dynamic = (sh_offset, sh_size)
+        elif name == ".dynstr":
+            dynstr = (sh_offset, sh_size)
+    if dynamic is None or dynstr is None:
+        return None
+
+    dyn_off, dyn_size = dynamic
+    dynstr_off, dynstr_size = dynstr
+    # The loader ignores DT_RPATH when DT_RUNPATH is present, so prefer RUNPATH.
+    runpath_val: int | None = None
+    rpath_val: int | None = None
+    for i in range(dyn_size // 16):
+        base = dyn_off + i * 16
+        if base + 16 > len(data):
+            break
+        d_tag, d_val = struct.unpack_from("<qQ", data, base)
+        if d_tag == _DT_NULL:
+            break
+        if d_tag == _DT_RUNPATH:
+            runpath_val = d_val
+        elif d_tag == _DT_RPATH:
+            rpath_val = d_val
+    chosen = runpath_val if runpath_val is not None else rpath_val
+    if chosen is None or chosen >= dynstr_size:
+        return None
+    str_off = dynstr_off + chosen
+    end = data.find(b"\x00", str_off)
+    if str_off >= len(data) or end < 0:
+        return None
+    return str_off, data[str_off:end].decode("ascii", "replace")
+
+
+def patch_runpath_to_origin(binary_path: Path) -> str | None:
+    """Rewrite ``binary_path``'s RUNPATH to ``$ORIGIN`` in place.
+
+    Returns the previous RUNPATH on success, ``"$ORIGIN"`` if it was already set, or
+    None if the file could not be safely patched (the caller keeps relying on
+    ``LD_LIBRARY_PATH`` in that case).
+    """
+    try:
+        data = bytearray(binary_path.read_bytes())
+    except OSError:
+        return None
+    found = _find_runpath_string(bytes(data))
+    if found is None:
+        return None
+    str_off, current = found
+    if current.split(":")[0] == ORIGIN_RUNPATH:
+        return ORIGIN_RUNPATH
+    region_len = len(current.encode("ascii")) + 1  # include the NUL terminator
+    replacement = ORIGIN_RUNPATH.encode("ascii") + b"\x00"
+    if len(replacement) > region_len:
+        return None  # cannot shrink-fit; growing .dynstr would need patchelf
+    data[str_off : str_off + region_len] = replacement + b"\x00" * (
+        region_len - len(replacement)
+    )
+    try:
+        binary_path.write_bytes(bytes(data))
+    except OSError:
+        return None
+    return current

--- a/stability/q2rtx/runtime.py
+++ b/stability/q2rtx/runtime.py
@@ -11,7 +11,11 @@ import time
 from common.penguin_burner_paths import claim_desktop_user_ownership
 
 from .assets import _validate_demo_name, resolve_q2rtx_executable, resolve_workload
-from .constants import HIDDEN_WINDOW_POSITION
+from .constants import (
+    HIDDEN_WINDOW_POSITION,
+    LAUNCHER_ERROR_PATTERNS,
+    Q2RTX_LAUNCHER_ERROR_REASON,
+)
 from .gpu_binding import (
     _apply_hidden_window_env,
     _apply_nvidia_render_offload_env,
@@ -67,6 +71,37 @@ def _result_looks_like_gamescope_startup_crash(result: Q2RTXStabilityResult) -> 
         "Broken pipe",
     )
     return any(marker in tail for marker in startup_crash_markers)
+
+
+MAX_LAUNCHER_RETRY_ATTEMPTS = 3
+
+
+def _result_has_launcher_error(result: Q2RTXStabilityResult) -> bool:
+    """True when Q2RTX failed in the dynamic loader (e.g. missing libssl.so.1.1)."""
+    tail = "\n".join(str(line) for line in result.output_tail)
+    return any(pattern in tail for pattern in LAUNCHER_ERROR_PATTERNS)
+
+
+def _result_is_retryable_launcher_failure(result: Q2RTXStabilityResult) -> bool:
+    """A launch that died before stable metrics for a non-stability reason.
+
+    Covers a missing shared library and a flaky headless-gamescope startup; both
+    are random and self-clearing, so the same-mode retry is worth a few attempts.
+    """
+    if bool(result.success):
+        return False
+    return _result_has_launcher_error(
+        result
+    ) or _result_looks_like_gamescope_startup_crash(result)
+
+
+def _reclassify_launcher_failure(
+    result: Q2RTXStabilityResult,
+) -> Q2RTXStabilityResult:
+    """Tag an unrecovered loader failure so Auto-UV never blacklists the voltage."""
+    if bool(result.success) or not _result_has_launcher_error(result):
+        return result
+    return replace(result, reason=Q2RTX_LAUNCHER_ERROR_REASON)
 
 
 def _common_q2rtx_args(
@@ -1013,6 +1048,10 @@ def run_q2rtx_stability_test(config: Q2RTXStabilityConfig) -> Q2RTXStabilityResu
     )
     log_path = _prepare_log_path(config.log_dir)
 
+    # A Q2RTX launch can fail before any stable metrics for reasons that are not
+    # GPU instability: a flaky headless-gamescope startup, or the dynamic loader
+    # failing to resolve a shared library (e.g. libssl.so.1.1). These are random
+    # and self-clearing, so retry in the SAME mode a few times before giving up.
     result = _run_timedemo_session(
         config=config,
         executable_path=executable_path,
@@ -1022,29 +1061,53 @@ def run_q2rtx_stability_test(config: Q2RTXStabilityConfig) -> Q2RTXStabilityResu
         log_path=log_path,
         runtime_env=runtime_env,
     )
+    attempt = 1
+    while (
+        attempt < MAX_LAUNCHER_RETRY_ATTEMPTS
+        and _result_is_retryable_launcher_failure(result)
+    ):
+        attempt += 1
+        print(
+            f"Q2RTX failed to launch before stable metrics (reason={result.reason}); "
+            f"retry {attempt}/{MAX_LAUNCHER_RETRY_ATTEMPTS} in the same mode.",
+            flush=True,
+        )
+        result = _run_timedemo_session(
+            config=config,
+            executable_path=executable_path,
+            workdir=workdir,
+            workload_name=workload_name,
+            demo_path=demo_path,
+            log_path=_prepare_log_path(config.log_dir),
+            runtime_env=runtime_env,
+        )
+
+    # Last-resort recovery: if headless gamescope is still crashing at startup
+    # after the same-mode retries, fall back once to the offscreen X11 launcher.
     if (
-        bool(config.hide_window)
+        not result.success
+        and bool(config.hide_window)
         and bool(config.use_headless_gamescope)
         and _result_looks_like_gamescope_startup_crash(result)
     ):
         print(
-            "Q2RTX headless gamescope crashed before timedemo metrics; "
+            "Q2RTX headless gamescope still failing after retries; "
             "retrying with the offscreen X11 fallback.",
             flush=True,
         )
         retry_config = replace(config, use_headless_gamescope=False)
-        retry_log_path = _prepare_log_path(config.log_dir)
         retry_result = _run_timedemo_session(
             config=retry_config,
             executable_path=executable_path,
             workdir=workdir,
             workload_name=workload_name,
             demo_path=demo_path,
-            log_path=retry_log_path,
+            log_path=_prepare_log_path(config.log_dir),
             runtime_env=runtime_env,
         )
-        if retry_result.success:
-            return retry_result
-        if result.duration_observed_s <= 0.0:
-            return retry_result
-    return result
+        if retry_result.success or result.duration_observed_s <= 0.0:
+            result = retry_result
+
+    # A launch failure tells us nothing about voltage stability; tag it so the
+    # Auto-UV layer never records the voltage as unsafe.
+    return _reclassify_launcher_failure(result)

--- a/stability/q2rtx/runtime_env.py
+++ b/stability/q2rtx/runtime_env.py
@@ -5,9 +5,11 @@ from pathlib import Path
 import shutil
 import subprocess
 
+from common.penguin_burner_paths import claim_desktop_user_ownership
 from common.subprocess_locale import stable_subprocess_env
 
 from .constants import OPENSSL_111_REQUIRED_LIBS
+from .elf_runpath import ORIGIN_RUNPATH, patch_runpath_to_origin
 from .models import StabilityTestError
 from .openssl_compat import _ensure_openssl_111_compat_libs
 from .progress import DependencyProgressCallback, _emit_dependency_progress
@@ -54,6 +56,39 @@ def _prepend_library_path(env: dict[str, str], lib_dir: Path) -> dict[str, str]:
     return updated
 
 
+def _colocate_runpath_libs(
+    executable_path: Path,
+    compat_lib_dir: Path,
+) -> str | None:
+    """Stage the OpenSSL 1.1 libs next to the binary and point its RUNPATH there.
+
+    NVIDIA's Q2RTX records a non-relocatable RUNPATH (``/mnt/q2rtx/.``), so the
+    loader can only find libssl.so.1.1 via ``LD_LIBRARY_PATH`` -- which is stripped
+    when q2rtx is launched through a capability-carrying gamescope (AT_SECURE).
+    Copying the libs beside the binary and rewriting RUNPATH to ``$ORIGIN`` makes
+    the dependency resolve from the ELF itself, which survives that launch path.
+
+    Returns the previous RUNPATH when it was actually rewritten, else None.
+    """
+    binary_dir = executable_path.parent
+    for name in OPENSSL_111_REQUIRED_LIBS:
+        source = compat_lib_dir / name
+        if not source.is_file():
+            return None
+        destination = binary_dir / name
+        try:
+            if destination.exists() and destination.samefile(source):
+                continue
+            shutil.copy2(source, destination)  # follows symlinks -> real lib
+            claim_desktop_user_ownership(destination)
+        except OSError:
+            return None
+    previous_runpath = patch_runpath_to_origin(executable_path)
+    if previous_runpath in (None, ORIGIN_RUNPATH):
+        return None
+    return previous_runpath
+
+
 def _prepare_q2rtx_runtime_env(
     executable_path: Path,
     *,
@@ -95,6 +130,13 @@ def _prepare_q2rtx_runtime_env(
         progress_start_pct=progress_start_pct,
         progress_end_pct=progress_end_pct,
     )
+    previous_runpath = _colocate_runpath_libs(executable_path, compat_lib_dir)
+    if previous_runpath is not None and show_progress:
+        print(
+            f"Q2RTX RUNPATH set to {ORIGIN_RUNPATH} (was {previous_runpath}); "
+            f"bundled OpenSSL 1.1 libs next to {executable_path.name}",
+            flush=True,
+        )
     env = _prepend_library_path(env, compat_lib_dir)
     compat_root = compat_lib_dir.parent
     compat_conf = compat_root / "ssl" / "openssl11.cnf"

--- a/stability/q2rtx/runtime_env.py
+++ b/stability/q2rtx/runtime_env.py
@@ -77,8 +77,11 @@ def _colocate_runpath_libs(
             return None
         destination = binary_dir / name
         try:
-            if destination.exists() and destination.samefile(source):
-                continue
+            if (
+                destination.is_file()
+                and destination.stat().st_size == source.stat().st_size
+            ):
+                continue  # already staged this run; avoid a redundant copy
             shutil.copy2(source, destination)  # follows symlinks -> real lib
             claim_desktop_user_ownership(destination)
         except OSError:
@@ -101,7 +104,30 @@ def _prepare_q2rtx_runtime_env(
     env.setdefault("SDL_VIDEO_ALLOW_SCREENSAVER", "1")
 
     missing = _detect_missing_shared_libraries(executable_path, env=env)
-    if not missing:
+    remaining_missing = set(missing) - set(OPENSSL_111_REQUIRED_LIBS)
+    if remaining_missing:
+        raise StabilityTestError(
+            "Q2RTX is missing required shared libraries: "
+            + ", ".join(sorted(remaining_missing))
+        )
+    openssl_missing = bool(set(OPENSSL_111_REQUIRED_LIBS) & set(missing))
+
+    # Always bundle our own OpenSSL 1.1 next to the binary and point RUNPATH at
+    # $ORIGIN, so q2rtx resolves libssl/libcrypto from its own directory on every
+    # launch -- independent of the system libraries and of the ldd probe, which
+    # lies for privilege-dropped, gamescope-wrapped launches (AT_SECURE).
+    try:
+        compat_lib_dir = _ensure_openssl_111_compat_libs(
+            show_progress=show_progress,
+            progress_callback=progress_callback,
+            progress_start_pct=progress_start_pct,
+            progress_end_pct=progress_end_pct,
+        )
+    except StabilityTestError:
+        if openssl_missing:
+            raise
+        # System already provides OpenSSL 1.1 and we could not stage our own copy;
+        # the binary still resolves the libraries from the system.
         _emit_dependency_progress(
             progress_callback,
             progress_end_pct,
@@ -110,26 +136,6 @@ def _prepare_q2rtx_runtime_env(
         )
         return env, None
 
-    missing_set = set(missing)
-    openssl_missing = set(OPENSSL_111_REQUIRED_LIBS) & missing_set
-    remaining_missing = missing_set - set(OPENSSL_111_REQUIRED_LIBS)
-    if remaining_missing:
-        raise StabilityTestError(
-            "Q2RTX is missing required shared libraries: "
-            + ", ".join(sorted(remaining_missing))
-        )
-    if not openssl_missing:
-        raise StabilityTestError(
-            "Q2RTX is missing required shared libraries: "
-            + ", ".join(sorted(missing_set))
-        )
-
-    compat_lib_dir = _ensure_openssl_111_compat_libs(
-        show_progress=show_progress,
-        progress_callback=progress_callback,
-        progress_start_pct=progress_start_pct,
-        progress_end_pct=progress_end_pct,
-    )
     previous_runpath = _colocate_runpath_libs(executable_path, compat_lib_dir)
     if previous_runpath is not None and show_progress:
         print(

--- a/tests/auto_uv/test_q2rtx_logic_coverage.py
+++ b/tests/auto_uv/test_q2rtx_logic_coverage.py
@@ -180,6 +180,7 @@ def test_core_clock_below_floor_respects_tolerance() -> None:
 
 def test_probe_failure_controlled_reason_does_not_mark_unsafe() -> None:
     assert probe_failure_should_mark_voltage_unsafe("user-stop-requested") is False
+    assert probe_failure_should_mark_voltage_unsafe("q2rtx-launcher-error") is False
 
 
 def test_probe_failure_idle_and_stall_prefixes_do_not_mark_unsafe() -> None:

--- a/tests/auto_uv/test_voltage_search_and_cache.py
+++ b/tests/auto_uv/test_voltage_search_and_cache.py
@@ -254,7 +254,16 @@ def test_unsafe_entry_reason_values_drops_empty_and_ignores_non_dict_details() -
 def test_unsafe_entry_blocks_future_search_treats_controlled_detail_as_safe() -> None:
     # A controlled clock-floor exit recorded in details must not block future search.
     assert not unsafe_entry_blocks_future_search(
-        {"reason": "crash", "details": {"result_reason": "core_clock-regression-detected"}}
+        {
+            "reason": "crash",
+            "details": {"result_reason": "core_clock-regression-detected"},
+        }
+    )
+    assert not unsafe_entry_blocks_future_search(
+        {
+            "reason": "stability-probe-failed",
+            "details": {"result_reason": "q2rtx-launcher-error"},
+        }
     )
 
 
@@ -263,5 +272,6 @@ def test_controlled_failure_reason_matches_known_prefixes_only() -> None:
     assert controlled_failure_reason("core_clock-regression-x")
     assert controlled_failure_reason("user-stop-requested")
     assert controlled_failure_reason("cuda-bruteforce-failed exit=-15")
+    assert controlled_failure_reason("q2rtx-launcher-error")
     assert not controlled_failure_reason("timedemo-crash")
     assert not controlled_failure_reason(None)

--- a/tests/test_q2rtx_launcher_recovery.py
+++ b/tests/test_q2rtx_launcher_recovery.py
@@ -1,0 +1,197 @@
+"""Tests for Q2RTX launcher-error recovery: RUNPATH patching, same-mode retry,
+and reclassification so a failed *launch* never blacklists a voltage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+
+from auto_uv.persistence.unsafe_voltage_cache import controlled_failure_reason
+from auto_uv.q2rtx.probe_runtime_guardrails import (
+    probe_failure_should_mark_voltage_unsafe,
+)
+from stability.q2rtx.constants import Q2RTX_LAUNCHER_ERROR_REASON
+from stability.q2rtx.elf_runpath import (
+    ORIGIN_RUNPATH,
+    _find_runpath_string,
+    patch_runpath_to_origin,
+)
+from stability.q2rtx.models import Q2RTXStabilityResult
+from stability.q2rtx.runtime import (
+    _reclassify_launcher_failure,
+    _result_has_launcher_error,
+    _result_is_retryable_launcher_failure,
+)
+
+
+# ---- minimal ELF builder (64-bit LE, just enough for the RUNPATH patcher) ----
+
+
+def _build_minimal_elf(runpath: str) -> bytes:
+    dynstr = b"\x00" + runpath.encode("ascii") + b"\x00"
+    runpath_off = 1
+    dynamic = struct.pack("<qQ", 29, runpath_off) + struct.pack("<qQ", 0, 0)
+    shstrtab = b"\x00.dynstr\x00.dynamic\x00.shstrtab\x00"
+
+    ehsize = 64
+    off_dynstr = ehsize
+    off_dynamic = off_dynstr + len(dynstr)
+    off_shstrtab = off_dynamic + len(dynamic)
+    shoff = off_shstrtab + len(shstrtab)
+    shoff += (-shoff) % 8  # 8-byte align
+
+    def shdr(name: int, sh_type: int, offset: int, size: int, entsize: int = 0) -> bytes:
+        return struct.pack(
+            "<IIQQQQIIQQ",
+            name, sh_type, 0, 0, offset, size, 0, 0, 1, entsize,
+        )
+
+    shtable = (
+        shdr(0, 0, 0, 0)
+        + shdr(shstrtab.index(b".dynstr"), 3, off_dynstr, len(dynstr))
+        + shdr(shstrtab.index(b".dynamic"), 6, off_dynamic, len(dynamic), 16)
+        + shdr(shstrtab.index(b".shstrtab"), 3, off_shstrtab, len(shstrtab))
+    )
+
+    e_ident = b"\x7fELF" + bytes([2, 1, 1, 0]) + b"\x00" * 8
+    header = e_ident + struct.pack(
+        "<HHIQQQIHHHHHH",
+        2, 0x3E, 1, 0, 0, shoff, 0, ehsize, 0, 0, 64, 4, 3,
+    )
+    assert len(header) == 64
+
+    body = bytearray(header)
+    body += dynstr + dynamic + shstrtab
+    body += b"\x00" * (shoff - len(body))
+    body += shtable
+    return bytes(body)
+
+
+def test_minimal_elf_builder_roundtrips() -> None:
+    data = _build_minimal_elf("/mnt/q2rtx/.")
+    found = _find_runpath_string(data)
+    assert found is not None
+    _offset, value = found
+    assert value == "/mnt/q2rtx/."
+
+
+def test_patch_runpath_rewrites_build_path_to_origin(tmp_path: Path) -> None:
+    binary = tmp_path / "q2rtx"
+    binary.write_bytes(_build_minimal_elf("/mnt/q2rtx/."))
+
+    previous = patch_runpath_to_origin(binary)
+
+    assert previous == "/mnt/q2rtx/."
+    found = _find_runpath_string(binary.read_bytes())
+    assert found is not None and found[1] == ORIGIN_RUNPATH
+    # In-place edit: the file must not change size.
+    assert binary.stat().st_size == len(_build_minimal_elf("/mnt/q2rtx/."))
+    # The stale build path must be gone.
+    assert b"/mnt/q2rtx" not in binary.read_bytes()
+
+
+def test_patch_runpath_is_idempotent(tmp_path: Path) -> None:
+    binary = tmp_path / "q2rtx"
+    binary.write_bytes(_build_minimal_elf("/mnt/q2rtx/."))
+
+    assert patch_runpath_to_origin(binary) == "/mnt/q2rtx/."
+    assert patch_runpath_to_origin(binary) == ORIGIN_RUNPATH
+
+
+def test_patch_runpath_refuses_when_slot_too_short(tmp_path: Path) -> None:
+    binary = tmp_path / "q2rtx"
+    original = _build_minimal_elf("/x")  # 2 chars, cannot fit "$ORIGIN"
+    binary.write_bytes(original)
+
+    assert patch_runpath_to_origin(binary) is None
+    assert binary.read_bytes() == original
+
+
+def test_patch_runpath_ignores_non_elf(tmp_path: Path) -> None:
+    binary = tmp_path / "not-an-elf"
+    binary.write_bytes(b"this is not an ELF file" * 8)
+
+    assert patch_runpath_to_origin(binary) is None
+
+
+# ---- same-mode retry / reclassification helpers ----
+
+
+def _make_result(*, success: bool, reason: str, output_tail: list[str]):
+    return Q2RTXStabilityResult(
+        success=success,
+        reason=reason,
+        workload_kind="timedemo",
+        workload_name="q2demo1",
+        command=["q2rtx"],
+        executable_path=Path("/tmp/q2rtx"),
+        workdir=Path("/tmp"),
+        duration_requested_s=450,
+        timedemo_loops_requested=None,
+        duration_observed_s=0.8,
+        demo_path=None,
+        log_path=Path("/tmp/q2rtx.log"),
+        process_exit_code=-11,
+        shutdown_mode="completed",
+        fatal_output_matches=[],
+        xid_messages=[],
+        timedemo_runs=[],
+        telemetry_samples=[],
+        companion_telemetry_samples=[],
+        output_tail=output_tail,
+    )
+
+
+_LIBSSL_TAIL = [
+    "[gamescope] [Info]  vblank: Using timerfd.",
+    "q2rtx: error while loading shared libraries: libssl.so.1.1: "
+    "cannot open shared object file: No such file or directory",
+    "[gamescope] [Info]  launch: Primary child shut down!",
+]
+
+
+def test_libssl_failure_is_a_retryable_launcher_error() -> None:
+    result = _make_result(
+        success=False, reason="timedemo-nonzero-exit", output_tail=_LIBSSL_TAIL
+    )
+    assert _result_has_launcher_error(result) is True
+    assert _result_is_retryable_launcher_failure(result) is True
+
+
+def test_reclassify_relabels_launcher_failure() -> None:
+    result = _make_result(
+        success=False, reason="timedemo-nonzero-exit", output_tail=_LIBSSL_TAIL
+    )
+    reclassified = _reclassify_launcher_failure(result)
+    assert reclassified.reason == Q2RTX_LAUNCHER_ERROR_REASON
+
+
+def test_successful_result_is_not_a_launcher_failure() -> None:
+    result = _make_result(success=True, reason="ok", output_tail=["frames"])
+    assert _result_has_launcher_error(result) is False
+    assert _result_is_retryable_launcher_failure(result) is False
+    assert _reclassify_launcher_failure(result) is result
+
+
+def test_real_instability_is_not_a_launcher_error() -> None:
+    result = _make_result(
+        success=False,
+        reason="timedemo-nonzero-exit",
+        output_tail=["VK_ERROR_DEVICE_LOST", "device lost"],
+    )
+    assert _result_has_launcher_error(result) is False
+    assert _result_is_retryable_launcher_failure(result) is False
+
+
+# ---- the blacklist gate must skip a launcher error ----
+
+
+def test_launcher_error_reason_never_blacklists_voltage() -> None:
+    assert controlled_failure_reason(Q2RTX_LAUNCHER_ERROR_REASON) is True
+    assert (
+        probe_failure_should_mark_voltage_unsafe(Q2RTX_LAUNCHER_ERROR_REASON) is False
+    )
+
+
+def test_real_instability_reason_still_blacklists() -> None:
+    assert probe_failure_should_mark_voltage_unsafe("timedemo-nonzero-exit") is True

--- a/tests/test_q2rtx_launcher_recovery.py
+++ b/tests/test_q2rtx_launcher_recovery.py
@@ -4,18 +4,13 @@ and reclassification so a failed *launch* never blacklists a voltage."""
 from __future__ import annotations
 
 from pathlib import Path
-import struct
 
 from auto_uv.persistence.unsafe_voltage_cache import controlled_failure_reason
 from auto_uv.q2rtx.probe_runtime_guardrails import (
     probe_failure_should_mark_voltage_unsafe,
 )
 from stability.q2rtx.constants import Q2RTX_LAUNCHER_ERROR_REASON
-from stability.q2rtx.elf_runpath import (
-    ORIGIN_RUNPATH,
-    _find_runpath_string,
-    patch_runpath_to_origin,
-)
+from stability.q2rtx.elf_runpath import ORIGIN_RUNPATH, patch_runpath_to_origin
 from stability.q2rtx.models import Q2RTXStabilityResult
 from stability.q2rtx.runtime import (
     _reclassify_launcher_failure,
@@ -24,94 +19,42 @@ from stability.q2rtx.runtime import (
 )
 
 
-# ---- minimal ELF builder (64-bit LE, just enough for the RUNPATH patcher) ----
+# ---- RUNPATH patcher: rewrite the vendored build path to $ORIGIN ----
 
-
-def _build_minimal_elf(runpath: str) -> bytes:
-    dynstr = b"\x00" + runpath.encode("ascii") + b"\x00"
-    runpath_off = 1
-    dynamic = struct.pack("<qQ", 29, runpath_off) + struct.pack("<qQ", 0, 0)
-    shstrtab = b"\x00.dynstr\x00.dynamic\x00.shstrtab\x00"
-
-    ehsize = 64
-    off_dynstr = ehsize
-    off_dynamic = off_dynstr + len(dynstr)
-    off_shstrtab = off_dynamic + len(dynamic)
-    shoff = off_shstrtab + len(shstrtab)
-    shoff += (-shoff) % 8  # 8-byte align
-
-    def shdr(name: int, sh_type: int, offset: int, size: int, entsize: int = 0) -> bytes:
-        return struct.pack(
-            "<IIQQQQIIQQ",
-            name, sh_type, 0, 0, offset, size, 0, 0, 1, entsize,
-        )
-
-    shtable = (
-        shdr(0, 0, 0, 0)
-        + shdr(shstrtab.index(b".dynstr"), 3, off_dynstr, len(dynstr))
-        + shdr(shstrtab.index(b".dynamic"), 6, off_dynamic, len(dynamic), 16)
-        + shdr(shstrtab.index(b".shstrtab"), 3, off_shstrtab, len(shstrtab))
-    )
-
-    e_ident = b"\x7fELF" + bytes([2, 1, 1, 0]) + b"\x00" * 8
-    header = e_ident + struct.pack(
-        "<HHIQQQIHHHHHH",
-        2, 0x3E, 1, 0, 0, shoff, 0, ehsize, 0, 0, 64, 4, 3,
-    )
-    assert len(header) == 64
-
-    body = bytearray(header)
-    body += dynstr + dynamic + shstrtab
-    body += b"\x00" * (shoff - len(body))
-    body += shtable
-    return bytes(body)
-
-
-def test_minimal_elf_builder_roundtrips() -> None:
-    data = _build_minimal_elf("/mnt/q2rtx/.")
-    found = _find_runpath_string(data)
-    assert found is not None
-    _offset, value = found
-    assert value == "/mnt/q2rtx/."
+# A stand-in for the q2rtx ELF: the vendored RUNPATH string surrounded by other
+# NUL-terminated .dynstr entries, so we can assert neighbours stay intact.
+_ELF_BLOB = b"\x7fELF" + b"\x00" * 16 + b"libssl.so.1.1\x00/mnt/q2rtx/.\x00libc.so.6\x00"
 
 
 def test_patch_runpath_rewrites_build_path_to_origin(tmp_path: Path) -> None:
     binary = tmp_path / "q2rtx"
-    binary.write_bytes(_build_minimal_elf("/mnt/q2rtx/."))
+    binary.write_bytes(_ELF_BLOB)
 
     previous = patch_runpath_to_origin(binary)
 
+    patched = binary.read_bytes()
     assert previous == "/mnt/q2rtx/."
-    found = _find_runpath_string(binary.read_bytes())
-    assert found is not None and found[1] == ORIGIN_RUNPATH
-    # In-place edit: the file must not change size.
-    assert binary.stat().st_size == len(_build_minimal_elf("/mnt/q2rtx/."))
-    # The stale build path must be gone.
-    assert b"/mnt/q2rtx" not in binary.read_bytes()
+    assert b"$ORIGIN\x00" in patched
+    assert b"/mnt/q2rtx" not in patched
+    assert len(patched) == len(_ELF_BLOB)  # in-place: no offsets shift
+    assert b"libssl.so.1.1\x00" in patched and b"libc.so.6\x00" in patched
 
 
 def test_patch_runpath_is_idempotent(tmp_path: Path) -> None:
     binary = tmp_path / "q2rtx"
-    binary.write_bytes(_build_minimal_elf("/mnt/q2rtx/."))
+    binary.write_bytes(_ELF_BLOB)
 
     assert patch_runpath_to_origin(binary) == "/mnt/q2rtx/."
     assert patch_runpath_to_origin(binary) == ORIGIN_RUNPATH
 
 
-def test_patch_runpath_refuses_when_slot_too_short(tmp_path: Path) -> None:
-    binary = tmp_path / "q2rtx"
-    original = _build_minimal_elf("/x")  # 2 chars, cannot fit "$ORIGIN"
+def test_patch_runpath_noop_when_build_path_absent(tmp_path: Path) -> None:
+    binary = tmp_path / "other"
+    original = b"a binary without the vendored runpath"
     binary.write_bytes(original)
 
     assert patch_runpath_to_origin(binary) is None
     assert binary.read_bytes() == original
-
-
-def test_patch_runpath_ignores_non_elf(tmp_path: Path) -> None:
-    binary = tmp_path / "not-an-elf"
-    binary.write_bytes(b"this is not an ELF file" * 8)
-
-    assert patch_runpath_to_origin(binary) is None
 
 
 # ---- same-mode retry / reclassification helpers ----

--- a/tests/test_q2rtx_stability.py
+++ b/tests/test_q2rtx_stability.py
@@ -756,6 +756,55 @@ def test_device_lost_output_is_fatal_case_insensitive(tmp_path: Path) -> None:
     assert "device lost" in matches
 
 
+def test_loader_error_output_is_launcher_failure_not_fatal_output(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "q2rtx.log"
+    log_path.write_text(
+        "q2rtx: error while loading shared libraries: "
+        "libssl.so.1.1: cannot open shared object file\n",
+        encoding="utf-8",
+    )
+
+    matches = _scan_output_for_fatal_patterns(log_path)
+
+    assert "error while loading shared libraries" not in matches
+
+
+def test_loader_error_result_is_retryable_and_reclassified(tmp_path: Path) -> None:
+    result = Q2RTXStabilityResult(
+        success=False,
+        reason="timedemo-nonzero-exit",
+        workload_kind="timedemo",
+        workload_name="q2demo1",
+        command=["q2rtx"],
+        executable_path=tmp_path / "q2rtx",
+        workdir=tmp_path,
+        duration_requested_s=30,
+        timedemo_loops_requested=3,
+        duration_observed_s=0.8,
+        demo_path=None,
+        log_path=tmp_path / "q2rtx.log",
+        process_exit_code=127,
+        shutdown_mode="completed",
+        fatal_output_matches=[],
+        xid_messages=[],
+        timedemo_runs=[],
+        telemetry_samples=[],
+        companion_telemetry_samples=[],
+        output_tail=[
+            "q2rtx: error while loading shared libraries: "
+            "libssl.so.1.1: cannot open shared object file",
+        ],
+    )
+
+    assert q2rtx_runtime._result_is_retryable_launcher_failure(result) is True
+    assert (
+        q2rtx_runtime._reclassify_launcher_failure(result).reason
+        == "q2rtx-launcher-error"
+    )
+
+
 def test_report_output_tail_filters_normal_gamescope_shutdown_noise() -> None:
     assert _filter_report_output_tail(
         [


### PR DESCRIPTION
## Summary

Fix Q2RTX launcher failures where the process can die before startup with `libssl.so.1.1` missing under gamescope.

## Root Cause

The Q2RTX Linux binary needs OpenSSL 1.1. PenguinBurner already installs compat OpenSSL libraries, but the runtime previously depended on `LD_LIBRARY_PATH` for Q2RTX to find them. Under a gamescope launch path, that environment can be unreliable or stripped, so Q2RTX can fail in the dynamic loader before it produces timedemo metrics. The old fatal-output classification then treated the loader error as voltage instability and could poison the unsafe-voltage cache.

## Changes

- Copy compat `libssl.so.1.1` and `libcrypto.so.1.1` beside the Q2RTX binary.
- Add an ELF RUNPATH patcher that rewrites Q2RTX non-relocatable RUNPATH to `$ORIGIN` when it can be done safely in place.
- Keep `LD_LIBRARY_PATH` as fallback behavior.
- Split dynamic-loader errors from GPU/Q2RTX fatal output.
- Retry retryable launcher failures, but reclassify unrecovered loader failures as `q2rtx-launcher-error` so Auto-UV does not blacklist the voltage.
- Add regression tests for RUNPATH patching, loader-error reclassification, retryability, and unsafe-cache behavior.

## Validation

- `pytest tests/test_q2rtx_launcher_recovery.py tests/test_q2rtx_stability.py tests/auto_uv/test_voltage_search_and_cache.py tests/auto_uv/test_q2rtx_logic_coverage.py tests/auto_uv/test_q2rtx_live_abort_rules.py -q`
- `git diff --check`
