### PR TITLE
Clear the header candidate label when profile verification finishes

### DIFF
--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -299,9 +299,18 @@ def test_window_scan_finished_branches(main_window) -> None:
 
 
 def test_window_verify_and_command_finished(main_window) -> None:
+    main_window.header.set_candidate("User edited memory offset +6000 MT/s")
     main_window._verify_finished(0, 0, False)  # success
+    assert main_window.header.candidate_label.text() == ""
+
+    main_window.header.set_candidate("stale candidate")
     main_window._verify_finished(1, 0, True)  # stopped
+    assert main_window.header.candidate_label.text() == ""
+
+    main_window.header.set_candidate("stale candidate")
     main_window._verify_finished(1, 0, False)  # failed
+    assert main_window.header.candidate_label.text() == ""
+
     main_window._command_finished("delete", 0, 0)
 
 

--- a/ui/window.py
+++ b/ui/window.py
@@ -709,6 +709,11 @@ class MainWindow(ProfileActionsMixin):
                     exit_code=exit_code,
                     exit_status=exit_status,
                 )
+        # The header's candidate label is only ever set by a running scan or
+        # verify; clear it here too, or it keeps showing the just-verified
+        # profile's name indefinitely, including through unrelated later
+        # Apply actions that never touch this label themselves.
+        self.header.set_candidate("")
         self.controls.set_running(False)
         self._load_profiles()
 


### PR DESCRIPTION
## Summary
- `_verify_profile()` sets the header's "candidate" label to the profile being verified, but `_verify_finished()` never clears or updates it — and the Apply flow never touches it either. So the label sticks with whatever was last verified indefinitely, including through later, completely unrelated Apply actions on a different profile.
- Clear it in `_verify_finished()` on completion (success, stopped, or failed), matching the existing "clear when there's no active candidate" convention used elsewhere (e.g. scan discarded/dependency-download paths).
- Added a regression test asserting the label is cleared in all three finish branches — confirmed it fails without the fix and passes with it.

Found while live-testing a saved-profile "Verify" action on real hardware: after verifying a profile, the header kept showing its name even after applying a completely different profile.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite passes (1641 passed, 57 skipped) with real PySide6/pyqtgraph/pytest-qt installed
- [x] `ruff check` / `pyright` on touched files — no new diagnostics; pyright error count on `ui/window.py` unchanged before/after (9/9)
- [x] Confirmed the new test fails on the pre-fix code and passes after the fix