### PR TITLE
Show the curve and live GPU position during profile verification

### DIFF
--- a/profiles/verification/runner.py
+++ b/profiles/verification/runner.py
@@ -32,6 +32,7 @@ from profiles.uv.runtime_auto_uv_profile import (
 from stability.q2rtx.long_stability_config import build_long_stability_test_config
 from stability.q2rtx.models import StabilityTestError
 from stability.q2rtx.output import attach_stdout_progress
+from stability.q2rtx.output import attach_stdout_telemetry_events
 from stability.q2rtx.reporting import print_q2rtx_stability_result
 from stability.q2rtx.runtime import run_q2rtx_stability_test
 
@@ -62,6 +63,7 @@ class ProfileVerificationDependencies:
     build_long_stability_test_config: Callable = build_long_stability_test_config
     run_q2rtx_stability_test: Callable = run_q2rtx_stability_test
     attach_stdout_progress: Callable = attach_stdout_progress
+    attach_stdout_telemetry_events: Callable = attach_stdout_telemetry_events
     print_q2rtx_stability_result: Callable = print_q2rtx_stability_result
     log: Callable[[str], None] = runtime_log
 
@@ -185,6 +187,12 @@ def run_profile_verification(
             stability_config.abort_callback = stability_stop_request_abort_callback(
                 stop_request_path,
                 previous_callback=stability_config.abort_callback,
+            )
+        if flatten_target is not None:
+            stability_config = deps.attach_stdout_telemetry_events(
+                stability_config,
+                target_voltage_mv=int(flatten_target["lock_voltage_mv"]),
+                target_clock_mhz=int(flatten_target["lock_clock_mhz"]),
             )
         deps.attach_stdout_progress(stability_config)
         try:

--- a/stability/q2rtx/output.py
+++ b/stability/q2rtx/output.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from pathlib import Path
+import json
 
 from .constants import (
     FATAL_OUTPUT_REGEXES,
@@ -76,6 +77,37 @@ def attach_stdout_progress(
 
     def _progress_callback(state: dict) -> None:
         print(_format_live_progress_state(state, prefix=prefix), flush=True)
+        if previous_progress_callback is not None:
+            previous_progress_callback(state)
+
+    config.progress_callback = _progress_callback
+    return config
+
+
+def attach_stdout_telemetry_events(
+    config: Q2RTXStabilityConfig,
+    *,
+    target_voltage_mv: int,
+    target_clock_mhz: int,
+) -> Q2RTXStabilityConfig:
+    """Print a load_telemetry JSON line per tick alongside the human status
+    line, so a listening GUI can plot the live GPU position on the curve
+    being verified (mirroring what a live Auto-UV scan already emits)."""
+    previous_progress_callback = config.progress_callback
+
+    def _progress_callback(state: dict) -> None:
+        latest_sample = state.get("latest_sample")
+        if latest_sample is not None:
+            payload = {
+                "event": "load_telemetry",
+                "voltage_mv": int(target_voltage_mv),
+                "clock_mhz": int(target_clock_mhz),
+            }
+            if latest_sample.voltage_mv is not None:
+                payload["measured_voltage_mv"] = round(float(latest_sample.voltage_mv))
+            if latest_sample.core_clock_mhz is not None:
+                payload["measured_clock_mhz"] = round(float(latest_sample.core_clock_mhz))
+            print(json.dumps(payload, sort_keys=True), flush=True)
         if previous_progress_callback is not None:
             previous_progress_callback(state)
 

--- a/tests/test_auto_uv_profiles.py
+++ b/tests/test_auto_uv_profiles.py
@@ -1478,6 +1478,105 @@ def test_profile_verification_promotes_verified_profile(
     assert resolve_auto_uv_profile(str(stored_path)) is not None
 
 
+def test_profile_verification_wires_live_telemetry_events_when_target_known(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    # A GUI listening on stdout can only plot the live GPU position if this
+    # is wired with the profile's own target voltage/clock, not left unset.
+    monkeypatch.setattr(profile_store, "default_user_config_dir", lambda: tmp_path)
+    stored_path = archive_auto_uv_profile(
+        {
+            "candidate_voltage_mv": 900,
+            "lock_clock_mhz": 2600,
+            "profile_source": "user-edited",
+            "final_verified": False,
+            "requires_verification": True,
+            "base_avg_core_clock_mhz": 2500.0,
+            "base_avg_fps": 100.0,
+            "base_avg_power_w": 250.0,
+            "base_efficiency_fps_per_w": 0.4,
+            "points": [
+                {
+                    "index": 0,
+                    "voltage_mv": 900,
+                    "base_mhz": 2500,
+                    "target_mhz": 2600,
+                    "new_offset_mhz": 100,
+                }
+            ],
+        }
+    )
+
+    class FakeGpuClient:
+        def refresh_points(self) -> None:
+            pass
+
+    config = SimpleNamespace(abort_callback=None)
+    result = SimpleNamespace(
+        success=True,
+        reason="ok",
+        log_path=tmp_path / "verify.log",
+        benchmark_summary=SimpleNamespace(fps_avg=120.0),
+        telemetry_summary=lambda: {"core_clock_avg": 2580.0, "power_avg": 240.0},
+    )
+    plan = [
+        {
+            "index": 0,
+            "voltage_mv": 900,
+            "base_mhz": 2500,
+            "target_mhz": 2600,
+            "new_offset_mhz": 100,
+        }
+    ]
+    monkeypatch.setattr(
+        profile_verification_runner,
+        "apply_verify_auto_uv_profile",
+        lambda *_args, **_kwargs: (
+            "auto-UV:2600MHz@900mV",
+            {"lock_voltage_mv": 900, "lock_clock_mhz": 2600},
+            plan,
+        ),
+    )
+
+    telemetry_calls = []
+
+    def fake_attach_telemetry(stability_config, *, target_voltage_mv, target_clock_mhz):
+        telemetry_calls.append(
+            {"target_voltage_mv": target_voltage_mv, "target_clock_mhz": target_clock_mhz}
+        )
+        return stability_config
+
+    deps = profile_verification_runner.ProfileVerificationDependencies(
+        stop_existing_penguin_burner_runtime=lambda **_kwargs: None,
+        gpu_client_factory=lambda **_kwargs: FakeGpuClient(),
+        backup_current_offsets=lambda *_args, **_kwargs: None,
+        restore_offsets=lambda *_args, **_kwargs: None,
+        build_stability_config=lambda *_args, **_kwargs: config,
+        build_long_stability_test_config=lambda stability_config, **_kwargs: (
+            stability_config
+        ),
+        attach_stdout_progress=lambda _config: None,
+        attach_stdout_telemetry_events=fake_attach_telemetry,
+        run_q2rtx_stability_test=lambda _config: result,
+        print_q2rtx_stability_result=lambda _result: None,
+    )
+
+    profile_verification_runner.run_profile_verification(
+        SimpleNamespace(
+            auto_uv_profile=str(stored_path),
+            stability_seconds=600,
+            stability_stop_request_file="",
+        ),
+        gpu_index=0,
+        config_path=tmp_path / "runtime.ini",
+        auto_uv_runtime_options={},
+        dependencies=deps,
+    )
+
+    assert telemetry_calls == [{"target_voltage_mv": 900, "target_clock_mhz": 2600}]
+
+
 def test_profile_verification_voltage_abort_requires_sustained_busy_mismatch() -> None:
     callback = profile_verification_rules.profile_verification_voltage_abort_callback(
         {"lock_voltage_mv": 870}

--- a/tests/test_q2rtx_stability.py
+++ b/tests/test_q2rtx_stability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+import json
 import sys
 import tarfile
 from types import SimpleNamespace
@@ -35,11 +36,13 @@ from stability.q2rtx.models import (
     Q2RTXStabilityConfig,
     Q2RTXStabilityResult,
     StabilityTestError,
+    TelemetrySample,
 )
 from stability.q2rtx.output import (
     _benchmark_summary_from_events,
     _format_live_progress_state,
     _scan_output_for_fatal_patterns,
+    attach_stdout_telemetry_events,
 )
 from stability.q2rtx.reporting import _filter_report_output_tail
 from stability.q2rtx.runtime import build_benchmark_command
@@ -680,6 +683,53 @@ def test_cuda_companion_progress_is_labeled_as_cuda() -> None:
     assert "running=cuda" in line
     assert "demo=q2demo1" not in line
     assert "elapsed=512.0s" in line
+
+
+def test_attach_stdout_telemetry_events_prints_load_telemetry_json(capsys) -> None:
+    config = Q2RTXStabilityConfig(duration_s=1, log_dir=Path("/tmp"))
+    previous_calls = []
+    config.progress_callback = previous_calls.append
+
+    attach_stdout_telemetry_events(
+        config,
+        target_voltage_mv=925,
+        target_clock_mhz=2950,
+    )
+    sample = TelemetrySample(
+        elapsed_s=12.0,
+        gpu_util_pct=99.0,
+        power_w=280.0,
+        core_clock_mhz=2940.0,
+        temperature_c=62.0,
+        voltage_mv=923.0,
+        fan_speed_pct=50.0,
+    )
+    config.progress_callback({"elapsed_s": 12.0, "latest_sample": sample})
+
+    printed = capsys.readouterr().out.strip()
+    payload = json.loads(printed)
+    assert payload == {
+        "event": "load_telemetry",
+        "voltage_mv": 925,
+        "clock_mhz": 2950,
+        "measured_voltage_mv": 923,
+        "measured_clock_mhz": 2940,
+    }
+    # The wrapped config still chains to whatever callback was set before.
+    assert previous_calls == [{"elapsed_s": 12.0, "latest_sample": sample}]
+
+
+def test_attach_stdout_telemetry_events_skips_missing_sample(capsys) -> None:
+    config = Q2RTXStabilityConfig(duration_s=1, log_dir=Path("/tmp"))
+
+    attach_stdout_telemetry_events(
+        config,
+        target_voltage_mv=925,
+        target_clock_mhz=2950,
+    )
+    config.progress_callback({"elapsed_s": 0.0, "latest_sample": None})
+
+    assert capsys.readouterr().out.strip() == ""
 
 
 def test_fatal_output_abort_reason_uses_active_workload() -> None:

--- a/tests/test_ui_controllers.py
+++ b/tests/test_ui_controllers.py
@@ -251,6 +251,32 @@ def test_verify_runs_and_reports_progress(qtbot, tmp_path) -> None:
     assert not (tmp_path / "vstop").exists()  # cleaned up on finish
 
 
+def test_verify_routes_telemetry_json_out_of_the_log_view(qtbot, tmp_path) -> None:
+    controller = VerifyController(QtCore=QtCore, stop_request_path=tmp_path / "vstop")
+    outputs: list[str] = []
+    telemetry: list[dict] = []
+    controller.on_output = outputs.append
+    controller.on_telemetry = telemetry.append
+
+    # The last line has no trailing newline, exercising the drain-on-finish path.
+    script = (
+        "import sys\n"
+        "print('{\"event\": \"load_telemetry\", \"voltage_mv\": 925, \"clock_mhz\": 2950}')\n"
+        "print('status elapsed=5.0s running')\n"
+        "sys.stdout.write('{\"event\": \"load_telemetry\", \"voltage_mv\": 926, \"clock_mhz\": 2951}')\n"
+    )
+    assert controller.start([sys.executable, "-c", script], duration_s=60) is True
+    qtbot.waitUntil(lambda: not controller.is_running(), timeout=5000)
+
+    assert telemetry == [
+        {"event": "load_telemetry", "voltage_mv": 925, "clock_mhz": 2950},
+        {"event": "load_telemetry", "voltage_mv": 926, "clock_mhz": 2951},
+    ]
+    joined_output = "".join(outputs)
+    assert "load_telemetry" not in joined_output
+    assert "status elapsed=5.0s running" in joined_output
+
+
 def test_verify_failed_start_reports(qtbot, tmp_path) -> None:
     controller = VerifyController(QtCore=QtCore, stop_request_path=tmp_path / "vstop")
     outputs: list[str] = []

--- a/tests/test_ui_window.py
+++ b/tests/test_ui_window.py
@@ -305,6 +305,38 @@ def test_window_verify_and_command_finished(main_window) -> None:
     main_window._command_finished("delete", 0, 0)
 
 
+def test_verify_controller_telemetry_plots_the_live_gpu_position(main_window) -> None:
+    win = main_window
+    win.verify_controller.on_telemetry(
+        {
+            "event": "load_telemetry",
+            "voltage_mv": 925,
+            "clock_mhz": 2950,
+            "measured_voltage_mv": 923,
+            "measured_clock_mhz": 2940,
+        }
+    )
+    assert win.vf_plot._last_live_probe_values == (923.0, 2940.0)
+
+
+def test_verify_finished_clears_the_live_gpu_position_marker(main_window) -> None:
+    win = main_window
+    win.verify_controller.on_telemetry(
+        {
+            "event": "load_telemetry",
+            "voltage_mv": 925,
+            "clock_mhz": 2950,
+            "measured_voltage_mv": 923,
+            "measured_clock_mhz": 2940,
+        }
+    )
+    assert win.vf_plot._last_live_probe_values is not None
+
+    win._verify_finished(0, 0, False)
+
+    assert win.vf_plot._last_live_probe_values is None
+
+
 def test_window_simple_helpers(main_window) -> None:
     win = main_window
     assert win._workflow_running() is False

--- a/tests/test_ui_window_profile_methods.py
+++ b/tests/test_ui_window_profile_methods.py
@@ -176,6 +176,42 @@ def test_verify_profile_guards_and_runs(win) -> None:
     assert fake.started
 
 
+def test_verify_profile_shows_the_static_curve_being_verified(win) -> None:
+    window, monkeypatch = win
+    monkeypatch.setattr(actions_mod, "select_verify_options", lambda **k: {"duration_s": 60})
+    monkeypatch.setattr(actions_mod, "ensure_daemon_ready_for_privileged_action", lambda **_k: True)
+    monkeypatch.setattr(actions_mod, "profile_verify_command", lambda **k: ["echo", "verify"])
+    monkeypatch.setattr(actions_mod, "profile_base_curve_points", lambda profile: [(900, 2400)])
+    monkeypatch.setattr(
+        actions_mod,
+        "profile_curve_plan",
+        lambda profile: [{"index": 0, "voltage_mv": 900, "base_mhz": 2400, "target_mhz": 2500}],
+    )
+    window.verify_controller = _FakeController()
+
+    window._verify_profile(PROFILE)
+
+    assert window.vf_plot._source_points == [(900.0, 2400.0)]
+    assert window.vf_plot._candidate_points == [(900.0, 2500.0)]
+
+
+def test_verify_profile_without_a_curve_leaves_the_plot_untouched(win) -> None:
+    window, monkeypatch = win
+    monkeypatch.setattr(actions_mod, "select_verify_options", lambda **k: {"duration_s": 60})
+    monkeypatch.setattr(actions_mod, "ensure_daemon_ready_for_privileged_action", lambda **_k: True)
+    monkeypatch.setattr(actions_mod, "profile_verify_command", lambda **k: ["echo", "verify"])
+    monkeypatch.setattr(actions_mod, "profile_base_curve_points", lambda profile: [])
+    monkeypatch.setattr(actions_mod, "profile_curve_plan", lambda profile: [])
+    window.vf_plot.set_source_points([(800, 2000)])
+    window.vf_plot.set_candidate_points([(800, 2100)], remember_previous=False)
+    window.verify_controller = _FakeController()
+
+    window._verify_profile(PROFILE)
+
+    assert window.vf_plot._source_points == [(800.0, 2000.0)]
+    assert window.vf_plot._candidate_points == [(800.0, 2100.0)]
+
+
 def test_delete_selected_profiles(win) -> None:
     window, monkeypatch = win
     window.profile_summaries = [PROFILE]

--- a/ui/controllers/verify.py
+++ b/ui/controllers/verify.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 import os
 import signal
 
@@ -17,7 +18,9 @@ class VerifyController:
         self.target_duration_s = 0
         self.last_elapsed_s = 0.0
         self.stop_requested = False
+        self._buffer = ""
         self.on_output = lambda _text: None
+        self.on_telemetry = lambda _payload: None
         self.on_progress = lambda _percent, _elapsed_s, _target_s, _detail: None
         self.on_finished = lambda _exit_code, _exit_status, _stopped: None
 
@@ -31,6 +34,7 @@ class VerifyController:
         self.target_duration_s = max(1, int(duration_s))
         self.last_elapsed_s = 0.0
         self.stop_requested = False
+        self._buffer = ""
         self.stop_request_path.parent.mkdir(parents=True, exist_ok=True)
         self.stop_request_path.unlink(missing_ok=True)
         process = self.QtCore.QProcess(self.parent)
@@ -82,21 +86,54 @@ class VerifyController:
         )
         if not data:
             return
-        self.on_output(data)
-        for line in data.splitlines():
-            elapsed = elapsed_from_line(line)
-            if elapsed is None:
-                continue
-            self.last_elapsed_s = max(self.last_elapsed_s, elapsed)
-            self.on_progress(
-                progress_percent(self.last_elapsed_s, self.target_duration_s),
-                self.last_elapsed_s,
-                self.target_duration_s,
-                line.strip(),
-            )
+        # load_telemetry JSON lines are already rendered as a live plot marker,
+        # so keep them out of the human-visible log (mirrors ScanController).
+        self._buffer += data
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            self._handle_line(line)
+
+    def _handle_line(self, line: str) -> None:
+        stripped = line.strip()
+        if stripped.startswith("{"):
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                payload = None
+            if isinstance(payload, dict) and payload.get("event") == "load_telemetry":
+                self.on_telemetry(payload)
+                return
+        self.on_output(line + "\n")
+        elapsed = elapsed_from_line(line)
+        if elapsed is None:
+            return
+        self.last_elapsed_s = max(self.last_elapsed_s, elapsed)
+        self.on_progress(
+            progress_percent(self.last_elapsed_s, self.target_duration_s),
+            self.last_elapsed_s,
+            self.target_duration_s,
+            stripped,
+        )
 
     def _finished(self, exit_code, exit_status) -> None:
         process = self.process
+        # Drain anything still buffered in the pipe so a final trailing
+        # progress/telemetry line emitted just before exit is not lost.
+        if process is not None:
+            try:
+                tail = bytes(process.readAllStandardOutput()).decode(
+                    "utf-8", errors="replace"
+                )
+            except RuntimeError:
+                tail = ""
+            if tail:
+                self._buffer += tail
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            self._handle_line(line)
+        if self._buffer.strip():
+            self._handle_line(self._buffer)
+        self._buffer = ""
         stopped = bool(self.stop_requested)
         self.process = None
         self.stop_requested = False

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -15,6 +15,7 @@ from ui.commands import runtime_profile_command
 from ui.daemon_setup import ensure_daemon_ready_for_privileged_action
 from ui.components.fan_curve_editor import open_fan_curve_editor_dialog
 from ui.components.vf_curve_editor import open_vf_curve_editor_dialog
+from ui.features.curves.curve_profiles import curve_points_from_values
 from ui.features.curves.curve_profiles import profile_base_curve_points
 from ui.features.curves.curve_profiles import profile_curve_plan
 from ui.features.curves.curve_profiles import save_edited_curve_profile
@@ -328,6 +329,16 @@ class ProfileActionsMixin:
         self.header.set_candidate(label)
         self.controls.set_status_text(f"Verifying {label} with {workload}.")
         self.tabs.setCurrentIndex(self.auto_uv_tab_index)
+        # Verify tests an already-known curve rather than discovering one, so
+        # there's no live candidate-curve event stream to plot from — just
+        # show the static curve being verified instead of leaving the plot
+        # showing whatever it last had.
+        base_points = profile_base_curve_points(profile)
+        if base_points:
+            self.vf_plot.set_source_points(base_points)
+        candidate_points = curve_points_from_values(profile_curve_plan(profile))
+        if candidate_points:
+            self.vf_plot.set_candidate_points(candidate_points, remember_previous=False)
         self.controls.set_verify_progress(
             0,
             elapsed_s=0,

--- a/ui/window.py
+++ b/ui/window.py
@@ -99,6 +99,7 @@ class MainWindow(ProfileActionsMixin):
             stop_request_path=verify_stop_request_path(),
         )
         self.verify_controller.on_output = self.log_view.append
+        self.verify_controller.on_telemetry = self.vf_plot.set_live_load_marker
         self.verify_controller.on_progress = self.controls.set_verify_progress
         self.verify_controller.on_finished = self._verify_finished
         self._load_profiles()
@@ -709,6 +710,10 @@ class MainWindow(ProfileActionsMixin):
                     exit_code=exit_code,
                     exit_status=exit_status,
                 )
+        # The live GPU-position marker only means something while this
+        # profile's own verification is running; leaving it up afterward
+        # would misleadingly suggest it still reflects the current state.
+        self.vf_plot.clear_load_markers()
         self.controls.set_running(False)
         self._load_profiles()
 


### PR DESCRIPTION
## Summary
Two related additions to the "Verify" action on a saved profile — previously the Auto-UV tab's plot just sat unchanged for the whole run, giving no visual feedback that the test was even testing the right thing.

1. **Static curve.** Verify tests an already-known saved curve rather than discovering one, so there's no live candidate-curve event stream for it to plot from. Populate the plot once at verify-start from the profile's own base/candidate points (`profile_base_curve_points`/`profile_curve_plan`, already used elsewhere for the same profile), so there's something to look at besides the progress bar.

2. **Live GPU-position marker.** Verify already polls voltage/clock telemetry every tick for its own abort-on-drift logic (`profile_verification_voltage_abort_callback` in `profiles/verification/rules.py`), so this reuses that same data: `stability/q2rtx/output.py` gains `attach_stdout_telemetry_events()`, which prints a `load_telemetry` JSON line alongside the existing human-readable progress line (mirroring what a live Auto-UV scan already emits). `VerifyController` now buffers and routes stdout lines the same way `ScanController` does — keeping machine-readable JSON out of the human-visible log and dispatching it to a new `on_telemetry` callback instead, wired to `vf_plot.set_live_load_marker`. The marker is cleared when verification finishes, since it stops meaning anything once a different profile may be running.

No daemon/Rust changes needed — telemetry was already being collected, just not surfaced.

Live-tested on real hardware (RTX 5070 Ti): confirmed the curve renders at verify-start and the live marker tracks actual GPU telemetry during a real Q2RTX + CUDA stability run.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite passes with real PySide6/pyqtgraph/pytest-qt installed
- [x] `ruff check` / `vulture` / `pyright` on touched files — no new diagnostics beyond pre-existing repo-wide conventions (verified via before/after comparison against `origin/main` on every touched file)
- [x] New regression tests: `attach_stdout_telemetry_events` JSON emission (`tests/test_q2rtx_stability.py`), the runner wiring (`tests/test_auto_uv_profiles.py`), `VerifyController` JSON routing/log-filtering including a trailing-line-without-newline drain-on-finish case (`tests/test_ui_controllers.py`), and the window-level marker plot/clear wiring (`tests/test_ui_window.py`) — each confirmed to fail without its corresponding fix and pass with it
- [x] Live GUI + real GPU verification run, described above