### PR TITLE
Skip fixed power limits for mobile GPU profiles

### DIFF
--- a/auto_uv/gpu/gpu_vf_curve_applier.py
+++ b/auto_uv/gpu/gpu_vf_curve_applier.py
@@ -83,7 +83,8 @@ class LiveGpuVfCurveApplier:
         if requested_w is None:
             return self.power_limit_w
         if fixed_power_limit_excluded_by_identity(
-            gpu_name=self.translated_gpu_policy.get("gpu_name")
+            gpu_name=self.translated_gpu_policy.get("gpu_name"),
+            pci_device_id=self.translated_gpu_policy.get("pci_device_id"),
         ):
             self.requested_power_limit_w = None
             self.translated_gpu_policy.pop("power_limit_w", None)
@@ -153,8 +154,10 @@ def open_live_gpu_vf_curve_applier(
     assert_zero_runtime_vf_offsets(gpu)
 
     gpu_name = runtime_reset.get("gpu_name")
+    pci_device_id = runtime_reset.get("pci_device_id")
     fixed_power_limit_excluded = fixed_power_limit_excluded_by_identity(
-        gpu_name=gpu_name
+        gpu_name=gpu_name,
+        pci_device_id=pci_device_id,
     )
     baseline_power_limit_w = (
         _positive_power_limit_w(runtime_reset.get("power_limit_w"))
@@ -170,6 +173,8 @@ def open_live_gpu_vf_curve_applier(
         reset_power_limits.get("power_limit_max_w")
     )
     translated_gpu_policy = {"gpu_name": gpu_name}
+    if pci_device_id:
+        translated_gpu_policy["pci_device_id"] = pci_device_id
     if baseline_power_limit_w is not None:
         translated_gpu_policy["power_limit_w"] = baseline_power_limit_w
     requested_power_limit_w = _auto_uv_power_limit_w(runtime_options)

--- a/auto_uv/gpu/gpu_vf_curve_applier.py
+++ b/auto_uv/gpu/gpu_vf_curve_applier.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, cast
 
 from drivers.nvidia.daemon_gpu import DaemonGpuClient
+from drivers.nvidia.nvml_gpu_policy import fixed_power_limit_excluded_by_identity
 from runtime.support.vf_curve_plan import apply_plan
 from runtime.support.nvidia_runtime_defaults import reset_nvidia_runtime_defaults
 
@@ -81,6 +82,16 @@ class LiveGpuVfCurveApplier:
         requested_w = _positive_power_limit_w(self.requested_power_limit_w)
         if requested_w is None:
             return self.power_limit_w
+        if fixed_power_limit_excluded_by_identity(
+            gpu_name=self.translated_gpu_policy.get("gpu_name")
+        ):
+            self.requested_power_limit_w = None
+            self.translated_gpu_policy.pop("power_limit_w", None)
+            log(
+                "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+                "continuing without saved power limit"
+            )
+            return None
         requested_w = self.clamp_power_limit_w(int(requested_w))
         if self.power_limit_w == requested_w:
             self.requested_power_limit_w = None
@@ -141,7 +152,15 @@ def open_live_gpu_vf_curve_applier(
     gpu.refresh_points()
     assert_zero_runtime_vf_offsets(gpu)
 
-    baseline_power_limit_w = _positive_power_limit_w(runtime_reset.get("power_limit_w"))
+    gpu_name = runtime_reset.get("gpu_name")
+    fixed_power_limit_excluded = fixed_power_limit_excluded_by_identity(
+        gpu_name=gpu_name
+    )
+    baseline_power_limit_w = (
+        _positive_power_limit_w(runtime_reset.get("power_limit_w"))
+        if not fixed_power_limit_excluded
+        else None
+    )
     reset_power_limits = runtime_reset.get("power_limits")
     reset_power_limits = reset_power_limits if isinstance(reset_power_limits, dict) else {}
     min_power_limit_w = _positive_power_limit_w(
@@ -150,12 +169,17 @@ def open_live_gpu_vf_curve_applier(
     max_power_limit_w = _positive_power_limit_w(
         reset_power_limits.get("power_limit_max_w")
     )
-    translated_gpu_policy = {
-        "gpu_name": runtime_reset.get("gpu_name"),
-        "power_limit_w": baseline_power_limit_w,
-    }
+    translated_gpu_policy = {"gpu_name": gpu_name}
+    if baseline_power_limit_w is not None:
+        translated_gpu_policy["power_limit_w"] = baseline_power_limit_w
     requested_power_limit_w = _auto_uv_power_limit_w(runtime_options)
-    if requested_power_limit_w is not None and (
+    if requested_power_limit_w is not None and fixed_power_limit_excluded:
+        log(
+            "Auto-UV power limit: skipped requested fixed write on mobile GPU; "
+            "continuing without saved power limit"
+        )
+        requested_power_limit_w = None
+    elif requested_power_limit_w is not None and (
         baseline_power_limit_w is None
         or int(requested_power_limit_w) >= int(baseline_power_limit_w)
     ):

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -606,6 +606,7 @@ fn execute(backend: &dyn GpuBackend, write: GpuWrite) -> Result<Value, String> {
             Ok(json!({
                 "reset": true,
                 "gpu_name": identity.name,
+                "pci_device_id": identity.pci_device_id,
                 "power_limits": power_limits_json(power_limits),
                 "clock_offsets_mhz": {
                     "gpc": clock_offsets.gpc_clk_vf_offset_mhz,
@@ -1012,6 +1013,7 @@ mod tests {
 
         assert_eq!(result["reset"], true);
         assert_eq!(result["gpu_name"], "Mock RTX");
+        assert_eq!(result["pci_device_id"], "0x123410DE");
         assert_eq!(result["power_limits"]["power_limit_default_w"], 360);
         assert_eq!(result["points"][0]["index"], 12);
         assert_eq!(

--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -621,7 +621,7 @@ impl AdaptiveAutoUvRuntimeController {
         log: &mut dyn FnMut(&str),
     ) -> Result<AdaptiveSwitchResult, String> {
         let label = profile_tier_label(tier);
-        let (_power, memory) = apply_adaptive_curve(backend, curve, ceiling, &label)?;
+        let (_power, memory) = apply_adaptive_curve(backend, curve, ceiling, &label, log)?;
         publisher.profile_tier = curve.profile_tier.clone();
         publisher.profile_tier_key = if curve.profile_tier_key.is_empty() {
             tier.to_string()

--- a/burnerd/src/profile/apply.rs
+++ b/burnerd/src/profile/apply.rs
@@ -118,29 +118,29 @@ pub(super) fn reset_gpu_to_stock(
         )),
         Err(exc) => failures.push(format!("clock offsets: {exc}")),
     }
-    // Best-effort: mobile boards expose a readable default limit while
-    // rejecting the manual setter, and a rejected setter also means the limit
-    // was never moved off its default. A failure here must not fail the
-    // reset, or Auto-UV startup and the stock fallback break on that hardware.
-    let default_w = backend.query_power_limits().power_limit_default_w;
-    if let Some(default_w) = default_w {
-        if default_w != 0 {
-            if let Err(exc) = backend.apply_power_limit_w(default_w) {
-                log(&format!(
-                    "keep-stock: default power limit restore skipped: {exc}"
-                ));
-            } else {
-                // The setter succeeded, so this is not the fixed-limit mobile
-                // case: a readback that still shows a tuned limit is a real
-                // incomplete reset and stays fatal.
-                let readback = backend.query_power_limits();
-                if readback.power_limit_w != Some(default_w)
-                    && readback.enforced_power_limit_w != Some(default_w)
-                {
-                    failures.push(format!(
-                        "power limit readback: current={:?} enforced={:?} expected={default_w}",
-                        readback.power_limit_w, readback.enforced_power_limit_w
+    if fixed_power_limit_excluded(backend) {
+        log("keep-stock: fixed power limit restore skipped on mobile GPU; power is platform-managed");
+    } else {
+        // Unknown mobile identities can still reject the setter. A rejected
+        // restore means the fixed limit was not moved, so keep reset best-effort
+        // rather than blocking Auto-UV startup or the stock fallback.
+        let default_w = backend.query_power_limits().power_limit_default_w;
+        if let Some(default_w) = default_w {
+            if default_w != 0 {
+                if let Err(exc) = backend.apply_power_limit_w(default_w) {
+                    log(&format!(
+                        "keep-stock: default power limit restore skipped: {exc}"
                     ));
+                } else {
+                    let readback = backend.query_power_limits();
+                    if readback.power_limit_w != Some(default_w)
+                        && readback.enforced_power_limit_w != Some(default_w)
+                    {
+                        failures.push(format!(
+                            "power limit readback: current={:?} enforced={:?} expected={default_w}",
+                            readback.power_limit_w, readback.enforced_power_limit_w
+                        ));
+                    }
                 }
             }
         }
@@ -538,11 +538,10 @@ mod tests {
         );
     }
 
-    /// Mobile boards expose a readable default power limit while rejecting the
-    /// manual setter; the stock reset must still succeed and zero the V/F
-    /// curve, or Auto-UV startup and the stock fallback break on laptops.
+    /// An unrecognized mobile board can still reject the manual setter; the
+    /// stock reset must remain tolerant and zero the V/F curve.
     #[test]
-    fn stock_reset_tolerates_rejected_power_limit_setter() {
+    fn stock_reset_tolerates_rejected_power_limit_setter_for_unknown_identity() {
         let mut mock = MockGpu::new();
         mock.vf_available = true;
         mock.power_limits.power_limit_default_w = Some(115);
@@ -579,6 +578,45 @@ mod tests {
                 .any(|msg| msg.contains("default power limit restore skipped")),
             "the skipped power limit restore must be logged: {messages:?}"
         );
+    }
+
+    #[test]
+    fn stock_reset_never_writes_fixed_power_limit_on_mobile() {
+        let mut mock = MockGpu::new();
+        mock.identity.name = "NVIDIA GeForce RTX 4090 Laptop GPU".to_string();
+        mock.vf_available = true;
+        mock.power_limits.power_limit_default_w = Some(150);
+        mock.power_limits.power_limit_w = Some(150);
+        mock.vf_points = vec![crate::gpu::VfPoint {
+            index: 5,
+            type_: 0,
+            voltage_based: 1,
+            ..Default::default()
+        }];
+        mock.inject_failure(
+            "apply_power_limit_w",
+            crate::gpu::GpuError::nvml_with_text(
+                "nvmlDeviceSetPowerManagementLimit",
+                3,
+                "Not Supported",
+            ),
+        );
+        let mut messages = Vec::new();
+        let mut log = |message: &str| messages.push(message.to_string());
+
+        let result =
+            configure_runtime_spec_policy(&mock, true, RuntimeMode::Stock, None, &mut log).unwrap();
+
+        assert_eq!(result.active_vf_curve_source.as_deref(), Some("stock"));
+        assert!(!mock
+            .recorded()
+            .iter()
+            .any(|operation| matches!(operation, MockOp::ApplyPowerLimit { .. })));
+        assert!(mock.recorded().contains(&MockOp::ApplyVfOffsets {
+            offsets: vec![(5, 0)]
+        }));
+        assert!(messages.iter().any(|message| message
+            == "keep-stock: fixed power limit restore skipped on mobile GPU; power is platform-managed"));
     }
 
     #[test]

--- a/burnerd/src/profile/apply.rs
+++ b/burnerd/src/profile/apply.rs
@@ -20,6 +20,15 @@ use super::ceiling::FlattenedClockCeilingController;
 use super::guard::select_expected_vf_samples;
 use super::runtime_spec::{LoadedCurve, PlanItem, RuntimeMode};
 
+const FIXED_POWER_LIMIT_MOBILE_NAME_TOKENS: &[&str] =
+    &["laptop", "mobile", "notebook", "max-q", "max q"];
+const FIXED_POWER_LIMIT_MOBILE_PCI_DEVICE_IDS: &[&str] = &[
+    // Blackwell notebook IDs from NVIDIA supported-chip tables. Keep this in
+    // sync with drivers/nvidia/nvml_gpu_policy.py.
+    "2BB4", "2C18", "2C19", "2C38", "2C39", "2C58", "2C59", "2D18", "2D19", "2D39", "2D58", "2D59",
+    "2DB8", "2DB9", "2F18", "2F38", "2F58",
+];
+
 /// `apply_plan`: MHz→kHz ×1000, then a single `SetControl` write. The engine
 /// does the ×1000 here (coordinator answer, matches Python `apply_plan`).
 pub fn apply_plan(backend: &dyn GpuBackend, plan: &[PlanItem]) -> crate::gpu::GpuResult<()> {
@@ -175,10 +184,17 @@ fn apply_power_limit(
     backend: &dyn GpuBackend,
     label: &str,
     power_limit_w: Option<i64>,
+    log: &mut dyn FnMut(&str),
 ) -> Result<Option<i64>, String> {
     let Some(power) = power_limit_w.filter(|&p| p > 0) else {
         return Ok(None);
     };
+    if fixed_power_limit_excluded(backend) {
+        log(&format!(
+            "Skipped saved profile fixed power limit {power} W for {label}: mobile GPU power is platform-managed"
+        ));
+        return Ok(None);
+    }
     let applied = backend.apply_power_limit_w(power).map_err(|exc| {
         format!(
             "failed to apply saved profile power limit {power} W for {label}: driver rejected nvmlDeviceSetPowerManagementLimit: {exc}"
@@ -350,7 +366,7 @@ fn apply_auto_uv_final_curve<'a>(
         curve.plan.len()
     ));
 
-    let power = apply_power_limit(backend, "auto-UV final curve", curve.power_limit_w)?;
+    let power = apply_power_limit(backend, "auto-UV final curve", curve.power_limit_w, log)?;
     if let Some(w) = power {
         log(&format!("Applied auto-UV profile power limit: {w}W."));
     }
@@ -387,17 +403,74 @@ pub fn apply_adaptive_curve(
     curve: &LoadedCurve,
     ceiling: &mut Option<FlattenedClockCeilingController<'_>>,
     tier_label: &str,
+    log: &mut dyn FnMut(&str),
 ) -> Result<(Option<i64>, Option<i64>), String> {
     let label = format!("adaptive {tier_label} profile");
     let memory =
         apply_memory_offset_then_vf_plan(backend, &label, curve.memory_offset_mhz, &curve.plan)?;
-    let power = apply_power_limit(backend, &label, curve.power_limit_w)?;
+    let power = apply_power_limit(backend, &label, curve.power_limit_w, log)?;
     if let Some(controller) = ceiling {
         controller
             .retarget(curve.flatten_target.clone())
             .map_err(|e| e.to_string())?;
     }
     Ok((power, memory))
+}
+
+fn fixed_power_limit_excluded(backend: &dyn GpuBackend) -> bool {
+    let identity = backend.identity();
+    fixed_power_limit_excluded_by_identity(&identity.name, &identity.pci_device_id)
+}
+
+fn fixed_power_limit_excluded_by_identity(gpu_name: &str, pci_device_id: &str) -> bool {
+    let name = gpu_name.to_ascii_lowercase();
+    if FIXED_POWER_LIMIT_MOBILE_NAME_TOKENS
+        .iter()
+        .any(|token| name.contains(token))
+    {
+        return true;
+    }
+    let normalized = normalize_pci_device_id(pci_device_id);
+    FIXED_POWER_LIMIT_MOBILE_PCI_DEVICE_IDS.contains(&normalized.as_str())
+}
+
+fn normalize_pci_device_id(value: &str) -> String {
+    let text = value
+        .trim()
+        .to_ascii_uppercase()
+        .replace("0X", "")
+        .replace(':', " ")
+        .replace('-', " ")
+        .replace('_', " ");
+    let parts: Vec<String> = text
+        .split_whitespace()
+        .map(|part| {
+            part.chars()
+                .filter(|ch| ch.is_ascii_hexdigit())
+                .collect::<String>()
+        })
+        .filter(|part| !part.is_empty())
+        .collect();
+    if parts.len() >= 2 && parts[0] == "10DE" {
+        return last_four_hex_digits(&parts[1]);
+    }
+    let token = parts.first().map(String::as_str).unwrap_or("");
+    if token.len() >= 8 && token.ends_with("10DE") {
+        return token[..4].to_string();
+    }
+    if token.len() >= 8 && token.starts_with("10DE") {
+        return token[4..8].to_string();
+    }
+    last_four_hex_digits(token)
+}
+
+fn last_four_hex_digits(value: &str) -> String {
+    let suffix = if value.len() > 4 {
+        &value[value.len() - 4..]
+    } else {
+        value
+    };
+    format!("{suffix:0>4}")
 }
 
 #[cfg(test)]
@@ -519,11 +592,53 @@ mod tests {
                 "Not Supported",
             ),
         );
-        let err = apply_power_limit(&mock, "auto-UV final curve", Some(320)).unwrap_err();
+        let mut log = |_: &str| {};
+        let err = apply_power_limit(&mock, "auto-UV final curve", Some(320), &mut log).unwrap_err();
         assert_eq!(
             err,
             "failed to apply saved profile power limit 320 W for auto-UV final curve: driver rejected nvmlDeviceSetPowerManagementLimit: nvmlDeviceSetPowerManagementLimit failed with NVML error 3: Not Supported"
         );
+    }
+
+    #[test]
+    fn pre_upgrade_static_power_limit_is_ignored_on_mobile() {
+        let mut mock = MockGpu::new();
+        mock.identity.name = "NVIDIA GeForce RTX 4090 Laptop GPU".to_string();
+        mock.inject_failure(
+            "apply_power_limit_w",
+            crate::gpu::GpuError::nvml_with_text(
+                "nvmlDeviceSetPowerManagementLimit",
+                3,
+                "Not Supported",
+            ),
+        );
+        let mut messages = Vec::new();
+        let mut log = |message: &str| messages.push(message.to_string());
+
+        let applied = apply_power_limit(&mock, "auto-UV final curve", Some(150), &mut log).unwrap();
+
+        assert_eq!(applied, None);
+        assert!(mock.recorded().is_empty());
+        assert_eq!(
+            messages,
+            ["Skipped saved profile fixed power limit 150 W for auto-UV final curve: mobile GPU power is platform-managed"]
+        );
+    }
+
+    #[test]
+    fn mobile_power_limit_identity_matches_name_or_pci_device_id() {
+        assert!(fixed_power_limit_excluded_by_identity(
+            "NVIDIA GeForce RTX 4090 Laptop GPU",
+            "0x271710DE"
+        ));
+        assert!(fixed_power_limit_excluded_by_identity(
+            "NVIDIA GeForce RTX 5090",
+            "0x2C1810DE"
+        ));
+        assert!(!fixed_power_limit_excluded_by_identity(
+            "NVIDIA GeForce RTX 5090",
+            "0x2B8510DE"
+        ));
     }
 
     #[test]
@@ -585,8 +700,9 @@ mod tests {
         };
 
         let mut ceiling = None;
+        let mut log = |_: &str| {};
         let (power, memory) =
-            apply_adaptive_curve(&mock, &curve, &mut ceiling, "balanced").unwrap();
+            apply_adaptive_curve(&mock, &curve, &mut ceiling, "balanced", &mut log).unwrap();
         assert_eq!(power, Some(320));
         assert_eq!(memory, Some(1500));
         // Exact op order: mem offset → VF plan → power limit (no ceiling here).
@@ -602,6 +718,61 @@ mod tests {
                 },
                 MockOp::ApplyPowerLimit { power_limit_w: 320 },
             ]
+        );
+    }
+
+    #[test]
+    fn pre_upgrade_adaptive_power_limit_is_ignored_on_mobile() {
+        use super::super::runtime_spec::FlattenTarget;
+
+        let mut mock = MockGpu::new();
+        mock.identity.pci_device_id = "0x2C1810DE".to_string();
+        mock.mem_offset_range = Some((-2000, 6000));
+        mock.vf_points = vec![crate::gpu::VfPoint {
+            index: 12,
+            type_: 0,
+            voltage_based: 1,
+            current_offset_khz: 240_000,
+            ..Default::default()
+        }];
+        let curve = LoadedCurve {
+            path: std::path::PathBuf::new(),
+            profile_id: "legacy-adaptive-mobile".to_string(),
+            profile_tier: "Balanced".to_string(),
+            profile_tier_key: "balanced".to_string(),
+            plan: vec![item(12, 240)],
+            lock_clock_mhz: 2640,
+            candidate_voltage_mv: 875,
+            memory_offset_mhz: Some(1500),
+            power_limit_w: Some(150),
+            avg_power_w: None,
+            base_avg_power_w: None,
+            flatten_target: FlattenTarget {
+                source: "auto-uv-final".to_string(),
+                lock_clock_mhz: 2640,
+                lock_voltage_mv: Some(875),
+                end_voltage_mv: Some(875),
+                tail_point_count: Some(1),
+                ceiling_clock_mhz: None,
+                tail_rise_bins: None,
+            },
+        };
+        let mut ceiling = None;
+        let mut messages = Vec::new();
+        let mut log = |message: &str| messages.push(message.to_string());
+
+        let (power, memory) =
+            apply_adaptive_curve(&mock, &curve, &mut ceiling, "balanced", &mut log).unwrap();
+
+        assert_eq!(power, None);
+        assert_eq!(memory, Some(1500));
+        assert!(!mock
+            .recorded()
+            .iter()
+            .any(|operation| matches!(operation, MockOp::ApplyPowerLimit { .. })));
+        assert_eq!(
+            messages,
+            ["Skipped saved profile fixed power limit 150 W for adaptive balanced profile: mobile GPU power is platform-managed"]
         );
     }
 

--- a/runtime/runtime_spec.py
+++ b/runtime/runtime_spec.py
@@ -14,6 +14,7 @@ from typing import Any
 from auto_uv.domain.user_options import AUTO_UV_FAN_TUNING
 from cli.runtime_config_file import default_runtime_config, load_runtime_config
 from common.penguin_burner_errors import NvmlError
+from drivers.nvidia.nvml_gpu_policy import fixed_power_limit_excluded_by_identity
 from overlay.config import load_overlay_config
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR, read_auto_uv_profiles
 from profiles.uv.profile_tiers import (
@@ -152,6 +153,10 @@ def build_runtime_spec(
     identity = capabilities.get("identity")
     if not isinstance(identity, dict) or not str(identity.get("uuid") or "").strip():
         raise RuntimeError(f"GPU {selected_index} did not report a stable UUID")
+    fixed_power_limit_excluded = fixed_power_limit_excluded_by_identity(
+        gpu_name=identity.get("name"),
+        pci_device_id=identity.get("pci_device_id"),
+    )
 
     selector = str(profile_selector or "").strip()
     selected_curve = (
@@ -172,6 +177,12 @@ def build_runtime_spec(
     elif selected_curve is not None:
         mode = "static"
         static_profile = _profile_spec(selected_curve)
+    if fixed_power_limit_excluded:
+        if static_profile is not None:
+            static_profile["power_limit_w"] = None
+        if adaptive is not None:
+            for profile in adaptive["profiles"].values():
+                profile["power_limit_w"] = None
 
     fan = _fan_spec(config, enabled=bool(silent_fan_curve))
     overlay = load_overlay_config()

--- a/runtime/support/nvidia_runtime_defaults.py
+++ b/runtime/support/nvidia_runtime_defaults.py
@@ -54,6 +54,7 @@ def reset_nvidia_runtime_defaults(
         ) from exc
 
     gpu_name = str(result.get("gpu_name") or "").strip() or None
+    pci_device_id = str(result.get("pci_device_id") or "").strip() or None
     power_limits = result.get("power_limits")
     power_limits = power_limits if isinstance(power_limits, dict) else {}
     default_power_limit_w = power_limits.get("power_limit_default_w")
@@ -68,6 +69,7 @@ def reset_nvidia_runtime_defaults(
     return {
         "plan": plan,
         "gpu_name": gpu_name,
+        "pci_device_id": pci_device_id,
         "power_limits": power_limits,
         "power_limit_w": power_limit_w,
         "source": "runtime-defaults",

--- a/tests/auto_uv/test_gpu_vf_curve_applier.py
+++ b/tests/auto_uv/test_gpu_vf_curve_applier.py
@@ -134,6 +134,47 @@ def test_open_live_gpu_applier_continues_when_raised_power_limit_is_rejected(
     ]
 
 
+def test_laptop_fixed_power_limit_is_platform_managed_and_not_saved(
+    monkeypatch,
+) -> None:
+    logs: list[str] = []
+    controllers = _patch_power_environment(monkeypatch)
+    monkeypatch.setattr(
+        gpu_vf_curve_applier,
+        "reset_nvidia_runtime_defaults",
+        lambda **_kwargs: {
+            "plan": [{"index": 0, "voltage_mv": 900, "target_mhz": 2490}],
+            "gpu_name": "NVIDIA GeForce RTX 4090 Laptop GPU",
+            "power_limit_w": 150,
+            "power_limits": {
+                "power_limit_default_w": 150,
+                "power_limit_min_w": 5,
+                "power_limit_max_w": 175,
+            },
+        },
+    )
+    applier = gpu_vf_curve_applier.open_live_gpu_vf_curve_applier(
+        gpu_index=0,
+        runtime_options={},
+        log=logs.append,
+    )
+
+    assert controllers[0].power_limit_calls == []
+    assert applier.power_limit_w is None
+    assert applier.baseline_power_limit_w is None
+    assert applier.requested_power_limit_w is None
+    assert "power_limit_w" not in applier.translated_gpu_policy
+    assert logs == []
+
+    applier.requested_power_limit_w = 150
+    assert applier.apply_requested_power_limit(log=logs.append) is None
+    assert controllers[0].power_limit_calls == []
+    assert logs == [
+        "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+        "continuing without saved power limit"
+    ]
+
+
 def test_final_power_limit_rejection_is_not_fatal_and_not_saved() -> None:
     logs: list[str] = []
 

--- a/tests/auto_uv/test_gpu_vf_curve_applier.py
+++ b/tests/auto_uv/test_gpu_vf_curve_applier.py
@@ -175,6 +175,53 @@ def test_laptop_fixed_power_limit_is_platform_managed_and_not_saved(
     ]
 
 
+def test_pci_identified_mobile_gpu_never_writes_or_saves_fixed_power_limit(
+    monkeypatch,
+) -> None:
+    logs: list[str] = []
+    controllers = _patch_power_environment(monkeypatch)
+    monkeypatch.setattr(
+        gpu_vf_curve_applier,
+        "reset_nvidia_runtime_defaults",
+        lambda **_kwargs: {
+            "plan": [{"index": 0, "voltage_mv": 900, "target_mhz": 2490}],
+            "gpu_name": "NVIDIA GeForce RTX 5090",
+            "pci_device_id": "0x2C1810DE",
+            "power_limit_w": 150,
+            "power_limits": {
+                "power_limit_default_w": 150,
+                "power_limit_min_w": 5,
+                "power_limit_max_w": 175,
+            },
+        },
+    )
+
+    applier = gpu_vf_curve_applier.open_live_gpu_vf_curve_applier(
+        gpu_index=0,
+        runtime_options={"auto_uv_power_limit_w": 175},
+        log=logs.append,
+    )
+
+    assert controllers[0].power_limit_calls == []
+    assert applier.power_limit_w is None
+    assert applier.baseline_power_limit_w is None
+    assert applier.requested_power_limit_w is None
+    assert applier.translated_gpu_policy["pci_device_id"] == "0x2C1810DE"
+    assert "power_limit_w" not in applier.translated_gpu_policy
+    assert logs == [
+        "Auto-UV power limit: skipped requested fixed write on mobile GPU; "
+        "continuing without saved power limit"
+    ]
+
+    applier.requested_power_limit_w = 150
+    assert applier.apply_requested_power_limit(log=logs.append) is None
+    assert controllers[0].power_limit_calls == []
+    assert logs[-1] == (
+        "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+        "continuing without saved power limit"
+    )
+
+
 def test_final_power_limit_rejection_is_not_fatal_and_not_saved() -> None:
     logs: list[str] = []
 

--- a/tests/test_nvidia_runtime_defaults.py
+++ b/tests/test_nvidia_runtime_defaults.py
@@ -34,6 +34,7 @@ def test_reset_runtime_defaults_passes_through_mobile_daemon_result(monkeypatch)
         assert gpu_index == 0
         return {
             "gpu_name": "NVIDIA GeForce RTX 5060 Laptop GPU",
+            "pci_device_id": "0x2D1910DE",
             "points": [
                 {
                     "index": 0,
@@ -57,6 +58,7 @@ def test_reset_runtime_defaults_passes_through_mobile_daemon_result(monkeypatch)
     )
 
     assert result["gpu_name"] == "NVIDIA GeForce RTX 5060 Laptop GPU"
+    assert result["pci_device_id"] == "0x2D1910DE"
     assert result["power_limit_w"] is None
     assert result["power_limits"] == {}
     assert len(result["plan"]) == 1

--- a/tests/test_runtime_spec.py
+++ b/tests/test_runtime_spec.py
@@ -85,9 +85,38 @@ def test_build_static_runtime_spec_resolves_gpu_and_profile(monkeypatch) -> None
     }
     assert spec["static_profile"]["profile_id"] == "balanced-new"
     assert spec["static_profile"]["plan"][0]["new_offset_mhz"] == 100
+    assert spec["static_profile"]["power_limit_w"] == 320
     assert spec["policy"]["enable_persistence_mode"] is False
     assert spec["overlay"] == {"enabled": True, "update_interval_s": 2}
 
+
+def test_laptop_runtime_ignores_legacy_saved_fixed_power_limit(monkeypatch) -> None:
+    legacy_curve = _curve("legacy-laptop")
+    legacy_curve["power_limit_w"] = 150
+    _stub_runtime_sources(monkeypatch, curve=legacy_curve)
+    monkeypatch.setattr(
+        runtime_spec,
+        "gpu_capabilities",
+        lambda index, **kwargs: {
+            "identity": {
+                "uuid": f"GPU-laptop-{index}",
+                "pci_bus_id": "0000:01:00.0",
+                "pci_device_id": "0x271710DE",
+                "name": "NVIDIA GeForce RTX 4090 Laptop GPU",
+            },
+            "power_limits": {
+                "power_limit_w": None,
+                "power_limit_default_w": 150,
+                "power_limit_min_w": 5,
+                "power_limit_max_w": 175,
+            },
+        },
+    )
+    spec = runtime_spec.build_runtime_spec(profile_selector="legacy-laptop")
+
+    assert spec["static_profile"]["power_limit_w"] is None
+    assert spec["static_profile"]["memory_offset_mhz"] == 1500
+    assert spec["static_profile"]["plan"][0]["new_offset_mhz"] == 100
 
 def test_build_static_runtime_spec_resolves_latest_profile_for_empty_selector(
     monkeypatch,


### PR DESCRIPTION
## Summary

- omit readable fixed power limits from newly generated Auto-UV profiles when the existing mobile-GPU identity policy marks the setter unsupported
- block deferred tier power-limit writes on those GPUs
- clear legacy saved limits from both static and adaptive runtime specs while preserving V/F curves and memory offsets
- retain existing fixed-power behavior on desktop GPUs

## Why

On an RTX 4090 Laptop GPU, NVML reports a readable 150 W default and a 5–175 W range, but `nvmlDeviceSetPowerManagementLimit` returns NVML error 3 (`NOT_SUPPORTED`). `nvidia-powerd` remains the supported platform-managed path and independently requests up to 175 W.

PenguinBurner 0.7.6 nevertheless saved `power_limit_w: 150`. Applying that profile wrote the V/F curve and memory offset, then failed on the fixed-limit setter; the supervisor's stock fallback subsequently removed the curve. This restores the mobile exclusions that were present before GPU access moved behind the Rust daemon and also handles already-saved profiles.

Related: #30, #22. This does not address #30's separate D3cold/daemon-handle problem.

## Validation

- `python3 -m pytest tests/auto_uv/test_gpu_vf_curve_applier.py tests/test_runtime_spec.py -q` — 27 passed
- `python -m pytest tests/ -q` in an isolated environment with the declared Qt dependencies — 1692 passed
- `scripts/check-feature-static-analysis.sh` — completed; Ruff/Vulture clean, and its advisory Pyright baseline reported no diagnostics in touched files
- `git diff --check` — clean
- live read-only runtime materialization on the affected RTX 4090 Laptop GPU: the original 127-point `2490 MHz @ 900 mV` profile now resolves with `power_limit_w: null` and keeps `memory_offset_mhz: 0`; the spec was not submitted

No post-patch Auto-UV scan or hardware write was run. The change does not modify `nvidia-powerd`, persistence settings, boot application, fan behavior, or LACT configuration. Protection is intentionally scoped to GPUs matched by the existing mobile identity policy; unknown identities still retain the current setter/error behavior.
