### PR TITLE
Use Launchpad FTP for PPA uploads

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -52,6 +52,6 @@ scripts/publish-ppa.sh 0.7.2
 ```
 
 That one command builds and validates both Questing and Resolute source
-packages, uploads them, waits for Launchpad's amd64 builds, prints their URLs,
-and fails if either build fails. Pass series names after the version to publish
-only selected targets.
+packages, uploads them through Launchpad's anonymous passive-FTP endpoint,
+waits for Launchpad's amd64 builds, prints their URLs, and fails if either build
+fails. Pass series names after the version to publish only selected targets.

--- a/scripts/publish-ppa.sh
+++ b/scripts/publish-ppa.sh
@@ -80,10 +80,11 @@ if [ "$ppa" = "ppa:jpietek/penguin-burner" ]; then
     cat > "$dput_profile_dir/profiles/penguin-ppa.json" <<'JSON'
 {
   "fqdn": "ppa.launchpad.net",
-  "incoming": "~jpietek/penguin-burner/ubuntu/",
-  "login": "jpietek",
+  "incoming": "~jpietek/ubuntu/penguin-burner/",
+  "login": "anonymous",
   "meta": "boring",
-  "method": "sftp"
+  "method": "ftp",
+  "passive_ftp": true
 }
 JSON
     mkdir -p "$HOME/.dput.d/profiles"

--- a/tests/test_ppa_publish_surface.py
+++ b/tests/test_ppa_publish_surface.py
@@ -41,6 +41,9 @@ def test_one_click_publisher_guards_git_and_waits_for_both_series() -> None:
     assert "PPA publication requires a clean checkout" in script
     assert "git check-ignore -q dist/deb" in script
     assert "dput_profile_backup" in script
+    assert '"login": "anonymous"' in script
+    assert '"method": "ftp"' in script
+    assert '"passive_ftp": true' in script
     assert '"$status_helper" check' in script
     assert '"$status_helper" wait' in script
     assert 'changes_files+=("$changes")' in script


### PR DESCRIPTION
## What changed

- use Canonical documented anonymous passive-FTP transport for public PPA uploads
- correct the Launchpad incoming path ordering
- assert and document the transport configuration

## Why

The previous SFTP profile required a Launchpad SSH credential that is not installed on this release host. Public PPAs support anonymous signed FTP uploads.

## Validation

- 1619 passed, 57 skipped
- Ruff clean
- Pyright: 0 errors
- shell syntax check passes
- staged audit: three text-only files