### PR TITLE
Add Edit Memory Offset action for saved Auto-UV profiles

### DIFF
--- a/profiles/uv/memory_offset_edit.py
+++ b/profiles/uv/memory_offset_edit.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+USER_EDITED_MEMORY_OFFSET_SOURCE = "user-edited"
+
+_EXCLUDED_PARENT_KEYS = {
+    "profile_id",
+    "profile_created_at",
+    "path",
+    "verified_at",
+    "avg_core_clock_mhz",
+    "avg_fps",
+    "avg_power_w",
+    "efficiency_fps_per_w",
+    "efficiency_mhz_per_w",
+    "watts_per_mhz",
+    "final_validation",
+    "validation",
+    "verification",
+}
+
+
+def editable_memory_offset_from_profile(profile: dict) -> int | None:
+    try:
+        return round(float(profile.get("memory_offset_mhz")))
+    except (TypeError, ValueError):
+        return None
+
+
+def user_edited_memory_offset_profile_payload(
+    parent_profile: dict,
+    new_memory_offset_mhz: int,
+    *,
+    original_memory_offset_mhz: int | None = None,
+) -> dict:
+    payload = {
+        key: value
+        for key, value in dict(parent_profile).items()
+        if key not in _EXCLUDED_PARENT_KEYS
+    }
+    parent_profile_id = str(parent_profile.get("profile_id", "")).strip()
+    parent_path = str(parent_profile.get("path", "")).strip()
+    payload.update(
+        {
+            "profile_source": USER_EDITED_MEMORY_OFFSET_SOURCE,
+            "display_name": (
+                f"User edited memory offset {int(new_memory_offset_mhz):+d} MT/s"
+            ),
+            "memory_offset_mhz": int(new_memory_offset_mhz),
+            "final_verified": False,
+            "verification_status": "unverified",
+            "requires_verification": True,
+            "manual_edit": {
+                "edit_kind": "memory-offset",
+                "parent_profile_id": parent_profile_id,
+                "parent_path": parent_path,
+                "original_memory_offset_mhz": (
+                    None
+                    if original_memory_offset_mhz is None
+                    else int(original_memory_offset_mhz)
+                ),
+                "new_memory_offset_mhz": int(new_memory_offset_mhz),
+            },
+        }
+    )
+    return payload

--- a/tests/test_memory_offset_edit.py
+++ b/tests/test_memory_offset_edit.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from profiles.uv.memory_offset_edit import (
+    editable_memory_offset_from_profile,
+    user_edited_memory_offset_profile_payload,
+)
+
+
+def test_editable_memory_offset_from_profile_valid() -> None:
+    assert editable_memory_offset_from_profile({"memory_offset_mhz": 400}) == 400
+    assert editable_memory_offset_from_profile({"memory_offset_mhz": "400"}) == 400
+
+
+def test_editable_memory_offset_from_profile_invalid() -> None:
+    assert editable_memory_offset_from_profile({}) is None
+    assert editable_memory_offset_from_profile({"memory_offset_mhz": None}) is None
+    assert editable_memory_offset_from_profile({"memory_offset_mhz": "not-a-number"}) is None
+
+
+def test_user_edited_memory_offset_profile_payload_requires_verification() -> None:
+    payload = user_edited_memory_offset_profile_payload(
+        {
+            "profile_id": "parent",
+            "path": "/tmp/parent.json",
+            "candidate_voltage_mv": 900,
+            "lock_clock_mhz": 2550,
+            "memory_offset_mhz": 200,
+            "plan": [{"index": 0, "voltage_mv": 900, "base_mhz": 2400, "target_mhz": 2500}],
+            "points": [{"voltage_mv": 900, "clock_mhz": 2500}],
+            "avg_fps": 120.0,
+            "final_verified": True,
+            "verification_status": "verified",
+        },
+        400,
+        original_memory_offset_mhz=200,
+    )
+
+    assert payload["profile_source"] == "user-edited"
+    assert payload["memory_offset_mhz"] == 400
+    assert payload["final_verified"] is False
+    assert payload["verification_status"] == "unverified"
+    assert payload["requires_verification"] is True
+    # Unrelated V/F curve and identity fields must pass through untouched.
+    assert payload["candidate_voltage_mv"] == 900
+    assert payload["lock_clock_mhz"] == 2550
+    assert payload["plan"] == [
+        {"index": 0, "voltage_mv": 900, "base_mhz": 2400, "target_mhz": 2500}
+    ]
+    assert "avg_fps" not in payload
+    assert "profile_id" not in payload
+    assert payload["manual_edit"] == {
+        "edit_kind": "memory-offset",
+        "parent_profile_id": "parent",
+        "parent_path": "/tmp/parent.json",
+        "original_memory_offset_mhz": 200,
+        "new_memory_offset_mhz": 400,
+    }
+
+
+def test_user_edited_memory_offset_profile_payload_without_original() -> None:
+    payload = user_edited_memory_offset_profile_payload(
+        {"profile_id": "parent", "path": "/tmp/parent.json"},
+        150,
+    )
+    assert payload["manual_edit"]["original_memory_offset_mhz"] is None
+    assert payload["manual_edit"]["new_memory_offset_mhz"] == 150

