### PR TITLE
Release hardening: mobile GPU tolerance, opt-in boot apply, stock recovery, Steam runtime details

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Auto-UV uses the same UI while testing your GPU.
 python -m pip install --user --upgrade penguin-burner
 ```
 
+On distros whose system Python is externally managed (Fedora 38+,
+Ubuntu 23.04+, Debian 12+), pip refuses with `externally-managed-environment`;
+use `pipx install penguin-burner` there — or a native package below.
+
 Also packaged for [Fedora (COPR)](https://copr.fedorainfracloud.org/coprs/jpietek/penguin-burner/),
 [Arch / CachyOS (AUR)](https://aur.archlinux.org/packages/penguin-burner), and
 [Ubuntu (PPA)](https://launchpad.net/~jpietek/+archive/ubuntu/penguin-burner) —
@@ -74,11 +78,12 @@ prompts.
    wrappers should use the [Flatpak guide](docs/flatpak.md).
 3. Click **Setup Auto Undervolt**, choose a performance bias, and let the scan
    find and verify a stable curve. When it finishes, the verified profile is
-   applied and set as your boot profile automatically.
+   applied automatically.
 4. On the **Profiles** tab you can select any saved profile and click **Apply**
-   to switch to it (applying also makes it the boot profile). Toggle **Silent
-   fan curve** for the quiet fan profile, or **Restore defaults** to return the
-   GPU to stock.
+   to switch to it. Tick **Apply on startup** to also make the applied profile
+   your boot profile — off by default, so a tuned curve is never re-applied at
+   boot unless you opted in. Toggle **Silent fan curve** for the quiet fan
+   profile, or **Restore defaults** to return the GPU to stock.
 5. For per-game tuning — including **Adaptive**, which switches tiers as your
    frame rate changes — use the **Steam** tab to pick a mode per game.
 

--- a/burnerd/src/profile/apply.rs
+++ b/burnerd/src/profile/apply.rs
@@ -109,12 +109,21 @@ pub(super) fn reset_gpu_to_stock(
         )),
         Err(exc) => failures.push(format!("clock offsets: {exc}")),
     }
+    // Best-effort: mobile boards expose a readable default limit while
+    // rejecting the manual setter, and a rejected setter also means the limit
+    // was never moved off its default. A failure here must not fail the
+    // reset, or Auto-UV startup and the stock fallback break on that hardware.
     let default_w = backend.query_power_limits().power_limit_default_w;
     if let Some(default_w) = default_w {
         if default_w != 0 {
             if let Err(exc) = backend.apply_power_limit_w(default_w) {
-                failures.push(format!("power limit: {exc}"));
+                log(&format!(
+                    "keep-stock: default power limit restore skipped: {exc}"
+                ));
             } else {
+                // The setter succeeded, so this is not the fixed-limit mobile
+                // case: a readback that still shows a tuned limit is a real
+                // incomplete reset and stays fatal.
                 let readback = backend.query_power_limits();
                 if readback.power_limit_w != Some(default_w)
                     && readback.enforced_power_limit_w != Some(default_w)
@@ -453,6 +462,49 @@ mod tests {
                     offsets: vec![(5, 0)]
                 },
             ]
+        );
+    }
+
+    /// Mobile boards expose a readable default power limit while rejecting the
+    /// manual setter; the stock reset must still succeed and zero the V/F
+    /// curve, or Auto-UV startup and the stock fallback break on laptops.
+    #[test]
+    fn stock_reset_tolerates_rejected_power_limit_setter() {
+        let mut mock = MockGpu::new();
+        mock.vf_available = true;
+        mock.power_limits.power_limit_default_w = Some(115);
+        mock.power_limits.power_limit_w = Some(115);
+        mock.vf_points = vec![crate::gpu::VfPoint {
+            index: 5,
+            type_: 0,
+            voltage_based: 1,
+            ..Default::default()
+        }];
+        mock.inject_failure(
+            "apply_power_limit_w",
+            crate::gpu::GpuError::nvml_with_text(
+                "nvmlDeviceSetPowerManagementLimit",
+                3,
+                "Not Supported",
+            ),
+        );
+        let mut messages = Vec::new();
+        let mut log = |msg: &str| messages.push(msg.to_string());
+        let result =
+            configure_runtime_spec_policy(&mock, true, RuntimeMode::Stock, None, &mut log).unwrap();
+        assert_eq!(result.active_vf_curve_source.as_deref(), Some("stock"));
+        let ops = mock.recorded();
+        assert!(
+            ops.contains(&MockOp::ApplyVfOffsets {
+                offsets: vec![(5, 0)]
+            }),
+            "V/F zero plan must still apply when the power limit setter is rejected: {ops:?}"
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|msg| msg.contains("default power limit restore skipped")),
+            "the skipped power limit restore must be logged: {messages:?}"
         );
     }
 

--- a/burnerd/src/profile/mod.rs
+++ b/burnerd/src/profile/mod.rs
@@ -576,7 +576,18 @@ fn run_fan_control_loop(
     let poll_interval_s = settings.poll_interval_s;
     let vf_reapply_cooldown_s = poll_interval_s.max(10.0);
 
-    let fan_count = backend.fan_count().map_err(|e| e.to_string())?;
+    // Laptop dGPUs commonly return NOT_SUPPORTED for the fan count (the EC
+    // owns the fans). That must not block profiles that never touch fans.
+    let fan_count = match backend.fan_count() {
+        Ok(count) => count,
+        Err(exc) if !fan_control_enabled => {
+            engine_log(&format!(
+                "fan control unavailable (continuing without it): {exc}"
+            ));
+            0
+        }
+        Err(exc) => return Err(exc.to_string()),
+    };
     if fan_control_enabled && fan_count == 0 {
         return Err("GPU reports zero controllable fans".to_string());
     }

--- a/burnerd/src/profile/tests.rs
+++ b/burnerd/src/profile/tests.rs
@@ -617,3 +617,85 @@ mod smoke {
         assert!(text.contains("voltage="));
     }
 }
+
+/// Laptop dGPUs commonly return NOT_SUPPORTED for `nvmlDeviceGetNumFans` (the
+/// EC owns the fans). With fan control disabled the engine must still start —
+/// stock and undervolt-only profiles never touch fans.
+#[test]
+fn unsupported_fan_count_is_tolerated_when_fan_control_disabled() {
+    let mock = MockGpu::new();
+    mock.inject_failure(
+        "fan_count",
+        crate::gpu::GpuError::nvml_with_text("nvmlDeviceGetNumFans", 3, "Not Supported"),
+    );
+
+    let mut publisher = super::telemetry::OverlayStatePublisher::new(
+        0,
+        false,
+        1.0,
+        String::new(),
+        String::new(),
+        String::new(),
+        false,
+        None,
+    );
+    let stop = Arc::new(AtomicBool::new(false));
+    let result = run_fan_control_loop(
+        &mock,
+        0,
+        false,
+        FanConfig::defaults(),
+        false, // fan control disabled → the unsupported fan count must not block
+        VfPolicyResult::default(),
+        &mut publisher,
+        None,
+        None,
+        None,
+        stop,
+        Some(1),
+        &mut None,
+    );
+    assert!(
+        result.is_ok(),
+        "engine must run without fan control when the fan count is unsupported: {result:?}"
+    );
+}
+
+/// With fan control REQUESTED, an unsupported fan count stays a hard error so
+/// the profile falls back instead of silently dropping the fan curve.
+#[test]
+fn unsupported_fan_count_still_fails_when_fan_control_enabled() {
+    let mock = MockGpu::new();
+    mock.inject_failure(
+        "fan_count",
+        crate::gpu::GpuError::nvml_with_text("nvmlDeviceGetNumFans", 3, "Not Supported"),
+    );
+
+    let mut publisher = super::telemetry::OverlayStatePublisher::new(
+        0,
+        false,
+        1.0,
+        String::new(),
+        String::new(),
+        String::new(),
+        false,
+        None,
+    );
+    let stop = Arc::new(AtomicBool::new(false));
+    let result = run_fan_control_loop(
+        &mock,
+        0,
+        false,
+        FanConfig::defaults(),
+        true,
+        VfPolicyResult::default(),
+        &mut publisher,
+        None,
+        None,
+        None,
+        stop,
+        Some(1),
+        &mut None,
+    );
+    assert!(result.is_err());
+}

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -279,6 +279,15 @@ def parse_arguments(argv):
         help="Print PenguinBurner hardware daemon status and exit.",
     )
     daemon_group.add_argument(
+        "--restore-stock",
+        action="store_true",
+        help=(
+            "Recovery: reset the GPU to stock now and make stock the boot "
+            "state through the running penguin-burnerd service. Saved "
+            "profiles are kept. Works without the GUI."
+        ),
+    )
+    daemon_group.add_argument(
         "--auto-uv-profile",
         default="",
         help=(

--- a/cli/entry.py
+++ b/cli/entry.py
@@ -50,6 +50,34 @@ def dispatch_cli(
             status = daemon_status(socket_path=DEFAULT_DAEMON_SOCKET)
             print(json.dumps(status, indent=2), flush=True)
             return 0
+        if runtime_flags["restore_stock"]:
+            # Headless recovery: reset the GPU to stock now and make stock the
+            # boot state. Kept GUI-independent so it works when a saved
+            # profile misbehaves or the desktop session is unusable.
+            from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR
+
+            try:
+                _apply_runtime_intent_through_daemon(
+                    {"profile_selector": STOCK_PROFILE_SELECTOR},
+                    persist_on_startup=True,
+                )
+            except Exception as exc:
+                print(
+                    "restore-stock could not reach the penguin-burnerd "
+                    f"service: {exc}\n"
+                    "Start the service first:  sudo systemctl start "
+                    "penguin-burnerd.service\n"
+                    "Or keep any saved profile from applying at boot at all:  "
+                    "sudo systemctl disable --now penguin-burnerd.service",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                return 1
+            log(
+                "GPU restored to stock; stock is now the boot state. "
+                "Saved profiles were kept and can be re-applied from the GUI."
+            )
+            return 0
         if runtime_flags["migrate_to_daemon"]:
             migrate_to_daemon_service(
                 program_file,
@@ -93,8 +121,19 @@ def _apply_runtime_through_daemon(
     *,
     persist_on_startup: bool,
 ) -> None:
-    result = apply_runtime_intent(
+    _apply_runtime_intent_through_daemon(
         runtime_intent_from_argv(runtime_argv),
+        persist_on_startup=persist_on_startup,
+    )
+
+
+def _apply_runtime_intent_through_daemon(
+    intent: dict,
+    *,
+    persist_on_startup: bool,
+) -> None:
+    result = apply_runtime_intent(
+        intent,
         persist_on_startup=bool(persist_on_startup),
         socket_path=DEFAULT_DAEMON_SOCKET,
     )

--- a/cli/runtime_config_file.py
+++ b/cli/runtime_config_file.py
@@ -6,6 +6,7 @@ The module owns config defaults and small persistence updates; runtime behavior 
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 import tomllib
 
 from integrations.afterburner.import_fan_curve import write_config as write_runtime_config
@@ -18,8 +19,7 @@ from runtime.support.adaptive_target_fps import (
 from common.penguin_burner_paths import default_runtime_config_path
 
 UI_CONFIG_SECTION = "ui"
-# Retired 2026-07: standing Apply and Restore defaults now always persist an
-# explicit profile or stock state for boot. Stale toggle keys are ignored.
+PERSIST_ON_STARTUP_CONFIG_KEY = "persist_on_startup"
 SILENT_FAN_CURVE_CONFIG_KEY = "silent_fan_curve"
 
 
@@ -58,6 +58,9 @@ def default_runtime_config() -> dict:
             "target_fps": DEFAULT_ADAPTIVE_TARGET_FPS,
         },
         UI_CONFIG_SECTION: {
+            # Safe default: applying a profile changes the current session
+            # only. The user opts into boot persistence explicitly.
+            PERSIST_ON_STARTUP_CONFIG_KEY: False,
             SILENT_FAN_CURVE_CONFIG_KEY: False,
         },
     }
@@ -69,7 +72,7 @@ def load_runtime_config(config_path=None):
     if not path.exists():
         return config, path
 
-    loaded = load_raw_runtime_config(path)
+    loaded = load_raw_runtime_config(path, tolerant=True)
     for section in ("gpu", "fan", "stability", "adaptive", UI_CONFIG_SECTION):
         values = loaded.get(section)
         if isinstance(values, dict):
@@ -77,12 +80,31 @@ def load_runtime_config(config_path=None):
     return config, path
 
 
-def load_raw_runtime_config(config_path):
+def load_raw_runtime_config(config_path, *, tolerant: bool = False):
+    """Read the raw TOML config.
+
+    Read-only paths pass ``tolerant=True`` so a hand-corrupted config
+    degrades to defaults — --restore-stock especially is a recovery command
+    and has to work when user state is broken. Read-modify-write persisters
+    must stay strict: swallowing the error there would re-emit the file with
+    a single section and silently drop the rest of the user's settings.
+    """
     path = Path(config_path).expanduser()
     if not path.exists():
         return {}
-    with path.open("rb") as config_file:
-        return tomllib.load(config_file)
+    try:
+        with path.open("rb") as config_file:
+            return tomllib.load(config_file)
+    except (tomllib.TOMLDecodeError, OSError) as exc:
+        if not tolerant:
+            raise
+        print(
+            f"warning: unreadable runtime config {path} ({exc}); "
+            "continuing with defaults",
+            file=sys.stderr,
+            flush=True,
+        )
+        return {}
 
 
 def persist_adaptive_target_fps_to_runtime_config(
@@ -104,7 +126,8 @@ def persist_adaptive_target_fps_to_runtime_config(
     return normalized
 
 
-def silent_fan_curve_from_runtime_config(
+def _ui_bool_from_runtime_config(
+    key: str,
     config_path=None,
     *,
     default: bool = False,
@@ -114,17 +137,20 @@ def silent_fan_curve_from_runtime_config(
         if config_path is None
         else Path(config_path).expanduser()
     )
-    config = load_raw_runtime_config(path)
+    # Tolerant read: GUI startup and recovery paths must degrade to the
+    # default on a corrupt config instead of failing.
+    config = load_raw_runtime_config(path, tolerant=True)
     raw_ui = config.get(UI_CONFIG_SECTION, {})
     if not isinstance(raw_ui, dict):
         return bool(default)
-    value = raw_ui.get(SILENT_FAN_CURVE_CONFIG_KEY)
+    value = raw_ui.get(key)
     if value is None:
         return bool(default)
     return _config_bool(value, default=default)
 
 
-def silent_fan_curve_to_runtime_config(
+def _ui_bool_to_runtime_config(
+    key: str,
     enabled,
     config_path=None,
 ) -> bool:
@@ -133,14 +159,54 @@ def silent_fan_curve_to_runtime_config(
         if config_path is None
         else Path(config_path).expanduser()
     )
+    # Strict read: a corrupt config must abort this read-modify-write instead
+    # of being re-emitted with only the [ui] section.
     config = load_raw_runtime_config(path)
     raw_ui = config.get(UI_CONFIG_SECTION, {})
     ui = dict(raw_ui) if isinstance(raw_ui, dict) else {}
     normalized = bool(enabled)
-    ui[SILENT_FAN_CURVE_CONFIG_KEY] = normalized
+    ui[key] = normalized
     config[UI_CONFIG_SECTION] = ui
     write_runtime_config(path, config)
     return normalized
+
+
+def persist_on_startup_from_runtime_config(
+    config_path=None,
+    *,
+    default: bool = False,
+) -> bool:
+    return _ui_bool_from_runtime_config(
+        PERSIST_ON_STARTUP_CONFIG_KEY, config_path, default=default
+    )
+
+
+def persist_on_startup_to_runtime_config(
+    enabled,
+    config_path=None,
+) -> bool:
+    return _ui_bool_to_runtime_config(
+        PERSIST_ON_STARTUP_CONFIG_KEY, enabled, config_path
+    )
+
+
+def silent_fan_curve_from_runtime_config(
+    config_path=None,
+    *,
+    default: bool = False,
+) -> bool:
+    return _ui_bool_from_runtime_config(
+        SILENT_FAN_CURVE_CONFIG_KEY, config_path, default=default
+    )
+
+
+def silent_fan_curve_to_runtime_config(
+    enabled,
+    config_path=None,
+) -> bool:
+    return _ui_bool_to_runtime_config(
+        SILENT_FAN_CURVE_CONFIG_KEY, enabled, config_path
+    )
 
 
 def _config_bool(value, *, default: bool = False) -> bool:

--- a/docs/features/profile-management.md
+++ b/docs/features/profile-management.md
@@ -17,12 +17,17 @@ Power W, and Memory offset. Sort by any column to compare runs.
 Top bar:
 
 - **Apply** — run the highlighted profile now.
+- **Apply on startup** — also save the applied profile as the boot profile.
+  Off by default: with it unticked, Apply changes the current session only
+  and clears any saved boot profile, so the GPU starts at stock.
 - **Silent fan curve** — use the saved fan curve with the applied profile.
 - **Restore defaults** — return the GPU to stock now and at boot.
 
-Apply always saves the selected profile as the standing boot state. Restore
-defaults saves stock as that state instead. The `penguin-burnerd` service stays
-enabled and available in both cases.
+With **Apply on startup** ticked, Apply saves the selected profile as the
+standing boot state. Restore defaults saves stock as that state instead. The
+`penguin-burnerd` service stays enabled and available in all cases. The toggle
+itself is remembered in `~/.config/PenguinBurner/penguin_burner.toml`
+(`[ui] persist_on_startup`) and survives reinstalls and upgrades.
 
 Right-click a profile:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,6 +15,20 @@ debugging but is not the GPU picker backend.
 python -m pip install --user --upgrade penguin-burner
 ```
 
