### PR TITLE
Deploy Flatpak Pages outside Git history

### DIFF
--- a/.github/workflows/deploy-flatpak-pages.yml
+++ b/.github/workflows/deploy-flatpak-pages.yml
@@ -1,0 +1,67 @@
+name: Deploy Flatpak repository to Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: GitHub Release tag containing the signed Pages snapshot
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Validate and deploy signed snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Check out snapshot validator
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download and validate release snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 scripts/flatpak_pages_artifact.py check-tag "$RELEASE_TAG"
+          archive="PenguinBurner-pages-${RELEASE_TAG}.tar.gz"
+          mkdir downloads
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$archive" \
+            --pattern "$archive.sha256" \
+            --dir downloads
+          test -f "downloads/$archive"
+          test -f "downloads/$archive.sha256"
+          python3 scripts/flatpak_pages_artifact.py extract \
+            "downloads/$archive" \
+            site \
+            --checksum "downloads/$archive.sha256"
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: site
+
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ and use, closing the feature gap with the Windows tools Linux users miss: the
 python -m pip install --user --upgrade penguin-burner
 ```
 
-Flatpak users should use the [Flatpak guide](docs/flatpak.md).
+[Flatpak v0.7.2](https://github.com/jpietek/PenguinBurner/releases/tag/v0.7.2)
+is available from the
+[PenguinBurner Flatpak repository](https://jpietek.github.io/PenguinBurner/penguin-burner.flatpakrepo);
+use the [Flatpak install and update guide](docs/flatpak.md).
 
 Also packaged for [Fedora (COPR)](https://copr.fedorainfracloud.org/coprs/jpietek/penguin-burner/),
 [Arch / CachyOS (AUR)](https://aur.archlinux.org/packages/penguin-burner), and

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -75,3 +75,52 @@ Launch the installed app at any time with:
 ```bash
 flatpak run io.github.jpietek.PenguinBurner
 ```
+
+## Publishing
+
+Flatpak repository output is deployed through a GitHub Pages Actions artifact,
+not committed to a `gh-pages` branch. Signing stays local: the publisher builds
+with the existing GPG key, verifies a clean installation and an update from the
+previous snapshot, uploads the signed snapshot to the matching GitHub Release,
+and dispatches the Pages workflow.
+
+From a clean checkout at the release tag, run:
+
+```bash
+scripts/publish-flatpak-pages.sh vX.Y.Z
+```
+
+The publisher discovers the newest compatible snapshot Release asset and uses
+it to preserve the OSTree repository across releases. It refuses to replace an
+existing snapshot unless `--replace` is passed explicitly.
+
+The one-time migration from legacy branch-backed Pages deliberately separates
+upload from deployment:
+
+```bash
+scripts/publish-flatpak-pages.sh --upload-only --migrate-ref origin/gh-pages v0.7.2
+```
+
+After that command succeeds, open repository **Settings → Pages** and change
+**Source** from the `gh-pages` branch to **GitHub Actions**, then dispatch the
+already-uploaded snapshot:
+
+```bash
+gh workflow run deploy-flatpak-pages.yml \
+  --repo jpietek/PenguinBurner \
+  --field tag=v0.7.2
+```
+
+Use `--prepare-only` instead of `--upload-only` to complete all local build,
+signature, installation, update, archive, and checksum checks without uploading
+an asset or dispatching the Pages workflow.
+
+The smoke test targets the published `x86_64` ref. On a cross-architecture
+maintenance host, set `PENGUIN_BURNER_FLATPAK_SMOKE_NO_DEPS=1` to validate the
+app ref without downloading a foreign-architecture runtime; release hosts
+should leave dependency verification enabled.
+
+After the workflow deploys, verify a fresh install and an update through the
+public URL before deleting `gh-pages`. The private GPG key is never uploaded;
+only the public key, signed repository, bundle, archive, and checksum leave the
+release machine.

--- a/scripts/build-flatpak-public-repo.sh
+++ b/scripts/build-flatpak-public-repo.sh
@@ -112,6 +112,6 @@ Local test:
   flatpak run "$APP_ID"
 
 Public hosting:
-  Upload the contents of $OUT_DIR to HTTPS static hosting.
-  Re-run with PENGUIN_BURNER_FLATPAK_REPO_URL set to the public repo URL.
+  Publish through scripts/publish-flatpak-pages.sh so generated files are
+  deployed as a GitHub Pages artifact instead of committed to Git.
 EOF

--- a/scripts/flatpak_pages_artifact.py
+++ b/scripts/flatpak_pages_artifact.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Create and validate safe, deterministic PenguinBurner Pages snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import gzip
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Callable, Iterable
+
+
+APP_ID = "io.github.jpietek.PenguinBurner"
+EXPECTED_REPOSITORY_URL = "https://jpietek.github.io/PenguinBurner/repo"
+EXPECTED_SIGNING_FINGERPRINT = "BA1929DBD4CE4A49A8106D122800D243DB4657B3"
+MAX_ARCHIVE_ENTRIES = 100_000
+MAX_UNPACKED_SIZE = 2 * 1024 * 1024 * 1024
+RELEASE_TAG_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+REQUIRED_PATHS = (
+    Path(".nojekyll"),
+    Path("index.html"),
+    Path("penguin-burner.flatpakrepo"),
+    Path("penguin-burner-flatpak.gpg"),
+    Path("PenguinBurner.flatpak"),
+    Path("repo/config"),
+    Path("repo/summary"),
+    Path("repo/summary.sig"),
+    Path(f"repo/refs/heads/app/{APP_ID}/x86_64/master"),
+)
+NONEMPTY_PATHS = REQUIRED_PATHS[1:]
+
+
+class ArtifactError(ValueError):
+    """Raised when a Pages snapshot is unsafe or internally inconsistent."""
+
+
+FingerprintReader = Callable[[Path], str]
+
+
+def validate_release_tag(tag: str) -> str:
+    """Return a release tag that is safe to use in filenames and shell arguments."""
+
+    if not RELEASE_TAG_PATTERN.fullmatch(tag):
+        raise ArtifactError(
+            "release tag must start with an alphanumeric character and contain "
+            "only letters, numbers, dots, underscores, or hyphens"
+        )
+    return tag
+
+
+def public_key_fingerprint(key_path: Path) -> str:
+    """Read the first fingerprint from an exported OpenPGP public key."""
+
+    result = subprocess.run(
+        (
+            "gpg",
+            "--batch",
+            "--with-colons",
+            "--import-options",
+            "show-only",
+            "--import",
+            str(key_path),
+        ),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "gpg could not read the public key"
+        raise ArtifactError(detail)
+
+    for line in result.stdout.splitlines():
+        fields = line.split(":")
+        if fields[0] == "fpr" and len(fields) > 9 and fields[9]:
+            return fields[9].upper()
+    raise ArtifactError("public signing key does not contain a fingerprint")
+
+
+def _tree_entries(root: Path) -> list[tuple[Path, Path, os.stat_result]]:
+    entries: list[tuple[Path, Path, os.stat_result]] = []
+    for current, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_names.sort()
+        file_names.sort()
+        current_path = Path(current)
+        for name in (*directory_names, *file_names):
+            path = current_path / name
+            metadata = path.lstat()
+            relative = path.relative_to(root)
+            if stat.S_ISLNK(metadata.st_mode):
+                raise ArtifactError(f"snapshot must not contain symlinks: {relative}")
+            if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
+                raise ArtifactError(f"unsupported snapshot entry: {relative}")
+            entries.append((relative, path, metadata))
+    entries.sort(key=lambda item: item[0].as_posix())
+    return entries
+
+
+def validate_site(
+    site_root: Path,
+    *,
+    fingerprint_reader: FingerprintReader = public_key_fingerprint,
+) -> None:
+    """Validate the static site layout, repository URL, and signing identity."""
+
+    if site_root.is_symlink():
+        raise ArtifactError(f"snapshot root must not be a symlink: {site_root}")
+    root = site_root.resolve()
+    if not root.is_dir():
+        raise ArtifactError(f"snapshot root is not a directory: {site_root}")
+
+    _tree_entries(root)
+    for relative in REQUIRED_PATHS:
+        path = root / relative
+        if not path.is_file():
+            raise ArtifactError(f"snapshot is missing required file: {relative}")
+    for relative in NONEMPTY_PATHS:
+        if (root / relative).stat().st_size == 0:
+            raise ArtifactError(f"required snapshot file is empty: {relative}")
+
+    remote = configparser.ConfigParser(interpolation=None)
+    try:
+        with (root / "penguin-burner.flatpakrepo").open(
+            "r", encoding="utf-8"
+        ) as stream:
+            remote.read_file(stream)
+        repository_url = remote["Flatpak Repo"]["Url"]
+    except (configparser.Error, KeyError, UnicodeError) as exc:
+        raise ArtifactError(f"invalid penguin-burner.flatpakrepo: {exc}") from exc
+    if repository_url != EXPECTED_REPOSITORY_URL:
+        raise ArtifactError(
+            "Flatpak repository URL mismatch: "
+            f"expected {EXPECTED_REPOSITORY_URL}, got {repository_url}"
+        )
+
+    fingerprint = fingerprint_reader(root / "penguin-burner-flatpak.gpg").upper()
+    if fingerprint != EXPECTED_SIGNING_FINGERPRINT:
+        raise ArtifactError(
+            "Flatpak signing key mismatch: "
+            f"expected {EXPECTED_SIGNING_FINGERPRINT}, got {fingerprint}"
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _default_checksum_path(archive_path: Path) -> Path:
+    return Path(f"{archive_path}.sha256")
+
+
+def write_checksum(archive_path: Path, checksum_path: Path | None = None) -> Path:
+    """Write a sha256sum-compatible checksum file for an archive."""
+
+    target = checksum_path or _default_checksum_path(archive_path)
+    target.write_text(
+        f"{sha256_file(archive_path)}  {archive_path.name}\n", encoding="ascii"
+    )
+    return target
+
+
+def verify_checksum(archive_path: Path, checksum_path: Path) -> None:
+    """Verify a checksum file and ensure that it names the supplied archive."""
+
+    try:
+        checksum_line = checksum_path.read_text(encoding="ascii").strip()
+    except (OSError, UnicodeError) as exc:
+        raise ArtifactError(f"could not read checksum file: {exc}") from exc
+    fields = checksum_line.split()
+    if len(fields) != 2 or not re.fullmatch(r"[0-9a-fA-F]{64}", fields[0]):
+        raise ArtifactError("checksum file must contain one SHA-256 and filename")
+    recorded_name = fields[1].lstrip("*")
+    if recorded_name != archive_path.name:
+        raise ArtifactError(
+            f"checksum names {recorded_name}, expected {archive_path.name}"
+        )
+    actual = sha256_file(archive_path)
+    if actual.lower() != fields[0].lower():
+        raise ArtifactError("snapshot archive checksum mismatch")
+
+
+def create_archive(
+    site_root: Path,
+    archive_path: Path,
+    *,
+    checksum_path: Path | None = None,
+    fingerprint_reader: FingerprintReader = public_key_fingerprint,
+) -> Path:
+    """Create a deterministic tar.gz snapshot and return its checksum path."""
+
+    validate_site(site_root, fingerprint_reader=fingerprint_reader)
+    root = site_root.resolve()
+    output = archive_path.resolve()
+    if output == root or root in output.parents:
+        raise ArtifactError("snapshot archive must be written outside the site root")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    entries = _tree_entries(root)
+
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as raw_stream:
+            with gzip.GzipFile(
+                filename="", mode="wb", fileobj=raw_stream, mtime=0
+            ) as gzip_stream:
+                with tarfile.open(
+                    fileobj=gzip_stream, mode="w", format=tarfile.PAX_FORMAT
+                ) as archive:
+                    for relative, path, metadata in entries:
+                        name = relative.as_posix()
+                        info = tarfile.TarInfo(
+                            f"{name}/" if stat.S_ISDIR(metadata.st_mode) else name
+                        )
+                        info.uid = 0
+                        info.gid = 0
+                        info.uname = ""
+                        info.gname = ""
+                        info.mtime = 0
+                        if stat.S_ISDIR(metadata.st_mode):
+                            info.type = tarfile.DIRTYPE
+                            info.mode = 0o755
+                            archive.addfile(info)
+                        else:
+                            info.type = tarfile.REGTYPE
+                            info.mode = 0o644
+                            info.size = metadata.st_size
+                            with path.open("rb") as source:
+                                archive.addfile(info, source)
+            raw_stream.flush()
+            os.fsync(raw_stream.fileno())
+        os.replace(temporary_path, output)
+        output.chmod(0o644)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return write_checksum(output, checksum_path)
+
+
+def _safe_member_path(name: str) -> PurePosixPath:
+    raw_parts = name.split("/")
+    if (
+        not name
+        or "\\" in name
+        or name.startswith("/")
+        or any(part in ("", ".", "..") for part in raw_parts)
+    ):
+        raise ArtifactError(f"unsafe archive path: {name!r}")
+    path = PurePosixPath(name)
+    return path
+
+
+def _validated_members(archive: tarfile.TarFile) -> list[tarfile.TarInfo]:
+    members = archive.getmembers()
+    if len(members) > MAX_ARCHIVE_ENTRIES:
+        raise ArtifactError(f"snapshot archive exceeds {MAX_ARCHIVE_ENTRIES} entries")
+
+    paths: dict[PurePosixPath, tarfile.TarInfo] = {}
+    total_size = 0
+    for member in members:
+        path = _safe_member_path(member.name)
+        if not (member.isdir() or member.isfile()):
+            raise ArtifactError(f"unsupported archive entry type: {member.name}")
+        if path in paths:
+            raise ArtifactError(f"duplicate archive path: {member.name}")
+        paths[path] = member
+        if member.isfile():
+            if member.size < 0:
+                raise ArtifactError(f"archive file has a negative size: {member.name}")
+            total_size += member.size
+            if total_size > MAX_UNPACKED_SIZE:
+                raise ArtifactError(
+                    f"snapshot archive exceeds {MAX_UNPACKED_SIZE} unpacked bytes"
+                )
+
+    for path, member in paths.items():
+        for parent in path.parents:
+            if parent == PurePosixPath("."):
+                break
+            parent_member = paths.get(parent)
+            if parent_member is not None and not parent_member.isdir():
+                raise ArtifactError(
+                    f"archive path has a non-directory parent: {member.name}"
+                )
+    return members
+
+
+def _extract_members(
+    archive: tarfile.TarFile, members: Iterable[tarfile.TarInfo], destination: Path
+) -> None:
+    ordered = sorted(members, key=lambda item: (not item.isdir(), item.name))
+    for member in ordered:
+        relative = _safe_member_path(member.name)
+        output = destination.joinpath(*relative.parts)
+        if member.isdir():
+            output.mkdir(parents=True, exist_ok=True)
+            output.chmod(0o755)
+            continue
+        output.parent.mkdir(parents=True, exist_ok=True)
+        source = archive.extractfile(member)
+        if source is None:
+            raise ArtifactError(f"could not read archive file: {member.name}")
+        with source, output.open("xb") as target:
+            shutil.copyfileobj(source, target, length=1024 * 1024)
+        if output.stat().st_size != member.size:
+            raise ArtifactError(f"archive file size mismatch: {member.name}")
+        output.chmod(0o644)
+
+
+def extract_archive(
+    archive_path: Path,
+    destination: Path,
+    *,
+    checksum_path: Path,
+    fingerprint_reader: FingerprintReader = public_key_fingerprint,
+) -> None:
+    """Safely extract and validate a Pages snapshot into a new directory."""
+
+    if destination.exists() or destination.is_symlink():
+        raise ArtifactError(f"extraction destination already exists: {destination}")
+    verify_checksum(archive_path, checksum_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent)
+    )
+    try:
+        try:
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                members = _validated_members(archive)
+                _extract_members(archive, members, temporary)
+        except (tarfile.TarError, OSError) as exc:
+            raise ArtifactError(f"could not extract snapshot archive: {exc}") from exc
+        validate_site(temporary, fingerprint_reader=fingerprint_reader)
+        os.replace(temporary, destination)
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    check_tag = commands.add_parser("check-tag", help="validate a release tag")
+    check_tag.add_argument("tag")
+
+    fingerprint = commands.add_parser(
+        "fingerprint", help="print an exported public key fingerprint"
+    )
+    fingerprint.add_argument("key", type=Path)
+
+    validate = commands.add_parser("validate", help="validate a static site tree")
+    validate.add_argument("site", type=Path)
+
+    pack = commands.add_parser("pack", help="create a deterministic snapshot")
+    pack.add_argument("site", type=Path)
+    pack.add_argument("archive", type=Path)
+
+    extract = commands.add_parser("extract", help="safely extract a snapshot")
+    extract.add_argument("archive", type=Path)
+    extract.add_argument("destination", type=Path)
+    extract.add_argument("--checksum", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "check-tag":
+            print(validate_release_tag(args.tag))
+        elif args.command == "fingerprint":
+            print(public_key_fingerprint(args.key))
+        elif args.command == "validate":
+            validate_site(args.site)
+        elif args.command == "pack":
+            print(create_archive(args.site, args.archive))
+        elif args.command == "extract":
+            extract_archive(args.archive, args.destination, checksum_path=args.checksum)
+        else:  # pragma: no cover - argparse enforces a known command
+            raise ArtifactError(f"unknown command: {args.command}")
+    except (ArtifactError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish-flatpak-pages.sh
+++ b/scripts/publish-flatpak-pages.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_ID="io.github.jpietek.PenguinBurner"
+APP_ARCH="x86_64"
+GITHUB_REPOSITORY="${PENGUIN_BURNER_GITHUB_REPOSITORY:-jpietek/PenguinBurner}"
+PUBLIC_REPO_URL="https://jpietek.github.io/PenguinBurner/repo"
+ARTIFACT_HELPER="$ROOT/scripts/flatpak_pages_artifact.py"
+BUILD_SCRIPT="$ROOT/scripts/build-flatpak-public-repo.sh"
+WORKFLOW_FILE="deploy-flatpak-pages.yml"
+OUTPUT_DIR="${PENGUIN_BURNER_FLATPAK_PAGES_DIST:-$ROOT/dist/flatpak-pages}"
+SMOKE_NO_DEPS="${PENGUIN_BURNER_FLATPAK_SMOKE_NO_DEPS:-0}"
+
+replace=0
+migration_ref=""
+prepare_only=0
+upload_only=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/publish-flatpak-pages.sh [--prepare-only|--upload-only] [--replace] [--migrate-ref REF] TAG
+
+Build, verify, and publish a signed Flatpak Pages snapshot without committing
+generated files to Git.
+
+Normal publication:
+  - requires a clean checkout at TAG;
+  - seeds the OSTree repository from the newest compatible Pages snapshot
+    attached to an earlier GitHub Release;
+  - builds and signs locally, uploads versioned Release assets, and dispatches
+    the GitHub Pages deployment workflow.
+
+One-time migration:
+  --migrate-ref REF exports an existing signed Pages tree (normally
+  origin/gh-pages), adds the Pages index, verifies and packages it without
+  rebuilding, then uploads and dispatches it for TAG.
+
+Options:
+  --prepare-only     Build, verify, and package without uploading or deploying.
+  --upload-only      Build, verify, package, and upload without dispatching.
+  --replace          Explicitly replace existing snapshot Release assets.
+  --migrate-ref REF  Package an existing Git tree without rebuilding it.
+  -h, --help         Show this help.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+snapshot_name() {
+    printf 'PenguinBurner-pages-%s.tar.gz\n' "$1"
+}
+
+release_has_asset() {
+    local release_tag="$1"
+    local asset_name="$2"
+    gh release view "$release_tag" \
+        --repo "$GITHUB_REPOSITORY" \
+        --json assets \
+        --jq '.assets[].name' | grep -Fxq "$asset_name"
+}
+
+find_previous_snapshot_tag() {
+    local target_tag="$1"
+    local target_prerelease="$2"
+    local target_published_at="$3"
+    local candidate
+    local candidate_archive
+    local -a candidates=()
+
+    mapfile -t candidates < <(
+        gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName,isDraft,isPrerelease,publishedAt \
+            --jq "sort_by(.publishedAt) | reverse | .[] | select(.isDraft == false and .isPrerelease == $target_prerelease and .publishedAt < \"$target_published_at\") | .tagName"
+    )
+    for candidate in "${candidates[@]}"; do
+        [[ "$candidate" == "$target_tag" ]] && continue
+        if ! python3 "$ARTIFACT_HELPER" check-tag "$candidate" >/dev/null 2>&1; then
+            continue
+        fi
+        candidate_archive="$(snapshot_name "$candidate")"
+        if release_has_asset "$candidate" "$candidate_archive" \
+            && release_has_asset "$candidate" "$candidate_archive.sha256"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+write_index() {
+    local site="$1"
+    rm -f "$site/repo/.lock"
+    cat >"$site/index.html" <<'EOF'
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PenguinBurner Flatpak Repository</title>
+</head>
+<body>
+  <h1>PenguinBurner Flatpak Repository</h1>
+  <p><a href="penguin-burner.flatpakrepo">Add the Flatpak repository</a></p>
+  <p><a href="PenguinBurner.flatpak">Download the current Flatpak bundle</a></p>
+</body>
+</html>
+EOF
+    : >"$site/.nojekyll"
+}
+
+flatpak_in_profile() {
+    local profile="$1"
+    shift
+    env \
+        XDG_DATA_HOME="$profile/data" \
+        XDG_CONFIG_HOME="$profile/config" \
+        XDG_CACHE_HOME="$profile/cache" \
+        XDG_RUNTIME_DIR="$profile/runtime" \
+        flatpak --user "$@"
+}
+
+prepare_flatpak_profile() {
+    local profile="$1"
+    mkdir -p \
+        "$profile/data" \
+        "$profile/config" \
+        "$profile/cache" \
+        "$profile/runtime"
+    chmod 700 "$profile/runtime"
+    flatpak_in_profile "$profile" remote-add \
+        --if-not-exists \
+        flathub \
+        https://dl.flathub.org/repo/flathub.flatpakrepo
+}
+
+smoke_install() {
+    local site="$1"
+    local profile="$2"
+    local remote_name="$3"
+    local -a install_options=(install -y --arch="$APP_ARCH")
+    if [[ "$SMOKE_NO_DEPS" == "1" ]]; then
+        install_options+=(--no-deps)
+    fi
+    prepare_flatpak_profile "$profile"
+    flatpak_in_profile "$profile" remote-add \
+        --if-not-exists \
+        --gpg-import="$site/penguin-burner-flatpak.gpg" \
+        "$remote_name" \
+        "file://$site/repo"
+    flatpak_in_profile "$profile" "${install_options[@]}" "$remote_name" "$APP_ID"
+    flatpak_in_profile "$profile" info --arch="$APP_ARCH" "$APP_ID" >/dev/null
+}
+
+smoke_update() {
+    local previous_site="$1"
+    local new_site="$2"
+    local profile="$3"
+    local -a update_options=(update -y --arch="$APP_ARCH")
+    local old_commit
+    local new_commit
+
+    smoke_install "$previous_site" "$profile" penguinburner-test
+    if [[ "$SMOKE_NO_DEPS" == "1" ]]; then
+        update_options+=(--no-deps)
+    fi
+    old_commit="$(
+        flatpak_in_profile "$profile" info \
+            --arch="$APP_ARCH" \
+            --show-commit \
+            "$APP_ID"
+    )"
+    flatpak_in_profile "$profile" remote-modify \
+        --url="file://$new_site/repo" \
+        penguinburner-test
+    flatpak_in_profile "$profile" "${update_options[@]}" "$APP_ID"
+    new_commit="$(
+        flatpak_in_profile "$profile" info \
+            --arch="$APP_ARCH" \
+            --show-commit \
+            "$APP_ID"
+    )"
+    [[ -n "$new_commit" ]] || die "updated Flatpak does not report a commit"
+    [[ "$new_commit" != "$old_commit" ]] \
+        || die "new snapshot did not produce a new Flatpak commit"
+}
+
+while (($#)); do
+    case "$1" in
+        --replace)
+            replace=1
+            shift
+            ;;
+        --prepare-only)
+            prepare_only=1
+            shift
+            ;;
+        --upload-only)
+            upload_only=1
+            shift
+            ;;
+        --migrate-ref)
+            (($# >= 2)) || die "--migrate-ref requires a Git ref"
+            migration_ref="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            die "unknown option: $1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+(($# == 1)) || {
+    usage >&2
+    exit 2
+}
+((prepare_only == 0 || upload_only == 0)) \
+    || die "--prepare-only and --upload-only are mutually exclusive"
+tag="$1"
+
+for command in git gh python3 gpg flatpak tar; do
+    require_command "$command"
+done
+python3 "$ARTIFACT_HELPER" check-tag "$tag" >/dev/null
+git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null
+git -C "$ROOT" rev-parse --verify "$tag^{commit}" >/dev/null \
+    || die "local release tag does not exist: $tag"
+gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null \
+    || die "GitHub Release does not exist: $tag"
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/penguin-burner-pages.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+site="$work_dir/site"
+previous_site="$work_dir/previous-site"
+mkdir -p "$site"
+
+if [[ -n "$migration_ref" ]]; then
+    git -C "$ROOT" rev-parse --verify "$migration_ref^{commit}" >/dev/null \
+        || die "migration ref does not exist: $migration_ref"
+    git -C "$ROOT" archive --format=tar "$migration_ref" \
+        | tar -xf - --no-same-owner --no-same-permissions -C "$site"
+    write_index "$site"
+    python3 "$ARTIFACT_HELPER" validate "$site"
+    smoke_install "$site" "$work_dir/migration-install" penguinburner-migration
+else
+    [[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]] \
+        || die "normal publication requires a clean checkout"
+    head_commit="$(git -C "$ROOT" rev-parse HEAD)"
+    tag_commit="$(git -C "$ROOT" rev-parse "$tag^{commit}")"
+    [[ "$head_commit" == "$tag_commit" ]] \
+        || die "normal publication requires HEAD to match $tag"
+
+    target_prerelease="$(
+        gh release view "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json isPrerelease \
+            --jq '.isPrerelease'
+    )"
+    target_published_at="$(
+        gh release view "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json publishedAt \
+            --jq '.publishedAt'
+    )"
+    previous_tag="$(
+        find_previous_snapshot_tag \
+            "$tag" \
+            "$target_prerelease" \
+            "$target_published_at"
+    )" \
+        || die "no compatible earlier Pages snapshot found; use --migrate-ref for the one-time migration"
+    previous_archive="$(snapshot_name "$previous_tag")"
+    mkdir -p "$work_dir/download"
+    gh release download "$previous_tag" \
+        --repo "$GITHUB_REPOSITORY" \
+        --pattern "$previous_archive" \
+        --pattern "$previous_archive.sha256" \
+        --dir "$work_dir/download"
+    python3 "$ARTIFACT_HELPER" extract \
+        "$work_dir/download/$previous_archive" \
+        "$previous_site" \
+        --checksum "$work_dir/download/$previous_archive.sha256"
+    cp -a "$previous_site/." "$site/"
+
+    PENGUIN_BURNER_FLATPAK_OUT_DIR="$site" \
+    PENGUIN_BURNER_FLATPAK_REPO_URL="$PUBLIC_REPO_URL" \
+    PENGUIN_BURNER_FLATPAK_BUILD_BUNDLE=1 \
+        "$BUILD_SCRIPT"
+    write_index "$site"
+    python3 "$ARTIFACT_HELPER" validate "$site"
+    smoke_install "$site" "$work_dir/new-install" penguinburner-new
+    smoke_update "$previous_site" "$site" "$work_dir/update-install"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+archive_name="$(snapshot_name "$tag")"
+archive_path="$OUTPUT_DIR/$archive_name"
+checksum_path="$archive_path.sha256"
+python3 "$ARTIFACT_HELPER" pack "$site" "$archive_path" >/dev/null
+[[ -f "$checksum_path" ]] || die "snapshot checksum was not created"
+
+if ((prepare_only)); then
+    cat <<EOF
+Prepared and verified signed Pages snapshot for $tag without uploading:
+  Archive:  $archive_path
+  Checksum: $checksum_path
+EOF
+    exit 0
+fi
+
+if ((replace == 0)); then
+    if release_has_asset "$tag" "$archive_name" \
+        || release_has_asset "$tag" "$archive_name.sha256"; then
+        die "snapshot assets already exist for $tag; pass --replace to replace them"
+    fi
+    upload_options=()
+else
+    upload_options=(--clobber)
+fi
+
+gh release upload "$tag" \
+    --repo "$GITHUB_REPOSITORY" \
+    "${upload_options[@]}" \
+    "$archive_path" \
+    "$checksum_path"
+
+if ((upload_only)); then
+    cat <<EOF
+Uploaded signed Pages snapshot for $tag without dispatching:
+  Release: https://github.com/$GITHUB_REPOSITORY/releases/tag/$tag
+
+After changing Settings → Pages → Source to GitHub Actions, deploy with:
+  gh workflow run $WORKFLOW_FILE --repo $GITHUB_REPOSITORY --field tag=$tag
+EOF
+    exit 0
+fi
+
+gh workflow run "$WORKFLOW_FILE" \
+    --repo "$GITHUB_REPOSITORY" \
+    --field "tag=$tag"
+
+cat <<EOF
+Uploaded signed Pages snapshot for $tag:
+  Archive:  $archive_path
+  Checksum: $checksum_path
+  Release:  https://github.com/$GITHUB_REPOSITORY/releases/tag/$tag
+  Runs:     https://github.com/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_FILE
+
+The remote gh-pages branch must not be deleted until the workflow succeeds and
+the public Flatpak install/update verification passes.
+EOF

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -114,6 +114,11 @@ def test_dispatch_cli_daemonize_applies_through_running_daemon(monkeypatch) -> N
     applied = []
     monkeypatch.setattr(
         entry,
+        "resolve_auto_uv_profile",
+        lambda *_args, **_kwargs: {"profile_id": "latest"},
+    )
+    monkeypatch.setattr(
+        entry,
         "apply_runtime_intent",
         lambda intent, **kwargs: applied.append((intent, kwargs))
         or {"started": True, "runtime_mode": "static"},

--- a/tests/test_flatpak_pages_artifact.py
+++ b/tests/test_flatpak_pages_artifact.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+
+_HELPER_PATH = Path("scripts/flatpak_pages_artifact.py")
+_SPEC = importlib.util.spec_from_file_location("flatpak_pages_artifact", _HELPER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+artifact = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = artifact
+_SPEC.loader.exec_module(artifact)
+
+
+def _fingerprint(_key: Path) -> str:
+    return artifact.EXPECTED_SIGNING_FINGERPRINT
+
+
+def _valid_site(tmp_path: Path) -> Path:
+    site = tmp_path / "site"
+    repository_ref = (
+        site / "repo/refs/heads/app/io.github.jpietek.PenguinBurner/x86_64/master"
+    )
+    repository_ref.parent.mkdir(parents=True)
+    repository_ref.write_text("commit\n", encoding="ascii")
+    (site / "repo/config").write_text("[core]\nmode=archive-z2\n", encoding="ascii")
+    (site / "repo/summary").write_bytes(b"summary")
+    (site / "repo/summary.sig").write_bytes(b"signature")
+    (site / ".nojekyll").touch()
+    (site / "index.html").write_text("<!doctype html>\n", encoding="utf-8")
+    (site / "PenguinBurner.flatpak").write_bytes(b"bundle")
+    (site / "penguin-burner-flatpak.gpg").write_bytes(b"public-key")
+    (site / "penguin-burner.flatpakrepo").write_text(
+        "[Flatpak Repo]\n"
+        "Title=PenguinBurner\n"
+        f"Url={artifact.EXPECTED_REPOSITORY_URL}\n",
+        encoding="utf-8",
+    )
+    return site
+
+
+def _write_archive(path: Path, members: list[tarfile.TarInfo]) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for member in members:
+            data = b"x" if member.isfile() else None
+            if data is not None:
+                member.size = len(data)
+            archive.addfile(member, io.BytesIO(data) if data is not None else None)
+
+
+def test_validate_release_tag_accepts_version_and_rejects_paths() -> None:
+    assert artifact.validate_release_tag("v0.7.2") == "v0.7.2"
+    for tag in ("", "../v1", "feature/v1", "-v1", "v1 *"):
+        with pytest.raises(artifact.ArtifactError):
+            artifact.validate_release_tag(tag)
+
+
+def test_valid_site_packs_deterministically_and_extracts(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    first = tmp_path / "first.tar.gz"
+    second = tmp_path / "second.tar.gz"
+
+    first_checksum = artifact.create_archive(
+        site, first, fingerprint_reader=_fingerprint
+    )
+    second_checksum = artifact.create_archive(
+        site, second, fingerprint_reader=_fingerprint
+    )
+
+    assert first.read_bytes() == second.read_bytes()
+    assert first_checksum.read_text(encoding="ascii").endswith("  first.tar.gz\n")
+    assert second_checksum.read_text(encoding="ascii").endswith("  second.tar.gz\n")
+    extracted = tmp_path / "extracted"
+    artifact.extract_archive(
+        first,
+        extracted,
+        checksum_path=first_checksum,
+        fingerprint_reader=_fingerprint,
+    )
+    assert (extracted / "PenguinBurner.flatpak").read_bytes() == b"bundle"
+    assert (extracted / "repo/summary").read_bytes() == b"summary"
+
+
+@pytest.mark.parametrize(
+    "missing",
+    (
+        "index.html",
+        "PenguinBurner.flatpak",
+        "penguin-burner.flatpakrepo",
+        "repo/summary",
+    ),
+)
+def test_validate_site_rejects_missing_required_files(
+    tmp_path: Path, missing: str
+) -> None:
+    site = _valid_site(tmp_path)
+    (site / missing).unlink()
+    with pytest.raises(artifact.ArtifactError, match="missing required file"):
+        artifact.validate_site(site, fingerprint_reader=_fingerprint)
+
+
+def test_validate_site_rejects_empty_payload(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    (site / "PenguinBurner.flatpak").write_bytes(b"")
+    with pytest.raises(artifact.ArtifactError, match="is empty"):
+        artifact.validate_site(site, fingerprint_reader=_fingerprint)
+
+
+def test_validate_site_rejects_repository_url_mismatch(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    (site / "penguin-burner.flatpakrepo").write_text(
+        "[Flatpak Repo]\nUrl=https://example.invalid/repo\n", encoding="utf-8"
+    )
+    with pytest.raises(artifact.ArtifactError, match="URL mismatch"):
+        artifact.validate_site(site, fingerprint_reader=_fingerprint)
+
+
+def test_validate_site_rejects_signing_key_mismatch(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    with pytest.raises(artifact.ArtifactError, match="signing key mismatch"):
+        artifact.validate_site(site, fingerprint_reader=lambda _path: "BAD")
+
+
+def test_validate_site_rejects_symlink(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    (site / "link").symlink_to("repo/summary")
+    with pytest.raises(artifact.ArtifactError, match="symlinks"):
+        artifact.validate_site(site, fingerprint_reader=_fingerprint)
+
+
+@pytest.mark.parametrize(
+    ("name", "entry_type"),
+    (
+        ("../escape", tarfile.REGTYPE),
+        ("/absolute", tarfile.REGTYPE),
+        ("./relative", tarfile.REGTYPE),
+        ("nested//empty", tarfile.REGTYPE),
+        ("link", tarfile.SYMTYPE),
+        ("hard-link", tarfile.LNKTYPE),
+    ),
+)
+def test_extract_rejects_unsafe_archive_entries(
+    tmp_path: Path, name: str, entry_type: bytes
+) -> None:
+    archive_path = tmp_path / "unsafe.tar.gz"
+    member = tarfile.TarInfo(name)
+    member.type = entry_type
+    if entry_type in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+        member.linkname = "target"
+    _write_archive(archive_path, [member])
+    checksum = artifact.write_checksum(archive_path)
+
+    with pytest.raises(artifact.ArtifactError):
+        artifact.extract_archive(
+            archive_path,
+            tmp_path / "output",
+            checksum_path=checksum,
+            fingerprint_reader=_fingerprint,
+        )
+    assert not (tmp_path / "output").exists()
+    assert not (tmp_path.parent / "escape").exists()
+
+
+def test_extract_rejects_wrapping_directory(tmp_path: Path) -> None:
+    archive_path = tmp_path / "wrapped.tar.gz"
+    member = tarfile.TarInfo("wrapper/index.html")
+    member.type = tarfile.REGTYPE
+    _write_archive(archive_path, [member])
+    checksum = artifact.write_checksum(archive_path)
+
+    with pytest.raises(artifact.ArtifactError, match="missing required file"):
+        artifact.extract_archive(
+            archive_path,
+            tmp_path / "output",
+            checksum_path=checksum,
+            fingerprint_reader=_fingerprint,
+        )
+
+
+def test_extract_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    site = _valid_site(tmp_path)
+    archive_path = tmp_path / "site.tar.gz"
+    checksum = artifact.create_archive(
+        site, archive_path, fingerprint_reader=_fingerprint
+    )
+    archive_path.write_bytes(archive_path.read_bytes() + b"corrupt")
+
+    with pytest.raises(artifact.ArtifactError, match="checksum mismatch"):
+        artifact.extract_archive(
+            archive_path,
+            tmp_path / "output",
+            checksum_path=checksum,
+            fingerprint_reader=_fingerprint,
+        )
+
+
+def test_public_key_fingerprint_reads_gpg_colon_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    key = tmp_path / "key.gpg"
+    key.write_bytes(b"key")
+    completed = subprocess.CompletedProcess(
+        args=["gpg"],
+        returncode=0,
+        stdout=f"fpr:::::::::{artifact.EXPECTED_SIGNING_FINGERPRINT}:\n",
+        stderr="",
+    )
+    monkeypatch.setattr(artifact.subprocess, "run", lambda *args, **kwargs: completed)
+
+    assert artifact.public_key_fingerprint(key) == artifact.EXPECTED_SIGNING_FINGERPRINT

--- a/tests/test_flatpak_pages_publish_surface.py
+++ b/tests/test_flatpak_pages_publish_surface.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import subprocess
+
+
+PUBLISH_SCRIPT = Path("scripts/publish-flatpak-pages.sh")
+WORKFLOW = Path(".github/workflows/deploy-flatpak-pages.yml")
+
+
+def test_flatpak_pages_publish_script_has_valid_bash_syntax() -> None:
+    subprocess.run(("bash", "-n", str(PUBLISH_SCRIPT)), check=True)
+
+
+def test_flatpak_pages_publisher_uses_release_assets_not_git_commits() -> None:
+    script = PUBLISH_SCRIPT.read_text(encoding="utf-8")
+    assert 'gh release upload "$tag"' in script
+    assert 'gh workflow run "$WORKFLOW_FILE"' in script
+    assert "git commit" not in script
+    assert "git push" not in script
+    assert "--migrate-ref" in script
+    assert "--prepare-only" in script
+    assert "--upload-only" in script
+    assert "PENGUIN_BURNER_FLATPAK_BUILD_BUNDLE=1" in script
+    assert '.publishedAt < \\"$target_published_at\\"' in script
+    assert "Settings → Pages → Source to GitHub Actions" in script
+
+
+def test_flatpak_pages_workflow_is_manual_and_minimally_privileged() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in workflow
+    assert "push:" not in workflow
+    assert "permissions: {}" in workflow
+    assert "contents: read" in workflow
+    assert "pages: write" in workflow
+    assert "id-token: write" in workflow
+    assert "secrets." not in workflow
+    assert "gh-pages" not in workflow
+
+
+def test_flatpak_pages_workflow_pins_and_validates_actions() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow
+    assert (
+        "actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b" in workflow
+    )
+    assert (
+        "actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b"
+        in workflow
+    )
+    assert "actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e" in workflow
+    assert "flatpak_pages_artifact.py check-tag" in workflow
+    assert "flatpak_pages_artifact.py extract" in workflow

--- a/tests/test_steam_game_runtime.py
+++ b/tests/test_steam_game_runtime.py
@@ -130,8 +130,9 @@ def test_profile_argv_for_unresolved_tier_is_none(monkeypatch) -> None:
 
 
 def test_game_runtime_profile_argv_reads_setting(
-    steam_home: Path, tmp_path: Path
+    steam_home: Path, tmp_path: Path, monkeypatch
 ) -> None:
+    _stub_adaptive_profiles(monkeypatch)
     settings_path = tmp_path / "steam-game-settings.json"
     store_steam_game_setting(
         ACCOUNT_ID,
@@ -263,6 +264,7 @@ def test_flatpak_runtime_helper_passes_explicit_game_identity(monkeypatch) -> No
 def test_apply_soft_fails_when_daemon_unreachable(
     steam_home: Path, tmp_path: Path, monkeypatch, capsys
 ) -> None:
+    _stub_adaptive_profiles(monkeypatch)
     settings_path = tmp_path / "steam-game-settings.json"
     store_steam_game_setting(
         ACCOUNT_ID,

--- a/tests/test_steam_manager.py
+++ b/tests/test_steam_manager.py
@@ -7,7 +7,6 @@ from integrations.steam.manager import SteamIntegrationManager
 from integrations.steam.settings import (
     GAME_MODE_ADAPTIVE,
     GAME_MODE_DEFAULT,
-    GAME_MODE_NONE,
     GAME_MODE_STOCK,
     load_steam_game_settings,
 )
@@ -493,6 +492,8 @@ def test_hot_reapply_tolerates_grace_window_exit(manager, monkeypatch) -> None:
             "game_runtime": {
                 "active": True,
                 "watched": [{"pid": 4242, "app_id": APP_ID}],
+                "standing_runtime_mode": "adaptive",
+                "standing_profile_id": "performance-9",
             }
         },
     )

--- a/tests/test_ui_commands.py
+++ b/tests/test_ui_commands.py
@@ -2522,6 +2522,7 @@ def test_scan_tuning_unsupported_power_limit_only_omits_power_option(
             [
                 SimpleNamespace(
                     index=0,
+                    name="NVIDIA GeForce RTX 5060 Laptop GPU",
                     label="GPU 0 - NVIDIA GeForce RTX 5060 Laptop GPU",
                 )
             ],

--- a/tests/test_ui_dialogs.py
+++ b/tests/test_ui_dialogs.py
@@ -230,6 +230,9 @@ def test_select_scan_tuning_mirrors_balanced_and_performance_memory(
     Performance; Efficiency stays independent, and the single-profile scope
     releases the mirror."""
     qtcore, qtgui, qtwidgets, _pg = qt
+    monkeypatch.setattr(
+        scan_tuning_dialog, "memory_offset_mhz_range", lambda **_kwargs: (0, 4000)
+    )
 
     checked: dict[str, bool] = {}
 


### PR DESCRIPTION
## Summary

- publish the signed Flatpak repository as a versioned GitHub Release snapshot and deploy it with a manual Pages workflow
- validate archive paths, checksum, repository URL, signing fingerprint, clean installation, and release-to-release updates
- document Flatpak v0.7.2 and repair stale runtime test fixtures

## Verification

- `python -m pytest tests/ -q` — 1602 passed, 57 skipped
- Ruff — clean
- Pyright — 0 errors
- actionlint and bash syntax — clean
- real `origin/gh-pages` migration dry run and x86_64 app-ref install — passed