### PR TITLE
Fix TypeError in profile-verification progress callback

### DIFF
--- a/tests/test_ui_controllers.py
+++ b/tests/test_ui_controllers.py
@@ -11,8 +11,9 @@ import sys
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from PySide6 import QtCore
+from PySide6 import QtCore, QtWidgets
 
+from ui.components.scan_controls import ScanControls
 from ui.controllers.scan import ScanController
 from ui.controllers.verify import VerifyController
 
@@ -238,7 +239,7 @@ def test_verify_runs_and_reports_progress(qtbot, tmp_path) -> None:
     controller = VerifyController(QtCore=QtCore, stop_request_path=tmp_path / "vstop")
     progress: list[tuple] = []
     finished: list[tuple] = []
-    controller.on_progress = lambda pct, elapsed, target, detail: progress.append((pct, elapsed))
+    controller.on_progress = lambda pct, *, elapsed_s, target_s, detail: progress.append((pct, elapsed_s))
     controller.on_finished = lambda code, status, stopped: finished.append((code, stopped))
 
     script = "print('status elapsed=30.0s running'); print('status elapsed=60.0s done')"
@@ -249,6 +250,22 @@ def test_verify_runs_and_reports_progress(qtbot, tmp_path) -> None:
     assert progress and progress[-1][0] == 100  # 60/60 -> 100%
     assert finished and finished[0][1] is False
     assert not (tmp_path / "vstop").exists()  # cleaned up on finish
+
+
+def test_verify_progress_wires_to_real_scan_controls(qtbot, tmp_path) -> None:
+    # Regression test: on_progress is assigned ScanControls.set_verify_progress
+    # verbatim in ui/window.py, whose elapsed_s/target_s/detail are keyword-only.
+    # A mocked positional-lambda stub would not catch a calling-convention
+    # mismatch between the two, so this wires the real widget instead.
+    controller = VerifyController(QtCore=QtCore, stop_request_path=tmp_path / "vstop")
+    controls = ScanControls(QtWidgets=QtWidgets)
+    controller.on_progress = controls.set_verify_progress
+
+    script = "print('status elapsed=30.0s running')"
+    assert controller.start([sys.executable, "-c", script], duration_s=60) is True
+    qtbot.waitUntil(lambda: not controller.is_running(), timeout=5000)
+
+    assert controls.dependency_progress.text() == "Verifying profile 30s / 1min"
 
 
 def test_verify_failed_start_reports(qtbot, tmp_path) -> None:

--- a/ui/controllers/verify.py
+++ b/ui/controllers/verify.py
@@ -18,7 +18,7 @@ class VerifyController:
         self.last_elapsed_s = 0.0
         self.stop_requested = False
         self.on_output = lambda _text: None
-        self.on_progress = lambda _percent, _elapsed_s, _target_s, _detail: None
+        self.on_progress = lambda _percent, *, elapsed_s=None, target_s=None, detail="": None
         self.on_finished = lambda _exit_code, _exit_status, _stopped: None
 
     def is_running(self) -> bool:
@@ -90,9 +90,9 @@ class VerifyController:
             self.last_elapsed_s = max(self.last_elapsed_s, elapsed)
             self.on_progress(
                 progress_percent(self.last_elapsed_s, self.target_duration_s),
-                self.last_elapsed_s,
-                self.target_duration_s,
-                line.strip(),
+                elapsed_s=self.last_elapsed_s,
+                target_s=self.target_duration_s,
+                detail=line.strip(),
             )
 
     def _finished(self, exit_code, exit_status) -> None:


### PR DESCRIPTION
## Summary
- `VerifyController._read_output()` called `on_progress` positionally, but the real production callback (`ScanControls.set_verify_progress`) declares `elapsed_s`/`target_s`/`detail` as keyword-only. Every profile verification that emitted a parseable `elapsed=Ns` line crashed this callback, leaving the progress display stuck at its initial value and spamming the console with a `TypeError` traceback for the rest of the run.
- Pass the arguments as keywords, matching the calling convention already used at every other call site of `set_verify_progress` in the codebase.
- Added a regression test that wires the real `ScanControls` widget (instead of a permissive positional stub) so this calling-convention mismatch can't silently reappear — confirmed it fails without the fix and passes with it.

Found while live-testing a saved-profile "Verify" action on real hardware.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite passes (1642 passed, 57 skipped) with real PySide6/pyqtgraph/pytest-qt installed
- [x] `ruff check` / `pyright` on touched files — no new diagnostics beyond pre-existing repo-wide ones
- [x] Confirmed the new test fails on the pre-fix code and passes after the fix