+Fedora 38+, Ubuntu 23.04+, and Debian 12+ mark the system Python as
+externally managed (PEP 668), so the command above fails with
+`error: externally-managed-environment`. On those distros install through
+pipx instead:
+
+```bash
+pipx install penguin-burner   # sudo dnf/apt install pipx first if needed
+```
+
+or use a dedicated virtual environment
+(`python -m venv ~/.venvs/penguin-burner && ~/.venvs/penguin-burner/bin/pip
+install penguin-burner`), or simply prefer the native COPR/AUR/PPA package
+for your distro below.
+
 ## Flatpak
 
 ```bash
@@ -34,6 +48,11 @@ Rust binary) built into the sandbox. The first privileged action installs it
 onto the host at `/usr/libexec/penguin-burnerd` together with its systemd
 service, with a single admin prompt; after that all privileged GPU operations
 go through the running service with no further prompts.
+
+After that very first daemon setup, quit and relaunch the app once: the
+sandbox can only see the daemon socket (`/run/penguin-burnerd.sock`) when it
+already exists at app launch. If GPU actions report the daemon socket as
+missing right after the first setup, the relaunch is the fix.
 
 ## Fedora ([COPR](https://copr.fedorainfracloud.org/coprs/jpietek/penguin-burner/))
 
@@ -96,3 +115,34 @@ copies the current wheel-bundled `runtime/daemon_bin/penguin-burnerd`, or the
 dev build at `burnerd/target/release/penguin-burnerd`, into that fixed path. An
 existing safe `/usr/libexec` copy is used only when a distro package provides no
 separate source payload.
+
+## Recovery: getting back to stock
+
+Applied tuning persists across reboots only while **Apply on startup** on the
+Profiles tab is ticked (off by default). Unticking it clears any saved boot
+profile immediately, so a plain reboot returns an unticked setup to stock.
+
+If the GPU is in a bad state (or a boot profile misbehaves), reset it to
+stock — now and at boot — without the GUI:
+
+```bash
+penguin-burner-cli --restore-stock
+```
+
+This asks the running root daemon to clear core/memory offsets, release locked
+clocks, restore the factory V/F curve and default power limit, and makes stock
+the boot state. Saved profiles are kept and can be re-applied later.
+
+If a boot profile ever makes the desktop unusable before you can run that
+command, boot once into systemd rescue mode (hold the boot menu, select the
+rescue/recovery entry, or add `systemd.unit=rescue.target` to the kernel
+command line) and run:
+
+```bash
+systemctl disable --now penguin-burnerd.service
+```
+
+That stops the profile from applying at the next normal boot. (The
+`--restore-stock` command needs the daemon service running, so in rescue mode
+either disable the unit as above, or `systemctl start penguin-burnerd.service`
+first and then run `penguin-burner-cli --restore-stock`.)

--- a/readme-cli.md
+++ b/readme-cli.md
@@ -204,6 +204,13 @@ Remove the persistent boot-time service:
 sudo ./penguin_burner.sh --uninstall-systemd-service
 ```
 