--- a/tests/test_ui_memory_offset_profiles.py
+++ b/tests/test_ui_memory_offset_profiles.py
@@ -1,0 +1,55 @@
+"""Coverage for ui/features/curves/memory_offset_profiles.py's save wrapper.
+
+Dependencies are monkeypatched so no live profile store is touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ui.features.curves.memory_offset_profiles as mop
+
+
+def test_save_edited_memory_offset_profile_reads_from_disk_and_archives(monkeypatch) -> None:
+    monkeypatch.setattr(mop, "profile_payload_from_path", lambda profile: {"base": 1})
+    monkeypatch.setattr(
+        mop,
+        "user_edited_memory_offset_profile_payload",
+        lambda parent, new_memory_offset_mhz, **kw: {
+            "edited": True,
+            "parent": parent,
+            "new_memory_offset_mhz": new_memory_offset_mhz,
+            "kw": kw,
+        },
+    )
+    archived = Path("/tmp/auto-uv-profile-mem-edit.json")
+    monkeypatch.setattr(mop, "archive_auto_uv_profile", lambda payload: archived)
+
+    path, payload = mop.save_edited_memory_offset_profile(
+        {"path": "x"},
+        400,
+        original_memory_offset_mhz=200,
+    )
+
+    assert path == archived
+    assert payload["edited"] is True
+    # The parent payload came from the re-read (disk), not the trimmed summary dict.
+    assert payload["parent"] == {"base": 1}
+    assert payload["new_memory_offset_mhz"] == 400
+    assert payload["kw"] == {"original_memory_offset_mhz": 200}
+
+
+def test_save_edited_memory_offset_profile_falls_back_to_profile_dict(monkeypatch) -> None:
+    monkeypatch.setattr(mop, "profile_payload_from_path", lambda profile: None)
+    captured = {}
+
+    def fake_builder(parent, new_memory_offset_mhz, **kw):
+        captured["parent"] = parent
+        return {"edited": True}
+
+    monkeypatch.setattr(mop, "user_edited_memory_offset_profile_payload", fake_builder)
+    monkeypatch.setattr(mop, "archive_auto_uv_profile", lambda payload: Path("/tmp/x.json"))
+
+    mop.save_edited_memory_offset_profile({"path": "", "memory_offset_mhz": 100}, 250)
+
+    assert captured["parent"] == {"path": "", "memory_offset_mhz": 100}

--- a/tests/test_ui_window_profile_methods.py
+++ b/tests/test_ui_window_profile_methods.py
@@ -120,6 +120,34 @@ def test_edit_vf_curve_opens_and_saves(win) -> None:
     assert window.last_auto_uv_candidate_id == "c9"
 
 
+def test_edit_memory_offset_no_value_shows_info(win) -> None:
+    window, monkeypatch = win
+    monkeypatch.setattr(actions_mod, "editable_memory_offset_from_profile", lambda profile: None)
+    shown: list = []
+    monkeypatch.setattr(window.QtWidgets.QMessageBox, "information", lambda *a, **k: shown.append(a))
+    window._edit_profile_memory_offset(PROFILE)
+    assert shown
+
+
+def test_edit_memory_offset_opens_and_saves(win) -> None:
+    window, monkeypatch = win
+    monkeypatch.setattr(actions_mod, "editable_memory_offset_from_profile", lambda profile: 200)
+    monkeypatch.setattr(actions_mod, "memory_offset_mhz_range", lambda gpu_index: (0, 2000))
+    monkeypatch.setattr(
+        actions_mod,
+        "save_edited_memory_offset_profile",
+        lambda profile, new_memory_offset_mhz, **kw: (
+            Path("/tmp/auto-uv-profile-mem.json"),
+            {"memory_offset_mhz": new_memory_offset_mhz},
+        ),
+    )
+    # The editor stub fires the save callback to exercise the closure.
+    monkeypatch.setattr(
+        actions_mod, "open_memory_offset_editor_dialog", lambda **k: k["save_callback"](400)
+    )
+    window._edit_profile_memory_offset(PROFILE)
+
+
 def test_export_lact_cancelled_and_no_gpu(win) -> None:
     window, monkeypatch = win
     monkeypatch.setattr(

--- a/ui/components/memory_offset_editor.py
+++ b/ui/components/memory_offset_editor.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def open_memory_offset_editor_dialog(
+    *,
+    QtWidgets,
+    parent,
+    current_memory_offset_mhz: int,
+    min_mhz: int,
+    max_mhz: int,
+    save_callback: Callable[[int], str | None],
+) -> bool:
+    dialog = QtWidgets.QDialog(parent)
+    dialog.setWindowTitle("Edit Memory Offset")
+    layout = QtWidgets.QVBoxLayout(dialog)
+
+    form = QtWidgets.QFormLayout()
+    layout.addLayout(form)
+
+    # NVML applies memory offsets in transfer-rate units (MT/s), but the
+    # realized memory clock moves by half (verified on Blackwell, issue
+    # #20), so the spin box works in clock MHz and the stored/applied value
+    # is twice that.
+    memory_spin = QtWidgets.QSpinBox()
+    memory_spin.setObjectName("memoryOffsetEditSpin")
+    memory_spin.setSuffix(" MHz")
+    memory_spin.setSingleStep(25)
+    memory_spin.setFixedWidth(136)
+    memory_spin.setRange(int(min_mhz) // 2, max(int(min_mhz) // 2, int(max_mhz) // 2))
+    memory_spin.setValue(
+        max(
+            memory_spin.minimum(),
+            min(memory_spin.maximum(), int(current_memory_offset_mhz) // 2),
+        )
+    )
+
+    memory_clock_label = QtWidgets.QLabel()
+    memory_clock_label.setObjectName("memoryOffsetEditClockLabel")
+
+    def update_memory_label(value: int) -> None:
+        memory_clock_label.setText(f"= {int(value) * 2:+d} MT/s transfer rate")
+
+    memory_spin.valueChanged.connect(update_memory_label)
+    update_memory_label(memory_spin.value())
+
+    memory_widget = QtWidgets.QWidget()
+    memory_layout = QtWidgets.QHBoxLayout(memory_widget)
+    memory_layout.setContentsMargins(0, 0, 0, 0)
+    memory_layout.setSpacing(10)
+    memory_layout.addWidget(memory_spin)
+    memory_layout.addWidget(memory_clock_label)
+    memory_layout.addStretch(1)
+    form.addRow("Memory Offset", memory_widget)
+
+    status_label = QtWidgets.QLabel()
+    layout.addWidget(status_label)
+
+    button_row = QtWidgets.QHBoxLayout()
+    button_row.addStretch(1)
+    save_button = QtWidgets.QPushButton("Save")
+    cancel_button = QtWidgets.QPushButton("Cancel")
+    button_row.addWidget(save_button)
+    button_row.addWidget(cancel_button)
+    layout.addLayout(button_row)
+
+    def save_edit() -> None:
+        try:
+            message = save_callback(int(memory_spin.value()) * 2)
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(
+                dialog,
+                "Edit Memory Offset",
+                f"Failed to save edited memory offset: {exc}",
+            )
+            return
+        if message:
+            status_label.setText(str(message))
+        dialog.accept()
+
+    save_button.clicked.connect(save_edit)
+    cancel_button.clicked.connect(dialog.reject)
+    return bool(dialog.exec() == QtWidgets.QDialog.Accepted)

--- a/ui/features/curves/memory_offset_profiles.py
+++ b/ui/features/curves/memory_offset_profiles.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from profiles.uv.memory_offset_edit import user_edited_memory_offset_profile_payload
+from profiles.uv.profile_store import archive_auto_uv_profile
+from ui.features.curves.fan_profiles import profile_payload_from_path
+
+
+def save_edited_memory_offset_profile(
+    profile: dict,
+    new_memory_offset_mhz: int,
+    *,
+    original_memory_offset_mhz: int | None = None,
+) -> tuple[Path, dict]:
+    parent_payload = profile_payload_from_path(profile) or dict(profile)
+    payload = user_edited_memory_offset_profile_payload(
+        parent_payload,
+        int(new_memory_offset_mhz),
+        original_memory_offset_mhz=original_memory_offset_mhz,
+    )
+    return archive_auto_uv_profile(payload), payload

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -4,6 +4,7 @@ import shlex
 
 from common.penguin_burner_paths import default_user_config_dir
 from curve_editors.uv.vf_curve_manual_editor import editable_anchor_from_profile
+from profiles.uv.memory_offset_edit import editable_memory_offset_from_profile
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR
 from profiles.uv.profile_store import delete_auto_uv_profile_paths
 from profiles.uv.profile_tiers import save_profile_tier_assignment
@@ -14,6 +15,7 @@ from ui.commands import profile_verify_command
 from ui.commands import runtime_profile_command
 from ui.daemon_setup import ensure_daemon_ready_for_privileged_action
 from ui.components.fan_curve_editor import open_fan_curve_editor_dialog
+from ui.components.memory_offset_editor import open_memory_offset_editor_dialog
 from ui.components.vf_curve_editor import open_vf_curve_editor_dialog
 from ui.features.curves.curve_profiles import profile_base_curve_points
 from ui.features.curves.curve_profiles import profile_curve_plan
@@ -25,9 +27,11 @@ from ui.features.curves.fan_profiles import profile_fan_measurement_points
 from ui.features.curves.fan_profiles import profile_id_from_archive_path
 from ui.features.curves.fan_profiles import save_edited_fan_profile
 from ui.features.curves.fan_profiles import sync_profile_fan_payload
+from ui.features.curves.memory_offset_profiles import save_edited_memory_offset_profile
 from ui.features.integrations.lact_export import detect_lact_gpu_id
 from ui.features.integrations.lact_export import lact_export_output_path
 from ui.features.integrations.lact_export import write_lact_profile_config
+from ui.features.tuning.tuning import memory_offset_mhz_range
 from ui.features.profiles.profiles import adaptive_profile_tier_labels
 from ui.features.profiles.profiles import delete_confirmation_text
 from ui.features.profiles.profiles import profile_can_apply
@@ -252,6 +256,43 @@ class ProfileActionsMixin:
             anchor=anchor,
             save_callback=save_edit,
             control_voltage_mvs=control_voltage_mvs,
+        )
+
+    def _edit_profile_memory_offset(self, profile: dict) -> None:
+        current = editable_memory_offset_from_profile(profile)
+        if current is None:
+            self.QtWidgets.QMessageBox.information(
+                self.window,
+                "Edit Memory Offset",
+                "No editable memory offset is available for this profile.",
+            )
+            return
+        min_mhz, max_mhz = memory_offset_mhz_range(gpu_index=self.gpu_index)
+
+        def save_edit(new_memory_offset_mhz: int) -> str:
+            path, _payload = save_edited_memory_offset_profile(
+                profile,
+                new_memory_offset_mhz,
+                original_memory_offset_mhz=current,
+            )
+            profile_id = profile_id_from_archive_path(path)
+            message = (
+                f"Saved edited memory offset draft: {path.name}. "
+                "Verify it before Apply."
+            )
+            self.controls.set_status_text(message)
+            self._load_profiles()
+            if profile_id:
+                self.profile_list.select_profile(profile_id)
+            return message
+
+        open_memory_offset_editor_dialog(
+            QtWidgets=self.QtWidgets,
+            parent=self.window,
+            current_memory_offset_mhz=current,
+            min_mhz=min_mhz,
+            max_mhz=max_mhz,
+            save_callback=save_edit,
         )
 
     def _export_lact_profile(self, profile: dict) -> None:
@@ -500,6 +541,10 @@ class ProfileActionsMixin:
         edit_curve_action.setEnabled(bool(profile_curve_plan(profile)))
         fan_action = menu.addAction("Edit Fan Curve")
         fan_action.setEnabled(bool(profile_fan_curve_points(profile)))
+        memory_offset_action = menu.addAction("Edit Memory Offset")
+        memory_offset_action.setEnabled(
+            editable_memory_offset_from_profile(profile) is not None
+        )
         apply_action = menu.addAction("Apply")
         apply_action.setEnabled(not self._workflow_running() and profile_can_apply(profile))
         verify_action = menu.addAction("Verify")
@@ -532,6 +577,8 @@ class ProfileActionsMixin:
             self._edit_profile_vf_curve(profile)
         elif chosen == fan_action:
             self._edit_profile_fan_curve(profile)
+        elif chosen == memory_offset_action:
+            self._edit_profile_memory_offset(profile)
         elif chosen == apply_action:
             self._run_runtime_action("daemonize")
         elif chosen == verify_action:


### PR DESCRIPTION
## Summary
Saved Auto-UV profiles already support post-hoc editing of the V/F curve ("Edit VF Curve") and fan curve ("Edit Fan Curve") from the profile list's context menu, but there was no way to change a saved profile's memory clock offset after the scan that produced it — it was write-once at scan-configuration time.

This adds a third sibling action, "Edit Memory Offset", following the exact same pattern as the existing two:
- `profiles/uv/memory_offset_edit.py` (new): pure payload builder — `editable_memory_offset_from_profile()` / `user_edited_memory_offset_profile_payload()` — mirroring the VF-curve editor's exclusion set and verification-reset fields (`final_verified=False`, `requires_verification=True`, etc.), so the resulting draft is gated by `profile_can_apply()` identically to a VF-curve draft.
- `ui/features/curves/memory_offset_profiles.py` (new): thin save wrapper mirroring `save_edited_curve_profile`, re-reading the full profile from disk before building the new payload.
- `ui/components/memory_offset_editor.py` (new): a single-spinbox dialog, reusing the MT/s↔MHz half-conversion convention already used by the scan-tuning memory spinbox.
- `ui/features/profiles/profile_actions.py`: new `_edit_profile_memory_offset()` method plus a third context-menu entry alongside the existing two.

The edit produces a fresh "unverified draft" profile (never mutates the original saved profile file), requiring re-verification before Apply — same as VF-curve/fan-curve edits.

Live-tested end to end on real hardware (RTX 5070 Ti): opened the dialog on a saved profile, edited the memory offset, saved a draft, verified it (300s Q2RTX + CUDA stability test), and confirmed the profile is correctly marked `final_verified: true` afterward.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite passes (1641 passed, 57 skipped) with real PySide6/pyqtgraph/pytest-qt installed
- [x] `ruff check` / `vulture` / `pyright` on touched files — no new diagnostics beyond pre-existing repo-wide conventions (verified via `git diff origin/main` on sibling files)
- [x] Live GUI + real GPU verification run, described above