+Recovery — reset the GPU to stock now and make stock the boot state, keeping
+saved profiles (works headless, without the GUI):
+
+```bash
+./penguin_burner.sh --restore-stock
+```
+
 By default daemon runtime applies the saved V/F curve and leaves fan control to
 the GPU driver. Add `--silent-fan-curve` to opt into PenguinBurner's saved
 Auto-UV fan curve:

--- a/runtime/daemon_client.py
+++ b/runtime/daemon_client.py
@@ -247,9 +247,15 @@ def apply_runtime_intent(
     intent: dict[str, Any],
     *,
     persist_on_startup: bool = False,
+    clear_boot: bool = False,
     socket_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Resolve and apply a user runtime intent through the root daemon."""
+    """Resolve and apply a user runtime intent through the root daemon.
+
+    ``persist_on_startup`` saves the applied spec as the boot profile;
+    ``clear_boot`` removes any saved boot profile so the apply is
+    session-only. With neither flag the boot entry is left untouched.
+    """
     from runtime.runtime_spec import build_runtime_spec_from_intent
 
     resolved_socket = _resolved_socket_path(socket_path)
@@ -257,6 +263,8 @@ def apply_runtime_intent(
     result = apply_runtime_spec(spec, socket_path=resolved_socket)
     if persist_on_startup:
         set_boot_runtime_spec(spec, socket_path=resolved_socket)
+    elif clear_boot:
+        clear_boot_runtime_spec(socket_path=resolved_socket)
     return result
 
 
@@ -748,6 +756,7 @@ def main(argv: list[str] | None = None) -> int:
     start.add_argument("options_json")
     runtime = subparsers.add_parser("apply-runtime-intent")
     runtime.add_argument("--boot", action="store_true")
+    runtime.add_argument("--clear-boot", action="store_true")
     runtime.add_argument("intent_json")
     subparsers.add_parser("migrate-legacy-boot-intent")
     runtime_spec = subparsers.add_parser("apply-runtime-spec")
@@ -822,6 +831,7 @@ def main(argv: list[str] | None = None) -> int:
             result = apply_runtime_intent(
                 intent,
                 persist_on_startup=bool(args.boot),
+                clear_boot=bool(args.clear_boot),
                 socket_path=args.socket,
             )
             print(

--- a/runtime/support/runtime_service.py
+++ b/runtime/support/runtime_service.py
@@ -54,6 +54,7 @@ def parse_runtime_flags(argv, *, default_journal_hours=DEFAULT_JOURNAL_HOURS):
     uninstall_systemd_service = False
     migrate_to_daemon = False
     daemon_status_requested = False
+    restore_stock = False
     journal_hours = default_journal_hours
     passthrough = []
     index = 0
@@ -79,6 +80,10 @@ def parse_runtime_flags(argv, *, default_journal_hours=DEFAULT_JOURNAL_HOURS):
             daemon_status_requested = True
             index += 1
             continue
+        if arg == "--restore-stock":
+            restore_stock = True
+            index += 1
+            continue
         if arg == "--journal-hours":
             if index + 1 >= len(argv):
                 raise RuntimeError("--journal-hours requires a value")
@@ -97,12 +102,20 @@ def parse_runtime_flags(argv, *, default_journal_hours=DEFAULT_JOURNAL_HOURS):
         raise RuntimeError(
             "choose either --install-systemd-service or --uninstall-systemd-service"
         )
+    if restore_stock and (
+        daemonize or install_systemd_service or uninstall_systemd_service or migrate_to_daemon
+    ):
+        raise RuntimeError(
+            "--restore-stock is a standalone recovery command; do not combine "
+            "it with --daemonize or service install/uninstall/migrate flags"
+        )
     return {
         "daemonize": daemonize,
         "install_systemd_service": install_systemd_service,
         "uninstall_systemd_service": uninstall_systemd_service,
         "migrate_to_daemon": migrate_to_daemon,
         "daemon_status": daemon_status_requested,
+        "restore_stock": restore_stock,
         "journal_hours": journal_hours,
         "passthrough": passthrough,
     }

--- a/tests/test_adaptive_target_fps.py
+++ b/tests/test_adaptive_target_fps.py
@@ -9,6 +9,8 @@ from runtime.support.adaptive_target_fps import (
     parse_adaptive_target_fps,
 )
 from cli.runtime_config_file import persist_adaptive_target_fps_to_runtime_config
+from cli.runtime_config_file import persist_on_startup_from_runtime_config
+from cli.runtime_config_file import persist_on_startup_to_runtime_config
 from cli.runtime_config_file import silent_fan_curve_from_runtime_config
 from cli.runtime_config_file import silent_fan_curve_to_runtime_config
 
@@ -36,6 +38,25 @@ def test_adaptive_target_fps_reads_runtime_config(tmp_path) -> None:
         )
         == 50.0
     )
+
+
+def test_persist_on_startup_preference_round_trips_runtime_config(tmp_path) -> None:
+    path = tmp_path / "penguin_burner.toml"
+    path.write_text("[adaptive]\ntarget_fps = 72\n", encoding="utf-8")
+
+    # The default only applies while the key has never been written.
+    assert persist_on_startup_from_runtime_config(path, default=True) is True
+    assert persist_on_startup_from_runtime_config(path, default=False) is False
+    # Once written, the stored value is authoritative over any default.
+    assert persist_on_startup_to_runtime_config(False, path) is False
+    assert persist_on_startup_from_runtime_config(path, default=True) is False
+    assert persist_on_startup_to_runtime_config(True, path) is True
+    assert persist_on_startup_from_runtime_config(path, default=False) is True
+    text = path.read_text(encoding="utf-8")
+    assert "[adaptive]" in text
+    assert "target_fps = 72" in text
+    assert "[ui]" in text
+    assert "persist_on_startup = true" in text
 
 
 def test_adaptive_target_fps_persists_to_runtime_config(tmp_path) -> None:

--- a/tests/test_auto_uv_profiles.py
+++ b/tests/test_auto_uv_profiles.py
@@ -598,8 +598,7 @@ def test_profile_list_uses_one_apply_button() -> None:
     assert not hasattr(profile_list, "adaptive_button")
     assert not hasattr(profile_list, "adaptive_checkbox")
     assert not profile_list.daemonize_button.isEnabled()
-    assert "now and at boot" in profile_list.daemonize_button.toolTip()
-    assert not hasattr(profile_list, "boot_checkbox")
+    assert "Apply on startup" in profile_list.daemonize_button.toolTip()
     assert not hasattr(profile_list, "remove_button")
     restore_tooltip = profile_list.restore_defaults_button.toolTip()
     assert "core and memory offsets" in restore_tooltip
@@ -609,7 +608,7 @@ def test_profile_list_uses_one_apply_button() -> None:
     assert profile_list.daemonize_button.isEnabled()
 
 
-def test_profile_list_has_no_separate_boot_toggle() -> None:
+def test_profile_list_boot_toggle_defaults_off_and_survives_reloads() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6")
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -618,8 +617,21 @@ def test_profile_list_has_no_separate_boot_toggle() -> None:
     _ = app
     profile_list = ProfileList(QtCore=QtCore, QtGui=QtGui, QtWidgets=QtWidgets)
 
-    assert not hasattr(profile_list, "boot_checkbox")
-    assert not hasattr(profile_list, "profile_at_boot_enabled")
+    # Opt-in boot persistence: unticked until the config (or a pre-existing
+    # boot entry seeding the one-time default) says otherwise.
+    assert not profile_list.persist_on_startup_enabled()
+
+    # Profile reloads must never flip the user's choice — the config key is
+    # the single source of truth (the old toggle was removed over resync
+    # glitches; this pins the fix).
+    profile_list.set_boot_apply_checked(True)
+    profile_list.set_profiles(
+        [{"profile_id": "profile-a", "final_verified": True}],
+    )
+    assert profile_list.persist_on_startup_enabled()
+    profile_list.set_boot_apply_checked(False)
+    profile_list.set_profiles([])
+    assert not profile_list.persist_on_startup_enabled()
 
 
 def test_adaptive_profile_tier_labels_need_distinct_verified_tiers() -> None:

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -110,6 +110,33 @@ def test_dispatch_cli_rejects_adaptive_systemd_install_with_no_tiers(
     )
 
 
+def test_dispatch_cli_restore_stock_persists_stock_for_boot(monkeypatch) -> None:
+    applied = []
+    monkeypatch.setattr(
+        entry,
+        "apply_runtime_intent",
+        lambda intent, **kwargs: applied.append((intent, kwargs))
+        or {"started": True, "runtime_mode": "stock"},
+    )
+
+    exit_code = entry.dispatch_cli(
+        program_file="/tmp/penguin_burner.py",
+        main_callback=lambda *_args, **_kwargs: None,
+        argv=["--restore-stock"],
+    )
+
+    assert exit_code == 0
+    assert applied == [
+        (
+            {"profile_selector": "__stock__"},
+            {
+                "persist_on_startup": True,
+                "socket_path": entry.DEFAULT_DAEMON_SOCKET,
+            },
+        )
+    ]
+
+
 def test_dispatch_cli_daemonize_applies_through_running_daemon(monkeypatch) -> None:
     applied = []
     monkeypatch.setattr(

--- a/tests/test_runtime_spec.py
+++ b/tests/test_runtime_spec.py
@@ -161,6 +161,44 @@ def test_apply_runtime_intent_uses_daemon_for_apply_and_boot(monkeypatch) -> Non
     assert all(call[2]["socket_path"] == "/tmp/burnerd.sock" for call in calls)
 
 
+def test_apply_runtime_intent_session_only_clears_boot(monkeypatch) -> None:
+    calls = []
+    spec = {"format_version": 1, "mode": "profile"}
+    monkeypatch.setattr(
+        runtime_spec,
+        "build_runtime_spec_from_intent",
+        lambda intent, **kwargs: calls.append(("resolve", intent, kwargs)) or spec,
+    )
+    monkeypatch.setattr(
+        daemon_client,
+        "apply_runtime_spec",
+        lambda payload, **kwargs: calls.append(("apply", payload, kwargs))
+        or {"started": True},
+    )
+    monkeypatch.setattr(
+        daemon_client,
+        "set_boot_runtime_spec",
+        lambda payload, **kwargs: calls.append(("boot", payload, kwargs))
+        or {"saved": True},
+    )
+    monkeypatch.setattr(
+        daemon_client,
+        "clear_boot_runtime_spec",
+        lambda **kwargs: calls.append(("clear-boot", None, kwargs))
+        or {"cleared": True},
+    )
+
+    result = daemon_client.apply_runtime_intent(
+        {"profile_selector": "perf"},
+        persist_on_startup=False,
+        clear_boot=True,
+        socket_path="/tmp/burnerd.sock",
+    )
+
+    assert result == {"started": True}
+    assert [call[0] for call in calls] == ["resolve", "apply", "clear-boot"]
+
+
 def test_adaptive_runtime_keeps_explicit_old_profile_as_initial_tier(monkeypatch) -> None:
     selected = _curve("balanced-old")
     curves = {

--- a/tests/test_ui_commands.py
+++ b/tests/test_ui_commands.py
@@ -349,6 +349,7 @@ def test_flatpak_runtime_profile_daemonize_uses_daemon_client(
         profile_selector="profile-a",
         silent_fan_curve=True,
         gpu_index=0,
+    persist_on_startup=True,
     )
     intent = _runtime_profile_daemon_intent(command)
 
@@ -673,6 +674,7 @@ def test_ui_runtime_command_uses_auto_uv_profile_without_afterburner_flag(
         profile_selector="profile-a",
         silent_fan_curve=True,
         gpu_index=1,
+    persist_on_startup=True,
     )
     intent = _runtime_profile_daemon_intent(command)
 
@@ -689,6 +691,7 @@ def test_ui_runtime_command_adds_adaptive(monkeypatch) -> None:
     command = commands.runtime_profile_command(
         "daemonize",
         adaptive_auto_uv=True,
+    persist_on_startup=True,
     )
 
     assert _runtime_profile_daemon_intent(command)["adaptive_auto_uv"] is True
@@ -702,6 +705,7 @@ def test_ui_adaptive_boot_apply_uses_daemon_without_pkexec(monkeypatch) -> None:
         "daemonize",
         adaptive_auto_uv=True,
         gpu_index=0,
+    persist_on_startup=True,
     )
 
     assert command[1:5] == [
@@ -718,6 +722,25 @@ def test_ui_adaptive_boot_apply_uses_daemon_without_pkexec(monkeypatch) -> None:
         "adaptive_auto_uv": True,
         "gpu_index": 0,
     }
+
+
+def test_session_only_apply_clears_the_boot_profile(monkeypatch) -> None:
+    monkeypatch.setattr(commands.os, "geteuid", lambda: 1000)
+
+    command = commands.runtime_profile_command(
+        "daemonize",
+        profile_selector="perf",
+        gpu_index=0,
+        persist_on_startup=False,
+    )
+
+    assert command[1:5] == [
+        "-m",
+        "runtime.daemon_client",
+        "apply-runtime-intent",
+        "--clear-boot",
+    ]
+    assert "--boot" not in command
 
 
 def test_flatpak_normal_operations_never_request_elevation(
@@ -740,16 +763,19 @@ def test_flatpak_normal_operations_never_request_elevation(
             "daemonize",
             profile_selector="profile-a",
             gpu_index=0,
+        persist_on_startup=True,
         ),
         commands.runtime_profile_command(
             "daemonize",
             adaptive_auto_uv=True,
             gpu_index=0,
+        persist_on_startup=True,
         ),
         commands.runtime_profile_command(
             "daemonize",
             profile_selector="__stock__",
             gpu_index=0,
+        persist_on_startup=True,
         ),
         commands.profile_verify_command(
             profile_selector="profile-a",

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -309,10 +309,13 @@ def test_window_simple_helpers(main_window) -> None:
     win = main_window
     assert win._workflow_running() is False
     win._set_profile_actions_enabled(True)
+    win.profile_list.set_boot_apply_checked(True)
     assert "Autostart: Yes" in win._runtime_action_start_text()
     adaptive_text = win._runtime_action_start_text(adaptive_auto_uv=True)
     assert "adaptive" in adaptive_text.lower()
     assert "Autostart: Yes" in adaptive_text
+    win.profile_list.set_boot_apply_checked(False)
+    assert "Autostart: No" in win._runtime_action_start_text()
     win._load_profiles()
     win.show_about()
 

--- a/tests/test_ui_window_actions.py
+++ b/tests/test_ui_window_actions.py
@@ -263,6 +263,7 @@ def test_apply_selected_profile_with_persistence_stays_on_daemon_path(win) -> No
     )
     window.command_controller = _FakeController()
 
+    window.profile_list.set_boot_apply_checked(True)
     window._run_profiles()
 
     assert captured
@@ -270,6 +271,41 @@ def test_apply_selected_profile_with_persistence_stays_on_daemon_path(win) -> No
     assert args == ("daemonize",)
     assert kwargs["adaptive_auto_uv"] is False
     assert kwargs["profile_selector"] == "perf"
+    assert kwargs["persist_on_startup"] is True
+
+
+def test_apply_without_boot_toggle_is_session_only(win) -> None:
+    window, monkeypatch = win
+    captured: list[tuple[tuple, dict]] = []
+    window.profile_summaries = [
+        {"profile_id": "perf", "final_verified": True, "profile_tier": "Performance"},
+    ]
+    monkeypatch.setattr(window.profile_list, "silent_fan_enabled", lambda: False)
+    monkeypatch.setattr(window.profile_list, "selected_profile_id", lambda: "perf")
+    monkeypatch.setattr(
+        actions_mod,
+        "profile_for_selector",
+        lambda _profiles, _selector: window.profile_summaries[-1],
+    )
+    monkeypatch.setattr(
+        actions_mod,
+        "ensure_daemon_ready_for_privileged_action",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        actions_mod,
+        "runtime_profile_command",
+        lambda *args, **kwargs: captured.append((args, kwargs)) or ["daemon-client"],
+    )
+    window.command_controller = _FakeController()
+
+    window.profile_list.set_boot_apply_checked(False)
+    window._run_profiles()
+
+    assert captured
+    _args, kwargs = captured[0]
+    assert kwargs["persist_on_startup"] is False
+    assert "Autostart: No" in window.controls.status_label.text()
 
 
 def test_restore_defaults_persists_stock_now_and_at_boot(win) -> None:

--- a/tests/test_ui_window_profile_methods.py
+++ b/tests/test_ui_window_profile_methods.py
@@ -198,6 +198,65 @@ def test_delete_selected_profiles(win) -> None:
     window._delete_selected_profiles()
 
 
+def test_delete_running_session_only_profile_restores_stock(win) -> None:
+    # Session-only applies (Apply-on-startup unticked) leave no boot entry, so
+    # deleting the actively running profile must still restore stock instead
+    # of leaving an orphaned curve applied.
+    window, monkeypatch = win
+    window.profile_summaries = [PROFILE]
+    monkeypatch.setattr(window.profile_list, "selected_profile_ids", lambda: ["p1"])
+    monkeypatch.setattr(
+        window.profile_list, "selected_profile_paths", lambda: ["/tmp/p1.json"]
+    )
+    monkeypatch.setattr(
+        actions_mod,
+        "systemd_autostart_profile_info",
+        lambda: {"selector": "", "silent_fan_curve": False, "adaptive_auto_uv": False},
+    )
+    monkeypatch.setattr(actions_mod, "penguin_burner_runtime_is_active", lambda: True)
+    monkeypatch.setattr(
+        actions_mod,
+        "running_auto_uv_profile_info",
+        lambda: {"selector": "p1", "silent_fan_curve": False, "adaptive_auto_uv": False},
+    )
+    confirmations: list[dict] = []
+    monkeypatch.setattr(
+        MainWindow,
+        "_confirm_profile_delete",
+        lambda self, **kwargs: confirmations.append(kwargs) or False,
+    )
+
+    window._delete_selected_profiles()
+
+    assert confirmations and confirmations[0]["restore_stock"] is True
+
+
+def test_unticking_boot_apply_clears_saved_boot_profile(win, monkeypatch) -> None:
+    import runtime.daemon_client as daemon_client_mod
+
+    window, _mp = win
+    cleared: list[bool] = []
+    saved: list[bool] = []
+    monkeypatch.setattr(
+        window_mod, "persist_on_startup_to_runtime_config", lambda v: saved.append(bool(v))
+    )
+    monkeypatch.setattr(
+        daemon_client_mod, "clear_boot_runtime_spec", lambda **_k: cleared.append(True)
+    )
+
+    window.profile_list.set_boot_apply_checked(True)  # blocked signals: no side effects
+    assert cleared == [] and saved == []
+
+    window.profile_list.boot_apply_checkbox.setChecked(False)
+    assert saved == [False]
+    assert cleared == [True]
+
+    # Ticking arms boot persistence for the next Apply but clears nothing.
+    window.profile_list.boot_apply_checkbox.setChecked(True)
+    assert saved == [False, True]
+    assert cleared == [True]
+
+
 def test_delete_boot_profile_falls_back_to_persisted_stock(win) -> None:
     window, monkeypatch = win
     restored: list[bool] = []

--- a/ui/commands.py
+++ b/ui/commands.py
@@ -364,10 +364,13 @@ def runtime_profile_command(
     silent_fan_curve: bool = False,
     adaptive_auto_uv: bool = False,
     gpu_index: int | None = None,
+    persist_on_startup: bool,
 ) -> list[str]:
-    # Apply always targets the already-root daemon and always persists the
-    # runtime for boot (a standing action is complete: Apply persists the
-    # selected profile, Restore defaults persists the stock runtime).
+    # Apply always targets the already-root daemon. Boot persistence follows
+    # the user's "Apply on startup" toggle: on, the applied runtime is saved
+    # as the boot profile; off, the apply is session-only and any saved boot
+    # profile is cleared so boot state always matches the visible toggle.
+    # Restore defaults keeps persisting the stock runtime for boot.
     if action != "daemonize":
         raise ValueError(f"unknown runtime profile action: {action}")
     intent = {
@@ -381,7 +384,7 @@ def runtime_profile_command(
         "-m",
         "runtime.daemon_client",
         "apply-runtime-intent",
-        "--boot",
+        "--boot" if persist_on_startup else "--clear-boot",
         json.dumps(intent, separators=(",", ":")),
     ]
 

--- a/ui/components/profile_list.py
+++ b/ui/components/profile_list.py
@@ -63,9 +63,16 @@ class ProfileList:
 
         top = QtWidgets.QHBoxLayout()
         self.silent_fan_checkbox = QtWidgets.QCheckBox("Silent fan curve")
+        self.boot_apply_checkbox = QtWidgets.QCheckBox("Apply on startup")
+        self.boot_apply_checkbox.setToolTip(
+            "When ticked, Apply also saves the profile as the boot profile. "
+            "Unticking clears any saved boot profile immediately, and Apply "
+            "then changes this session only, so the GPU starts at stock."
+        )
         self.daemonize_button = QtWidgets.QPushButton("Apply")
         self.daemonize_button.setToolTip(
-            "Apply the single selected profile now and at boot."
+            "Apply the single selected profile now. \"Apply on startup\" "
+            "controls whether it also becomes the boot profile."
         )
         self.delete_button = QtWidgets.QToolButton()
         self.delete_button.setObjectName("deleteProfilesButton")
@@ -82,6 +89,7 @@ class ProfileList:
         top.addWidget(QtWidgets.QLabel("Stored undervolt profiles"))
         top.addStretch(1)
         top.addWidget(self.silent_fan_checkbox)
+        top.addWidget(self.boot_apply_checkbox)
         top.addWidget(self.daemonize_button)
         top.addWidget(self.delete_button)
         top.addWidget(self.restore_defaults_button)
@@ -119,10 +127,10 @@ class ProfileList:
         layout.addLayout(top)
         layout.addWidget(self.table, 1)
         adaptive_note = QtWidgets.QLabel(
-            "Apply saves the selected profile for boot. Restore defaults "
-            "makes stock the current and boot state. Per-game "
-            "adaptive profiles with a target pre-frame-gen FPS are managed "
-            "in the Steam tab."
+            "Apply changes the current session; tick \"Apply on startup\" to "
+            "also save the profile for boot. Restore defaults makes stock "
+            "the current and boot state. Per-game adaptive profiles with a "
+            "target pre-frame-gen FPS are managed in the Steam tab."
         )
         adaptive_note.setObjectName("profilesAdaptiveNote")
         adaptive_note.setWordWrap(True)
@@ -439,6 +447,7 @@ class ProfileList:
             and all(self._row_is_deletable(row) for row in selected_rows)
         )
         self.daemonize_button.setEnabled(has_apply_selection)
+        self.boot_apply_checkbox.setEnabled(self._runtime_actions_available)
         self.delete_button.setEnabled(has_delete_selection)
         self.restore_defaults_button.setEnabled(self._runtime_actions_available)
 
@@ -448,6 +457,23 @@ class ProfileList:
             self.silent_fan_checkbox.setChecked(bool(checked))
         finally:
             self.silent_fan_checkbox.blockSignals(signals_blocked)
+
+    def persist_on_startup_enabled(self) -> bool:
+        return bool(self.boot_apply_checkbox.isChecked())
+
+    def set_boot_apply_checked(self, checked: bool) -> None:
+        """One-time init from the persisted config; never called on reloads.
+
+        The home-dir config key is the single source of truth for this
+        toggle. `set_profiles` deliberately leaves it alone so list reloads
+        can never flip the user's choice (the old Persist-on-Startup toggle
+        was removed over exactly that class of resync glitch).
+        """
+        signals_blocked = self.boot_apply_checkbox.blockSignals(True)
+        try:
+            self.boot_apply_checkbox.setChecked(bool(checked))
+        finally:
+            self.boot_apply_checkbox.blockSignals(signals_blocked)
 
     def _selected_rows(self) -> list[int]:
         selection_model = self.table.selectionModel()

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -32,8 +32,10 @@ from ui.features.profiles.profiles import adaptive_profile_tier_labels
 from ui.features.profiles.profiles import delete_confirmation_text
 from ui.features.profiles.profiles import profile_can_apply
 from ui.features.profiles.profiles import profile_can_verify
+from ui.features.profiles.profiles import penguin_burner_runtime_is_active
 from ui.features.profiles.profiles import profile_delete_autostart_action
 from ui.features.profiles.profiles import profile_for_selector
+from ui.features.profiles.profiles import running_auto_uv_profile_info
 from ui.features.profiles.profiles import profile_is_deletable
 from ui.features.profiles.profiles import profile_status_label
 from ui.features.profiles.profiles import profile_verify_selector
@@ -106,14 +108,18 @@ class ProfileActionsMixin:
             ),
         ):
             return
-        # A standing action is always complete: Apply persists the selected
-        # profile for boot, while Restore defaults persists the stock runtime.
+        # Boot persistence follows the "Apply on startup" toggle: ticked saves
+        # the applied profile for boot, unticked applies session-only and
+        # clears any saved boot profile. Restore defaults still persists the
+        # stock runtime.
+        persist_on_startup = self.profile_list.persist_on_startup_enabled()
         command = runtime_profile_command(
             action,
             profile_selector=profile_id,
             silent_fan_curve=self.profile_list.silent_fan_enabled(),
             adaptive_auto_uv=adaptive_auto_uv,
             gpu_index=self.gpu_index,
+            persist_on_startup=persist_on_startup,
         )
         self._persist_silent_fan_preference(self.profile_list.silent_fan_enabled())
         # A profile is now in effect, so the GPU is no longer at stock.
@@ -148,6 +154,9 @@ class ProfileActionsMixin:
             profile_selector=STOCK_PROFILE_SELECTOR,
             silent_fan_curve=self.profile_list.silent_fan_enabled(),
             gpu_index=self.gpu_index,
+            # Stock is the safe state: restoring persists it for boot
+            # regardless of the Apply-on-startup toggle.
+            persist_on_startup=True,
         )
         self.controls.set_status_text(
             "Restoring GPU to stock now and at boot (daemon keeps running)."
@@ -345,11 +354,28 @@ class ProfileActionsMixin:
             list(selected_ids),
             autostart_info,
         )
-        restore_stock = autostart_action.get("action") == "restore-stock"
+        # Session-only applies (Apply-on-startup unticked) leave no boot
+        # entry, so also check the actively running profile — deleting it
+        # must restore stock instead of leaving an orphaned curve applied.
+        running_action = {"action": "keep"}
+        if penguin_burner_runtime_is_active():
+            running_action = profile_delete_autostart_action(
+                self.profile_summaries,
+                list(selected_ids),
+                running_auto_uv_profile_info(),
+            )
+        restore_stock = "restore-stock" in (
+            autostart_action.get("action"),
+            running_action.get("action"),
+        )
         if not self._confirm_profile_delete(
             restore_stock=restore_stock,
             removes_last_usable_adaptive_profile=(
-                autostart_action.get("reason") == "last-usable-adaptive-profile"
+                "last-usable-adaptive-profile"
+                in (
+                    autostart_action.get("reason"),
+                    running_action.get("reason"),
+                )
             ),
         ):
             return
@@ -533,11 +559,11 @@ class ProfileActionsMixin:
         return profile_for_selector(self.profile_summaries, profile_id)
 
     def _runtime_action_start_text(self, *, adaptive_auto_uv: bool = False) -> str:
-        # Every apply persists the runtime for boot.
+        autostart = "Yes" if self.profile_list.persist_on_startup_enabled() else "No"
         if adaptive_auto_uv:
-            return "Starting adaptive Auto-UV; Autostart: Yes."
+            return f"Starting adaptive Auto-UV; Autostart: {autostart}."
         selected = self.profile_list.selected_profile_name() or "none"
-        return f"Starting profile: {selected}; Autostart: Yes."
+        return f"Starting profile: {selected}; Autostart: {autostart}."
 
 
 def _manual_curve_control_voltage_mvs(manual_edit) -> tuple[int, ...]:

--- a/ui/window.py
+++ b/ui/window.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import shlex
 
 from cli.runtime_config_file import (
+    persist_on_startup_from_runtime_config,
+    persist_on_startup_to_runtime_config,
     silent_fan_curve_from_runtime_config,
     silent_fan_curve_to_runtime_config,
 )
@@ -254,6 +256,10 @@ class MainWindow(ProfileActionsMixin):
         self.profile_list.delete_button.clicked.connect(self._delete_selected_profiles)
         self.profile_list.silent_fan_checkbox.toggled.connect(
             self._persist_silent_fan_preference
+        )
+        self._boot_apply_toggle_initialized = False
+        self.profile_list.boot_apply_checkbox.toggled.connect(
+            self._persist_boot_apply_preference
         )
         self.profile_list.restore_defaults_button.clicked.connect(
             self._restore_gpu_defaults
@@ -638,7 +644,8 @@ class MainWindow(ProfileActionsMixin):
         # the boot/autostart profile, so the UI must not apply a second fallback.
         self._load_profiles()
         if apply_final_profile:
-            # Apply the freshly verified profile now and save it for boot.
+            # Apply the freshly verified profile now (and for boot when the
+            # "Apply on startup" toggle is ticked).
             # Deferred one event-loop turn so the scan controller has fully
             # released before the apply command starts. One static preset:
             # adaptivity is a per-game (Steam tab) choice, not a standing one.
@@ -684,6 +691,17 @@ class MainWindow(ProfileActionsMixin):
     def _load_profiles(self) -> None:
         self.profile_summaries = load_profile_summaries()
         autostart_info = systemd_autostart_profile_info()
+        if not self._boot_apply_toggle_initialized:
+            self._boot_apply_toggle_initialized = True
+            # One-time init: the persisted config value is authoritative. Only
+            # when the key has never been written does an existing boot entry
+            # seed the default, so 0.7.4 upgrades keep their boot profile
+            # until the user unticks the toggle. Reloads never touch the box.
+            self.profile_list.set_boot_apply_checked(
+                persist_on_startup_from_runtime_config(
+                    default=bool(autostart_info["selector"])
+                )
+            )
         running_info = (
             running_auto_uv_profile_info()
             if penguin_burner_runtime_is_active()
@@ -794,6 +812,25 @@ class MainWindow(ProfileActionsMixin):
         # Remember the silent-fan choice durably so the "latest profile setup"
         # restores it after an aborted Auto-UV run, profile reload, or restart.
         silent_fan_curve_to_runtime_config(bool(checked))
+
+    def _persist_boot_apply_preference(self, checked: bool) -> None:
+        # Every click lands in the home-dir config immediately: the key is the
+        # single source of truth for the toggle, survives reinstalls, and no
+        # reload path resyncs the checkbox against runtime state.
+        persist_on_startup_to_runtime_config(bool(checked))
+        if not checked:
+            # Unticking means "nothing applies at boot": clear any saved boot
+            # profile right away so the toggle and the real boot state cannot
+            # diverge while the user never clicks Apply again. Best-effort —
+            # the startup seed uses blocked signals and never lands here.
+            from runtime.daemon_client import clear_boot_runtime_spec
+
+            try:
+                clear_boot_runtime_spec()
+            except Exception as exc:
+                self.log_view.append(
+                    f"\nCould not clear the saved boot profile: {exc}\n"
+                )
 
     def _workflow_running(self) -> bool:
         return (


### PR DESCRIPTION
## What changed

**Mobile GPU fixes (Rust daemon)**
- Stock reset tolerates a rejected power-limit setter (fixed-limit mobile boards) — un-breaks Auto-UV startup, Reset to defaults, and the stock fallback on exactly the laptop class 0.6.6 targeted. A readback mismatch after a *successful* setter stays fatal.
- Engine start tolerates an unsupported `nvmlDeviceGetNumFans` when fan control is disabled, so undervolt-only/stock profiles run on EC-cooled laptop dGPUs.

**Opt-in boot persistence**
- Apply is session-only by default; the Profiles tab regains an "Apply on startup" toggle. Config key `[ui] persist_on_startup` in the home dir is the single source of truth: written on every click, never resynced by reloads (the old toggle's desync class is structurally gone and pinned by a test). Unticking clears the saved boot profile immediately. Existing boot entries seed the one-time default so 0.7.4 upgrades keep their behavior.
- Deleting the actively running session-only profile restores stock instead of leaving an orphaned curve applied.

**Recovery**
- `penguin-burner-cli --restore-stock`: headless stock-now-and-at-boot recovery; standalone-only (refuses flag combos), actionable guidance when the daemon is down, survives a corrupt config. Config reads are tolerant on read-only paths and strict on read-modify-write paths, so a corrupt TOML is never silently clobbered.

**Steam tab**
- Runtime shown near the title (Proton vs Native Linux; the exact tool version lives only in the selector), compatibility selector grayed for confirmed-native games, effective runtime resolved live from Steam (includes the Codex commit 6ebc93d).

**Docs**
- pipx guidance for PEP 668 distros (`pip install --user` fails on Fedora 38+/Ubuntu 23.04+/Debian 12+), flatpak first-run relaunch note, recovery section (rescue mode leads with `systemctl disable --now`).

## Why
Pre-release audit ahead of the wide public release found the mobile regressions (Rust daemon had no mobile gating), the boot crash-loop exposure (no escape hatch, no recovery docs), and the PEP 668 first-contact install failure.

## Checks
- Full pytest suite: 1689 passed; cargo test: 227 passed; `scripts/check-feature-static-analysis.sh` clean; `git diff --check` clean.
- 8-angle code review with adversarial verification; all confirmed findings fixed (incl. corrupt-config clobber, delete-flow orphan, readback over-reach).
- Live validation on real hardware (RTX 5080, daemon 0.7.4): GUI toggle flows against the running daemon (tick/untick/boot-spec round trips), `--restore-stock` happy/error paths, Q2RTX workload pass, real 37-game Steam library sweep (4 native games gray out correctly).
- Not live-tested: actual mobile GPU hardware (covered by Rust unit tests with NOT_SUPPORTED injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)