### PR TITLE
Auto-UV: fix power-bound (RTX 5090-class) scans end to end

### DIFF
--- a/auto_uv/auto_oc/ladder.py
+++ b/auto_uv/auto_oc/ladder.py
@@ -38,6 +38,40 @@ def build_auto_oc_ladder(
     if start_voltage == endpoint_voltage and start_clock == endpoint_clock:
         return []
 
+    # Power-bound savings tiers have already found their lowest stable
+    # voltage. Reclaim the clock headroom created by that undervolt without
+    # walking voltage upward again.
+    if start_voltage == endpoint_voltage:
+        step_count = max(1, int(max_steps))
+        seen_clocks: set[int] = set()
+        steps: list[AutoOcStep] = []
+        for raw_index in range(1, step_count + 1):
+            ratio = float(raw_index) / float(step_count)
+            requested_clock_mhz = int(
+                round(
+                    float(start_clock)
+                    + (float(endpoint_clock - start_clock) * ratio)
+                )
+            )
+            target_mhz = bounded_clock(
+                requested_clock_mhz,
+                start_clock_mhz=start_clock,
+                endpoint_clock_mhz=endpoint_clock,
+                clock_step_mhz=int(clock_step_mhz),
+            )
+            if target_mhz <= start_clock or target_mhz in seen_clocks:
+                continue
+            seen_clocks.add(target_mhz)
+            steps.append(
+                AutoOcStep(
+                    index=len(steps) + 1,
+                    voltage_mv=int(start_voltage),
+                    target_mhz=int(target_mhz),
+                    ratio=ratio,
+                )
+            )
+        return steps
+
     voltages = [
         int(voltage)
         for voltage in sorted(editable_voltage_bins(base_curve))

--- a/auto_uv/auto_oc/search.py
+++ b/auto_uv/auto_oc/search.py
@@ -12,6 +12,7 @@ from auto_uv.domain.types import (
     VfCurveCandidate,
 )
 from auto_uv.curve.base_vf_curve_voltage_bins import editable_voltage_bins
+from auto_uv.curve.measured_probe_lock_clock import probe_indicates_power_saturation
 from auto_uv.curve.flattened_voltage_probe_curve import build_flattened_voltage_probe_curve
 from auto_uv.curve.rising_tail import tail_ceiling_clock_mhz
 from auto_uv.scan_mode.uv_limits import UvTierTarget, uv_limit_profile_target_for_gpu
@@ -22,6 +23,11 @@ from .settings import (
     AUTO_OC_DEFAULT_MAX_INTERPOLATION_STEPS,
     AUTO_OC_TARGET_PROFILE_ID,
 )
+
+# A stable rung whose measured clock trails its requested lock by more than
+# this while the probe is power-saturated is wall-limited, not capability:
+# 1.5 driver clock steps absorbs bin snapping and telemetry averaging noise.
+AUTO_OC_WALL_SHORTFALL_TOLERANCE_MHZ = 22.5
 
 
 class AutoOcProbeRunner(Protocol):
@@ -113,6 +119,7 @@ def run_auto_oc_candidate_search(
     attempts: list[AutoOcAttempt] = []
     failed_voltage_floor_mv: int | None = None
     consumed_voltage_floor_mv: int | None = None
+    power_wall_reached = False
 
     def probe_step(step: AutoOcStep, *, action: str) -> tuple[VfCurveCandidate, VoltageProbeOutcome]:
         candidate = auto_oc_candidate(
@@ -154,8 +161,31 @@ def run_auto_oc_candidate_search(
         step: AutoOcStep,
         outcome: VoltageProbeOutcome,
     ) -> bool:
-        nonlocal selected_candidate, selected_probe, selected_key
+        nonlocal selected_candidate, selected_probe, selected_key, power_wall_reached
         if outcome.decision.passed and outcome.raw_probe is not None:
+            measured_clock = effective_q2rtx_clock_mhz(outcome.raw_probe)
+            if (
+                measured_clock is not None
+                and float(candidate.target_mhz) - float(measured_clock)
+                > AUTO_OC_WALL_SHORTFALL_TOLERANCE_MHZ
+                and probe_indicates_power_saturation(
+                    outcome.raw_probe,
+                    power_limit_w=getattr(runner, "power_limit_w", None),
+                )
+            ):
+                # The rung is stable but its measured clock is set by the
+                # board-power wall, not by the requested lock. Adopting it
+                # would ship a lock target the cap cannot deliver, and every
+                # higher rung would measure the same wall — the climb is over.
+                power_wall_reached = True
+                log_phase(
+                    log,
+                    "auto-oc",
+                    "power-walled rung not adopted "
+                    f"requested={int(candidate.target_mhz)}MHz "
+                    f"measured={_format_clock(measured_clock)}",
+                )
+                return True
             candidate_key = auto_oc_probe_key(
                 outcome.raw_probe,
                 voltage_mv=int(candidate.voltage_mv),
@@ -210,6 +240,14 @@ def run_auto_oc_candidate_search(
             )
         if auto_oc_should_stop(outcome):
             log_phase(log, "auto-oc", f"stop critical={outcome.decision.reason}")
+            break
+        if power_wall_reached:
+            log_phase(
+                log,
+                "auto-oc",
+                "stop power-wall reached; higher rungs cannot raise a "
+                "capped clock",
+            )
             break
         if passed:
             continue

--- a/auto_uv/auto_oc/search.py
+++ b/auto_uv/auto_oc/search.py
@@ -62,11 +62,14 @@ def run_auto_oc_candidate_search(
     target_voltage_mv: int | None = None,
     target_clock_mhz: int | None = None,
     measured_baseline_clock_mhz: float | int | None = None,
+    target_profile_id: str = AUTO_OC_TARGET_PROFILE_ID,
+    probe_stable_history: list[AutoUvProbeSummary] | None = None,
 ) -> AutoOcSearchResult:
     endpoint = auto_oc_endpoint(
         gpu_name,
         target_voltage_mv=target_voltage_mv,
         target_clock_mhz=target_clock_mhz,
+        target_profile_id=str(target_profile_id),
     )
     if endpoint is None:
         return _skip(start_candidate, start_probe, "no-auto-oc-target")
@@ -134,7 +137,7 @@ def run_auto_oc_candidate_search(
         )
         outcome = runner.probe_candidate(
             candidate,
-            stable_history=[],
+            stable_history=list(probe_stable_history or []),
             phase_label="candidate",
             enforce_target_core_clock_floor=False,
             summarize_saturated_tail=False,
@@ -274,8 +277,9 @@ def auto_oc_endpoint(
     *,
     target_voltage_mv: int | None = None,
     target_clock_mhz: int | None = None,
+    target_profile_id: str = AUTO_OC_TARGET_PROFILE_ID,
 ) -> UvTierTarget | None:
-    table_target = uv_limit_profile_target_for_gpu(gpu_name, AUTO_OC_TARGET_PROFILE_ID)
+    table_target = uv_limit_profile_target_for_gpu(gpu_name, target_profile_id)
     voltage_mv = positive_int(target_voltage_mv)
     clock_mhz = positive_int(target_clock_mhz)
     if table_target is None:

--- a/auto_uv/curve/measured_probe_lock_clock.py
+++ b/auto_uv/curve/measured_probe_lock_clock.py
@@ -9,11 +9,40 @@ def lock_clock_from_probe_loaded_clock(
     *,
     probe: AutoUvProbeSummary,
     previous_lock_clock_mhz: int,
+    power_limit_w: int | None = None,
+    power_saturation_headroom_pct: float = 2.0,
 ) -> int:
     if probe.avg_core_clock_mhz is None:
+        return int(previous_lock_clock_mhz)
+    if probe_indicates_power_saturation(
+        probe,
+        power_limit_w=power_limit_w,
+        power_saturation_headroom_pct=float(power_saturation_headroom_pct),
+    ):
+        # A power governor may hold the loaded clock below the curve target.
+        # That proves an operated point under the cap; it is not evidence that
+        # the requested V/F target itself needs to be ratcheted downward.
         return int(previous_lock_clock_mhz)
     measured_lock_clock_mhz = choose_sustained_curve_clock(
         base_curve,
         float(probe.avg_core_clock_mhz),
     )
     return min(int(previous_lock_clock_mhz), int(measured_lock_clock_mhz))
+
+
+def probe_indicates_power_saturation(
+    probe: AutoUvProbeSummary,
+    *,
+    power_limit_w: int | None,
+    power_saturation_headroom_pct: float = 2.0,
+) -> bool:
+    perf_cap_reason = str(getattr(probe, "perf_cap_reason", "") or "").lower()
+    if any("power" in token for token in perf_cap_reason.replace(",", "+").split("+")):
+        return True
+    avg_power_w = getattr(probe, "avg_power_w", None)
+    if avg_power_w is None or power_limit_w is None or int(power_limit_w) <= 0:
+        return False
+    saturation_floor_w = float(power_limit_w) * (
+        1.0 - max(0.0, float(power_saturation_headroom_pct)) / 100.0
+    )
+    return float(avg_power_w) >= float(saturation_floor_w)

--- a/auto_uv/curve/shipped_plan.py
+++ b/auto_uv/curve/shipped_plan.py
@@ -1,25 +1,45 @@
-"""Sanitize a final plan so only scan-validated points ship.
+"""Sanitize a final plan so only scan-validated curve geometry ships.
 
 The scan's probe curves shape bins below the candidate for load saturation
 (the baseline flatten floor and soft decay). Those shapes are scan machinery,
 not validated operating points — a real game dips through them on every load
 transition. Below the lowest voltage the current scan actually probed, the
-shipped profile must run the stock curve (2026-07-13: shipping the probe
-debris and archive-envelope points there crashed fullscreen Q2RTX repeatedly
-while every synthetic soak passed, because the soak pins at the lock voltage
-and never operates the mid-ramp).
+shipped profile must remain at or below the stock curve (2026-07-13: shipping
+raised probe debris and archive-envelope points there crashed fullscreen Q2RTX
+repeatedly while every synthetic soak passed, because the soak pins at the
+lock voltage and never operates the mid-ramp).
+
+Raw stock is not always safe curve *geometry*, though. On steep Blackwell
+curves stock immediately below the validated floor can exceed the selected
+lock clock, creating a downward V/F edge at the lock. Clamp those restored
+points to the same one-clock-step-below-lock ceiling used by probe curves.
 """
 
 from __future__ import annotations
+
+from auto_uv.domain.types import AutoUvError
 
 
 def restore_stock_below_validated_floor(
     plan: list[dict],
     *,
     floor_voltage_mv: int,
+    lock_clock_mhz: int,
+    below_lock_gap_mhz: int = 15,
 ) -> list[dict]:
-    """Return the plan with every editable bin below the floor at stock."""
+    """Restore safe stock geometry below the floor without a lock-edge cliff.
+
+    Every rewritten target is at most its stock clock and at least one clock
+    step below the selected lock. The result is rejected if the complete
+    editable curve is still non-monotonic; silently raising a point would ship
+    unverified frequency, while silently lowering a validated point would no
+    longer be the plan that passed its probe.
+    """
     floor = int(floor_voltage_mv)
+    below_lock_cap_mhz = max(
+        0,
+        int(lock_clock_mhz) - max(1, int(below_lock_gap_mhz)),
+    )
     shipped: list[dict] = []
     for point in plan:
         new_point = dict(point)
@@ -30,10 +50,32 @@ def restore_stock_below_validated_floor(
             shipped.append(new_point)
             continue
         if not point.get("preserve_base") and voltage_mv < floor:
-            new_point["target_mhz"] = base_mhz
-            new_point["new_offset_mhz"] = 0
+            target_mhz = min(int(base_mhz), int(below_lock_cap_mhz))
+            new_point["target_mhz"] = int(target_mhz)
+            new_point["new_offset_mhz"] = int(target_mhz) - int(base_mhz)
         shipped.append(new_point)
+    assert_monotonic_editable_targets(shipped)
     return shipped
+
+
+def assert_monotonic_editable_targets(plan: list[dict]) -> None:
+    """Reject a shipped editable V/F curve that falls as voltage rises."""
+    points: list[tuple[int, int]] = []
+    for point in plan:
+        if point.get("preserve_base"):
+            continue
+        try:
+            points.append((int(point["voltage_mv"]), int(point["target_mhz"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    points.sort(key=lambda item: item[0])
+    for previous, current in zip(points, points[1:]):
+        if int(current[1]) < int(previous[1]):
+            raise AutoUvError(
+                "refusing to ship non-monotonic V/F curve: "
+                f"{int(previous[0])}mV@{int(previous[1])}MHz -> "
+                f"{int(current[0])}mV@{int(current[1])}MHz"
+            )
 
 
 def validated_floor_voltage_mv(

--- a/auto_uv/domain/types.py
+++ b/auto_uv/domain/types.py
@@ -15,6 +15,10 @@ class AutoUvError(RuntimeError):
     pass
 
 
+class AutoUvPowerLimitApplyError(AutoUvError):
+    """The requested scan power regime could not be established reliably."""
+
+
 class AutoUvFinalChoiceDiscarded(RuntimeError):
     pass
 

--- a/auto_uv/final_verification/main_loop.py
+++ b/auto_uv/final_verification/main_loop.py
@@ -19,6 +19,7 @@ from auto_uv.domain.types import (
     VfCurveCandidate,
 )
 from ..curve.rising_tail import tail_ceiling_clock_mhz
+from ..shared.positive_int import positive_int
 from auto_uv.probes.stability_decision import (
     StabilityThresholds,
     evaluate_stable_run,
@@ -212,6 +213,9 @@ def run_final_verification_and_save(
         probe=final_probe,
         base_probe=discovery_summary,
         tail_rise_bins=int(tail_rise_bins),
+        configured_power_limit_w=positive_int(
+            gpu_policy.get("power_limit_w")
+        ),
     )
     final_status = f"completed {format_user_duration(final_verification_duration_s)} long check"
 

--- a/auto_uv/gpu/gpu_vf_curve_applier.py
+++ b/auto_uv/gpu/gpu_vf_curve_applier.py
@@ -13,7 +13,7 @@ from drivers.nvidia.nvml_gpu_policy import fixed_power_limit_excluded_by_identit
 from runtime.support.vf_curve_plan import apply_plan
 from runtime.support.nvidia_runtime_defaults import reset_nvidia_runtime_defaults
 
-from auto_uv.domain.types import AutoUvError
+from auto_uv.domain.types import AutoUvError, AutoUvPowerLimitApplyError
 from auto_uv.scan_mode.auto_uv_mode import (
     ADAPTIVE_TIER_MODES,
     adaptive_tier_option_key,
@@ -78,7 +78,12 @@ class LiveGpuVfCurveApplier:
             clamped = min(clamped, int(self.max_power_limit_w))
         return clamped
 
-    def apply_requested_power_limit(self, *, log: Callable[[str], None]) -> int | None:
+    def apply_requested_power_limit(
+        self,
+        *,
+        log: Callable[[str], None],
+        purpose: str = "final verification",
+    ) -> int | None:
         requested_w = _positive_power_limit_w(self.requested_power_limit_w)
         if requested_w is None:
             return self.power_limit_w
@@ -89,7 +94,8 @@ class LiveGpuVfCurveApplier:
             self.requested_power_limit_w = None
             self.translated_gpu_policy.pop("power_limit_w", None)
             log(
-                "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+                "Auto-UV power limit: skipped fixed write for "
+                f"{str(purpose)} on mobile GPU; "
                 "continuing without saved power limit"
             )
             return None
@@ -103,23 +109,36 @@ class LiveGpuVfCurveApplier:
             )
         except Exception as exc:
             self.requested_power_limit_w = None
-            self.translated_gpu_policy.pop("power_limit_w", None)
-            log(
-                "Auto-UV power limit: unable to apply "
-                f"{int(requested_w)}W for final verification; "
-                "continuing without saved power limit: "
-                f"{exc}"
+            raise AutoUvPowerLimitApplyError(
+                "Auto-UV power limit: unable to establish "
+                f"{int(requested_w)}W for {str(purpose)}; scan stopped before "
+                f"probing under an unknown power regime: {exc}"
+            ) from exc
+        try:
+            verified_power_limit_w = verify_applied_power_limit_w(
+                self.policy_controller,
+                requested_w=int(requested_w),
+                reported_applied_w=int(applied_power_limit_w),
             )
-            return None
-        self.translated_gpu_policy["power_limit_w"] = int(applied_power_limit_w)
+        except AutoUvPowerLimitApplyError:
+            self.requested_power_limit_w = None
+            raise
+        except Exception as exc:
+            self.requested_power_limit_w = None
+            raise AutoUvPowerLimitApplyError(
+                "Auto-UV power limit: unable to read back "
+                f"{int(requested_w)}W for {str(purpose)}; scan stopped before "
+                f"probing under an unknown power regime: {exc}"
+            ) from exc
+        self.translated_gpu_policy["power_limit_w"] = int(verified_power_limit_w)
         # Consume the request so a subsequent tier's apply starts clean and
         # never mistakes this tier's applied cap for a fresh scan-wide one.
         self.requested_power_limit_w = None
         log(
             "Auto-UV power limit: applied "
-            f"{int(applied_power_limit_w)}W for final verification"
+            f"{int(verified_power_limit_w)}W for {str(purpose)}"
         )
-        return int(applied_power_limit_w)
+        return int(verified_power_limit_w)
 
     def close(self) -> None:
         if self.clock_ceiling is not None:
@@ -184,32 +203,34 @@ def open_live_gpu_vf_curve_applier(
             "continuing without saved power limit"
         )
         requested_power_limit_w = None
-    elif requested_power_limit_w is not None and (
-        baseline_power_limit_w is None
-        or int(requested_power_limit_w) >= int(baseline_power_limit_w)
-    ):
+    elif requested_power_limit_w is not None:
+        if min_power_limit_w is not None:
+            requested_power_limit_w = max(
+                int(requested_power_limit_w), int(min_power_limit_w)
+            )
+        if max_power_limit_w is not None:
+            requested_power_limit_w = min(
+                int(requested_power_limit_w), int(max_power_limit_w)
+            )
         try:
             applied_power_limit_w = gpu.apply_power_limit_w(
                 int(requested_power_limit_w)
             )
-        except Exception as exc:
-            translated_gpu_policy.pop("power_limit_w", None)
-            log(
-                "Auto-UV power limit: unable to apply "
-                f"{int(requested_power_limit_w)}W; "
-                "continuing without saved power limit: "
-                f"{exc}"
+            verified_power_limit_w = verify_applied_power_limit_w(
+                gpu,
+                requested_w=int(requested_power_limit_w),
+                reported_applied_w=int(applied_power_limit_w),
             )
-            requested_power_limit_w = None
-            applied_power_limit_w = None
-        if applied_power_limit_w is not None:
-            translated_gpu_policy["power_limit_w"] = int(applied_power_limit_w)
-            log(f"Auto-UV power limit: applied {int(applied_power_limit_w)}W")
-    elif requested_power_limit_w is not None and baseline_power_limit_w is not None:
+        except Exception as exc:
+            raise AutoUvPowerLimitApplyError(
+                "Auto-UV power limit: unable to establish "
+                f"{int(requested_power_limit_w)}W for discovery and sweep; "
+                f"scan stopped before probing: {exc}"
+            ) from exc
+        translated_gpu_policy["power_limit_w"] = int(verified_power_limit_w)
         log(
-            "Auto-UV power limit: keeping "
-            f"{int(baseline_power_limit_w)}W for discovery/sweep; "
-            f"will apply {int(requested_power_limit_w)}W for final verification"
+            "Auto-UV power limit: applied "
+            f"{int(verified_power_limit_w)}W for discovery and sweep"
         )
 
     memory_offset_mhz, memory_offset_limit_mhz = auto_uv_memory_offset_mhz(
@@ -271,10 +292,10 @@ def _auto_uv_power_limit_w(runtime_options: dict) -> int | None:
     value = runtime_options.get("auto_uv_power_limit_w")
     if value in (None, ""):
         # Full scans carry per-tier power limits instead of the scan-wide
-        # key. The HIGHEST tier request stands in as the scan-wide request so
-        # a raised cap (above the stock default) holds during the shared
-        # discovery and the descents, like the old single slider did; each
-        # tier's own (lower) cap still applies at its final verification.
+        # key. The highest tier request establishes the startup regime before
+        # adaptive orchestration begins. Each tier then applies and reads back
+        # its own exact cap before its stock baseline, flattened baseline,
+        # descent, selection, and final verification.
         tier_values = [
             runtime_options.get(adaptive_tier_option_key(tier, "power_limit_w"))
             for tier in ADAPTIVE_TIER_MODES
@@ -298,3 +319,41 @@ def _positive_power_limit_w(value: object) -> int | None:
     except (TypeError, ValueError):
         return None
     return power_limit_w if power_limit_w > 0 else None
+
+
+def verify_applied_power_limit_w(
+    policy_controller,
+    *,
+    requested_w: int,
+    reported_applied_w: int,
+) -> int:
+    """Confirm the daemon's applied result against live capabilities when available."""
+    requested = int(requested_w)
+    reported = int(reported_applied_w)
+    capabilities = getattr(policy_controller, "capabilities", None)
+    if not callable(capabilities):
+        if reported != requested:
+            raise AutoUvPowerLimitApplyError(
+                f"daemon reported {reported}W after requesting {requested}W"
+            )
+        return reported
+    live = capabilities(refresh=True)
+    power = getattr(live, "power", None)
+    readbacks = (
+        getattr(power, "current_w", None),
+        getattr(power, "enforced_w", None),
+    )
+    confirmed = [
+        int(round(float(value)))
+        for value in readbacks
+        if value is not None
+        and abs(float(value) - float(requested)) <= 1.0
+    ]
+    if not confirmed:
+        current_w, enforced_w = readbacks
+        raise AutoUvPowerLimitApplyError(
+            "power-limit read-back mismatch after requesting "
+            f"{requested}W: current={current_w!r} enforced={enforced_w!r} "
+            f"daemon-reported={reported}W"
+        )
+    return requested

--- a/auto_uv/main_loop.py
+++ b/auto_uv/main_loop.py
@@ -408,6 +408,7 @@ def run_voltage_frequency_undervolt_main_loop(
             stable_probe,
             discovery_summary=discovery_summary,
             tail_rise_bins=int(tail_rise_bins),
+            configured_power_limit_w=positive_int(gpu.power_limit_w),
         )
         log_user_stage(
             log,
@@ -491,6 +492,7 @@ def run_voltage_frequency_undervolt_main_loop(
                 summary,
                 discovery_summary=discovery_summary,
                 tail_rise_bins=int(descent_tail_rise_bins),
+                configured_power_limit_w=positive_int(gpu.power_limit_w),
             )
 
         def record_passed_candidate(
@@ -716,6 +718,9 @@ def run_voltage_frequency_undervolt_main_loop(
                             tier_stable_probe,
                             discovery_summary=tier_discovery_summary,
                             tail_rise_bins=int(tier_tail_rise_bins),
+                            configured_power_limit_w=positive_int(
+                                gpu.power_limit_w
+                            ),
                         )
                         tier_min_search_voltage_mv = min_search_voltage_mv(
                             start_voltage_mv=int(tier_baseline_candidate.voltage_mv),
@@ -1407,6 +1412,7 @@ def run_adaptive_tier_descent(
             candidate,
             summary,
             discovery_summary=discovery_summary,
+            configured_power_limit_w=positive_int(gpu.power_limit_w),
             tail_rise_bins=int(
                 candidate.metadata.get("tail_rise_bins", tier_descent_tail)
             ),
@@ -2127,6 +2133,28 @@ def run_recovered_previous_crash_selection(
         settings,
         tail_rise_bins=int(recovery_tail_rise_bins),
     )
+    # Re-establish the board-power regime the candidate was measured under.
+    # The verified-candidate pool is regime-heterogeneous (per-tier caps), so
+    # resuming under whatever limit the fresh scan-open applied could
+    # re-verify and save this candidate in a regime it never ran in. Records
+    # from before this field resume under the current limit, logged.
+    recorded_power_limit_w = positive_int(
+        recovery_record.get("configured_power_limit_w")
+    )
+    if recorded_power_limit_w is None:
+        log_phase(
+            log,
+            "crash-recovery",
+            "saved candidate carries no recorded power limit; resuming under "
+            f"the current {_format_power_limit_w(gpu.power_limit_w)} limit",
+        )
+    elif recorded_power_limit_w != positive_int(gpu.power_limit_w):
+        gpu.requested_power_limit_w = int(recorded_power_limit_w)
+        apply_pending_power_limit(
+            gpu,
+            log=log,
+            purpose="crash-recovery regime",
+        )
     runner = AutoUvProbeRunner(
         reader=gpu.reader,
         live_voltage_reader=gpu.live_voltage_reader,

--- a/auto_uv/main_loop.py
+++ b/auto_uv/main_loop.py
@@ -16,8 +16,10 @@ from stability.q2rtx.process_harness import cleanup_managed_q2rtx_processes
 from auto_uv.domain.types import (
     AutoUvError,
     AutoUvFinalChoiceDiscarded,
+    AutoUvPowerLimitApplyError,
     AutoUvProbeSummary,
     AutoUvVoltageScanResult,
+    BaseLoadTarget,
     VfCurveCandidate,
 )
 from auto_uv.domain.scan_settings import AutoUvScanSettings
@@ -32,6 +34,7 @@ from auto_uv.run.baseline_probe import (
     require_probe_summary,
     retarget_clock_ceiling_for_candidate,
     run_discovery_probe,
+    run_discovery_probe_with_runner,
     write_verified_candidate,
 )
 from auto_uv.run.crash_recovery import (
@@ -64,7 +67,11 @@ from auto_uv.balanced_uv_loop import run_balanced_uv_loop
 from auto_uv.efficiency_uv_loop import run_efficiency_uv_loop
 from auto_uv.performance_uv_loop import (
     run_performance_uv_loop,
+    select_power_bound_clock_reclaim_candidate,
     select_performance_auto_oc_candidate,
+)
+from auto_uv.curve.measured_probe_lock_clock import (
+    probe_indicates_power_saturation,
 )
 from auto_uv.probes.runner import AutoUvProbeRunner
 from auto_uv.probes.runtime_guardrails import (
@@ -122,6 +129,17 @@ class FinalScanCandidate:
     verification_duration_s: int
     auto_oc_metadata: dict
     tail_rise_bins: int
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptiveTierBaseline:
+    runner: AutoUvProbeRunner
+    candidate: VfCurveCandidate
+    target: BaseLoadTarget
+    outcome: VoltageProbeOutcome
+    stable_probe: AutoUvProbeSummary
+    discovery_summary: AutoUvProbeSummary
+    min_search_voltage_mv: int
 
 
 def run_voltage_frequency_undervolt_main_loop(
@@ -505,8 +523,32 @@ def run_voltage_frequency_undervolt_main_loop(
             # scan-wide one; None keeps the scan-wide settings values.
             final_min_core_clock_pct: float | None = None,
             final_clock_drop_margin_pct: float | None = None,
+            final_stable_history: list[AutoUvProbeSummary] | None = None,
+            final_discovery_summary: AutoUvProbeSummary | None = None,
+            final_baseline_candidate: VfCurveCandidate | None = None,
+            final_measured_baseline_clock_mhz: float | None = None,
         ):
-            apply_requested_power_limit_for_final_verification(gpu, log=log)
+            apply_pending_power_limit(gpu, log=log)
+            selected_stable_history = (
+                final_stable_history
+                if final_stable_history is not None
+                else stable_history
+            )
+            selected_discovery_summary = (
+                final_discovery_summary
+                if final_discovery_summary is not None
+                else discovery_summary
+            )
+            selected_baseline_candidate = (
+                final_baseline_candidate
+                if final_baseline_candidate is not None
+                else baseline_candidate
+            )
+            selected_measured_baseline_clock_mhz = (
+                float(final_measured_baseline_clock_mhz)
+                if final_measured_baseline_clock_mhz is not None
+                else float(baseline_target.measured_clock_mhz)
+            )
             return run_final_verification_and_save(
                 probe_voltage_candidate=probe_voltage_candidate,
                 build_voltage_scan_result=build_voltage_scan_result,
@@ -516,17 +558,17 @@ def run_voltage_frequency_undervolt_main_loop(
                 stable_voltage_mv=int(final_stable_voltage_mv),
                 stable_lock_clock_mhz=int(final_stable_lock_clock_mhz),
                 stable_probe=final_stable_probe,
-                stable_history=stable_history,
+                stable_history=selected_stable_history,
                 probe_history=probe_history,
                 q2rtx_config=q2rtx_config,
                 final_verification_duration_s=int(
                     selected_final_verification_duration_s
                 ),
-                start_voltage_mv=int(baseline_candidate.voltage_mv),
-                measured_clock_mhz=float(baseline_target.measured_clock_mhz),
+                start_voltage_mv=int(selected_baseline_candidate.voltage_mv),
+                measured_clock_mhz=float(selected_measured_baseline_clock_mhz),
                 nvml_session=gpu.live_voltage_reader,
                 clock_ceiling=gpu.clock_ceiling,
-                discovery_summary=discovery_summary,
+                discovery_summary=selected_discovery_summary,
                 translated_gpu_policy=gpu.translated_gpu_policy,
                 min_performance_core_clock_pct=float(
                     final_min_core_clock_pct
@@ -594,11 +636,112 @@ def run_voltage_frequency_undervolt_main_loop(
                         nonlocal runner
                         runner = replace(
                             runner,
+                            power_limit_w=positive_int(gpu.power_limit_w),
                             min_performance_core_clock_pct=float(
                                 min_core_clock_pct
                             ),
                         )
                         return runner
+
+                    def prepare_tier_baseline(
+                        *,
+                        tier_mode: str,
+                        tier_runner: AutoUvProbeRunner,
+                        tier_tail_rise_bins: int,
+                    ) -> AdaptiveTierBaseline:
+                        # A stock baseline must not inherit the dynamic core
+                        # ceiling from the previous flattened candidate.
+                        if gpu.clock_ceiling is not None:
+                            gpu.clock_ceiling.close()
+                        tier_discovery_summary, tier_discovery_result = (
+                            run_discovery_probe_with_runner(
+                                base_curve,
+                                runner=tier_runner,
+                                log=log,
+                                event_callback=event_callback,
+                                label=f"{str(tier_mode)} stock curve",
+                            )
+                        )
+                        probe_history.append(tier_discovery_summary)
+                        if not bool(getattr(tier_discovery_result, "success", False)):
+                            raise AutoUvError(
+                                f"adaptive {str(tier_mode)} stock baseline failed "
+                                "the Q2RTX probe: "
+                                f"{getattr(tier_discovery_result, 'reason', 'unknown')}"
+                            )
+                        tier_baseline_candidate, tier_baseline_target = (
+                            build_loaded_baseline_candidate(
+                                base_curve,
+                                discovery_summary=tier_discovery_summary,
+                                discovery_result=tier_discovery_result,
+                                power_limit_w=positive_int(gpu.power_limit_w),
+                                tail_rise_bins=int(tier_tail_rise_bins),
+                            )
+                        )
+                        retarget_clock_ceiling_for_candidate(
+                            gpu.clock_ceiling,
+                            tier_baseline_candidate,
+                        )
+                        tier_runner = replace(
+                            tier_runner,
+                            power_limit_w=positive_int(gpu.power_limit_w),
+                            start_voltage_mv=int(tier_baseline_candidate.voltage_mv),
+                            baseline_clock_mhz=float(
+                                tier_baseline_target.measured_clock_mhz
+                            ),
+                        )
+                        tier_baseline_outcome = tier_runner.probe_baseline_candidate(
+                            tier_baseline_candidate
+                        )
+                        if tier_baseline_outcome.raw_probe is not None:
+                            probe_history.append(tier_baseline_outcome.raw_probe)
+                        if not tier_baseline_outcome.decision.passed:
+                            raise AutoUvError(
+                                f"adaptive {str(tier_mode)} flattened baseline "
+                                "failed the Q2RTX probe: "
+                                f"{tier_baseline_outcome.decision.reason}"
+                            )
+                        tier_stable_probe = require_probe_summary(
+                            tier_baseline_outcome
+                        )
+                        tier_baseline_candidate = adjust_baseline_to_measured_clock(
+                            base_curve,
+                            candidate=tier_baseline_candidate,
+                            stable_probe=tier_stable_probe,
+                            gpu=gpu,
+                            tail_rise_bins=int(tier_tail_rise_bins),
+                        )
+                        write_verified_candidate(
+                            tier_baseline_candidate,
+                            tier_stable_probe,
+                            discovery_summary=tier_discovery_summary,
+                            tail_rise_bins=int(tier_tail_rise_bins),
+                        )
+                        tier_min_search_voltage_mv = min_search_voltage_mv(
+                            start_voltage_mv=int(tier_baseline_candidate.voltage_mv),
+                            configured_min_voltage_mv=settings.configured_min_voltage_mv,
+                            configured_max_drop_pct=float(
+                                settings.configured_max_drop_pct
+                            ),
+                            gpu_name=gpu.translated_gpu_policy.get("gpu_name"),
+                        )
+                        log_phase(
+                            log,
+                            "auto-uv",
+                            f"adaptive {str(tier_mode)} capped baseline accepted "
+                            f"{int(tier_baseline_candidate.voltage_mv)}mV@"
+                            f"{int(tier_baseline_candidate.target_mhz)}MHz "
+                            f"power-limit={_format_power_limit_w(gpu.power_limit_w)}",
+                        )
+                        return AdaptiveTierBaseline(
+                            runner=tier_runner,
+                            candidate=tier_baseline_candidate,
+                            target=tier_baseline_target,
+                            outcome=tier_baseline_outcome,
+                            stable_probe=tier_stable_probe,
+                            discovery_summary=tier_discovery_summary,
+                            min_search_voltage_mv=int(tier_min_search_voltage_mv),
+                        )
 
                     return run_adaptive_tier_scans(
                         base_curve=base_curve,
@@ -617,7 +760,7 @@ def run_voltage_frequency_undervolt_main_loop(
                             effective_min_search_voltage_mv
                         ),
                         unsafe_entries=unsafe_entries,
-                        probe_candidate=probe_candidate,
+                        prepare_tier_baseline=prepare_tier_baseline,
                         finish_with_final_verification=finish_with_final_verification,
                         event_callback=event_callback,
                         log=log,
@@ -808,10 +951,12 @@ def run_adaptive_tier_scans(
     baseline_target,
     effective_min_search_voltage_mv: int,
     unsafe_entries: list[dict] | None,
-    probe_candidate: Callable[[VfCurveCandidate], VoltageProbeOutcome],
     finish_with_final_verification: Callable[..., AutoUvVoltageScanResult],
     event_callback: AutoUvEventCallback | None,
     log: Callable[[str], None],
+    prepare_tier_baseline: (
+        Callable[..., AdaptiveTierBaseline] | None
+    ) = None,
 ) -> AutoUvVoltageScanResult:
     """One scan, three profiles: run the proven per-tier descent for each tier.
 
@@ -819,11 +964,13 @@ def run_adaptive_tier_scans(
     rising tail compounds through the measured-clock ratchet, so each tier
     must descend with its OWN tail (efficiency +2 tail-tune to the floor,
     balanced +4 to the FPS/W wall, performance +4 then the Auto-OC climb).
-    Because balanced and performance descend with the same tail, performance
-    reuses the balanced descent when their inputs match (see
+    Each tier first establishes its own stock and flattened baselines under
+    the exact power/memory policy that profile will save. Because Balanced
+    and Performance descend with the same tail, Performance can reuse the
+    Balanced descent only when those policy inputs also match (see
     performance_can_reuse_balanced_descent) and runs only its Auto-OC climb.
-    The tiers share this one baseline and accumulate genuinely-unsafe voltages
-    so a later tier never re-crashes a point an earlier tier condemned. The
+    The tiers accumulate genuinely-unsafe voltages so a later tier never
+    re-crashes a point an earlier tier condemned. The
     first verified (deepest) profile soaks the full final duration; shallower
     tiers get the graduated confirm. Raises on producing no profile at all.
     """
@@ -832,11 +979,39 @@ def run_adaptive_tier_scans(
     any_tier_discarded = False
     balanced_donation: BalancedDescentDonation | None = None
     accumulated_unsafe: list[dict] = list(unsafe_entries or [])
-    stock_power_limit_w = positive_int(gpu.power_limit_w)
+
+    def record_tier_failure(
+        *,
+        tier_mode: str,
+        tier_error: AutoUvError,
+        stage: str,
+        event_details: dict,
+    ) -> None:
+        nonlocal last_tier_error, balanced_donation
+        last_tier_error = tier_error
+        if tier_mode == AUTO_UV_MODE_BALANCED:
+            balanced_donation = None
+        log_phase(
+            log,
+            "auto-uv",
+            f"adaptive {tier_mode} {stage} failed: {tier_error}; "
+            "continuing with the remaining tiers",
+        )
+        emit_auto_uv_event(
+            event_callback,
+            "tier_skipped",
+            **event_details,
+            reason=f"{stage}-failed",
+        )
+    stock_power_limit_w = positive_int(
+        getattr(gpu, "baseline_power_limit_w", None)
+    ) or positive_int(gpu.power_limit_w)
     # The original scan-wide power request (a manual slider, or None from a
     # plain CLI run) — captured once so each tier scales from it, never from
     # the previous tier's applied cap.
-    scan_power_limit_request_w = positive_int(gpu.requested_power_limit_w)
+    scan_power_limit_request_w = positive_int(
+        runtime_options.get("auto_uv_power_limit_w")
+    )
     balanced_power_limit_pct = uv_limit_power_limit_pct_for_gpu(
         gpu.translated_gpu_policy.get("gpu_name"),
         AUTO_UV_MODE_BALANCED,
@@ -873,7 +1048,6 @@ def run_adaptive_tier_scans(
             gpu_name=gpu_name,
         )
         tier_min_core_clock_pct = max(0.0, 100.0 - tier_clock_drop_margin_pct)
-        tier_runner = configure_tier_probe_runner(tier_min_core_clock_pct)
         log_phase(
             log,
             "auto-uv",
@@ -892,79 +1066,9 @@ def run_adaptive_tier_scans(
         tier_memory_offset_mhz = (
             memory_offset_from_gpu_policy(gpu.translated_gpu_policy) or 0
         )
-        if (
-            tier_mode == AUTO_UV_MODE_PERFORMANCE
-            and balanced_donation is not None
-            and performance_can_reuse_balanced_descent(
-                balanced_donation,
-                performance_memory_offset_mhz=tier_memory_offset_mhz,
-                performance_min_core_clock_pct=float(tier_min_core_clock_pct),
-                measured_baseline_clock_mhz=float(
-                    baseline_target.measured_clock_mhz
-                ),
-                log=log,
-            )
-        ):
-            donation = balanced_donation
-            # The descent would re-measure the ladder balanced just proved, so
-            # performance adopts balanced's result and goes straight to the
-            # Auto-OC climb. The Auto-OC probes still expect the stock power
-            # budget the skipped descent would have restored. The history is
-            # copied so performance's OC passes never append into balanced's.
-            reset_power_limit_to_stock(gpu, stock_power_limit_w, log=log)
-            tier_candidate = donation.candidate
-            tier_final_tail = int(donation.tail_rise_bins)
-            tier_probe = donation.probe
-            tier_history = list(donation.history)
-            log_phase(
-                log,
-                "auto-uv",
-                "adaptive performance reusing balanced descent "
-                f"{int(tier_candidate.voltage_mv)}mV@"
-                f"{int(tier_candidate.target_mhz)}MHz: "
-                "skipping downsweep, starting Auto-OC",
-            )
-            emit_auto_uv_event(
-                event_callback,
-                "tier_descent_reused",
-                **tier_event_details,
-                source_tier=str(AUTO_UV_MODE_BALANCED),
-                voltage_mv=int(tier_candidate.voltage_mv),
-                target_mhz=int(tier_candidate.target_mhz),
-            )
-        else:
-            tier_candidate, tier_final_tail, tier_probe, tier_history = (
-                run_adaptive_tier_descent(
-                    base_curve,
-                    tier_mode=str(tier_mode),
-                    base_loop_settings=base_loop_settings,
-                    baseline_candidate=baseline_candidate,
-                    initial_stable_outcome=initial_stable_outcome,
-                    fallback_probe=stable_probe,
-                    discovery_summary=discovery_summary,
-                    accumulated_unsafe=accumulated_unsafe,
-                    effective_min_search_voltage_mv=int(
-                        effective_min_search_voltage_mv
-                    ),
-                    probe_candidate=probe_candidate,
-                    stock_power_limit_w=stock_power_limit_w,
-                    min_core_clock_pct=float(tier_min_core_clock_pct),
-                    gpu=gpu,
-                    log=log,
-                )
-            )
-            if tier_mode == AUTO_UV_MODE_BALANCED:
-                balanced_donation = BalancedDescentDonation(
-                    candidate=tier_candidate,
-                    tail_rise_bins=int(tier_final_tail),
-                    probe=tier_probe,
-                    history=tier_history,
-                    descent_tail_rise_bins=adaptive_tier_descent_tail_rise_bins(
-                        AUTO_UV_MODE_BALANCED
-                    ),
-                    memory_offset_mhz=tier_memory_offset_mhz,
-                )
-        runs_auto_oc = tier_mode == AUTO_UV_MODE_PERFORMANCE
+        tier_tail_rise_bins = adaptive_tier_descent_tail_rise_bins(
+            str(tier_mode)
+        )
         apply_adaptive_tier_power_limit(
             gpu,
             tier_mode=str(tier_mode),
@@ -979,6 +1083,154 @@ def run_adaptive_tier_scans(
                 )
             ),
         )
+        apply_pending_power_limit(
+            gpu,
+            log=log,
+            purpose=f"adaptive {str(tier_mode)} scan",
+        )
+        tier_runner = configure_tier_probe_runner(tier_min_core_clock_pct)
+        tier_baseline_candidate = baseline_candidate
+        tier_initial_stable_outcome = initial_stable_outcome
+        tier_stable_probe = stable_probe
+        tier_discovery_summary = discovery_summary
+        tier_baseline_target = baseline_target
+        tier_effective_min_search_voltage_mv = int(
+            effective_min_search_voltage_mv
+        )
+        tier_base_loop_settings = base_loop_settings
+        if prepare_tier_baseline is not None:
+            try:
+                prepared = prepare_tier_baseline(
+                    tier_mode=str(tier_mode),
+                    tier_runner=tier_runner,
+                    tier_tail_rise_bins=int(tier_tail_rise_bins),
+                )
+            except AutoUvPowerLimitApplyError:
+                raise
+            except AutoUvError as tier_error:
+                record_tier_failure(
+                    tier_mode=str(tier_mode),
+                    tier_error=tier_error,
+                    stage="baseline",
+                    event_details=tier_event_details,
+                )
+                continue
+            tier_runner = prepared.runner
+            tier_baseline_candidate = prepared.candidate
+            tier_initial_stable_outcome = prepared.outcome
+            tier_stable_probe = prepared.stable_probe
+            tier_discovery_summary = prepared.discovery_summary
+            tier_baseline_target = prepared.target
+            tier_effective_min_search_voltage_mv = int(
+                prepared.min_search_voltage_mv
+            )
+            tier_base_loop_settings = replace(
+                base_loop_settings,
+                start_voltage_mv=int(tier_baseline_candidate.voltage_mv),
+                min_search_voltage_mv=int(tier_effective_min_search_voltage_mv),
+                baseline_core_clock_mhz=float(
+                    tier_baseline_target.measured_clock_mhz
+                ),
+                reference_actual_voltage_mv=tier_stable_probe.avg_voltage_mv,
+            )
+        try:
+            if (
+                tier_mode == AUTO_UV_MODE_PERFORMANCE
+                and balanced_donation is not None
+                and performance_can_reuse_balanced_descent(
+                    balanced_donation,
+                    performance_memory_offset_mhz=tier_memory_offset_mhz,
+                    performance_min_core_clock_pct=float(tier_min_core_clock_pct),
+                    measured_baseline_clock_mhz=float(
+                        tier_baseline_target.measured_clock_mhz
+                    ),
+                    performance_baseline_voltage_mv=int(
+                        tier_baseline_candidate.voltage_mv
+                    ),
+                    performance_baseline_target_mhz=int(
+                        tier_baseline_candidate.target_mhz
+                    ),
+                    performance_power_limit_w=positive_int(gpu.power_limit_w),
+                    log=log,
+                )
+            ):
+                donation = balanced_donation
+                # The descent would re-measure the same capped ladder balanced
+                # already proved, so performance adopts it and goes straight to
+                # the Auto-OC climb. The history is copied so performance's OC
+                # passes never append into balanced's.
+                tier_candidate = donation.candidate
+                tier_final_tail = int(donation.tail_rise_bins)
+                tier_probe = donation.probe
+                tier_history = list(donation.history)
+                if prepare_tier_baseline is not None and tier_stable_probe is not None:
+                    tier_history = [tier_stable_probe, *tier_history[1:]]
+                log_phase(
+                    log,
+                    "auto-uv",
+                    "adaptive performance reusing balanced descent "
+                    f"{int(tier_candidate.voltage_mv)}mV@"
+                    f"{int(tier_candidate.target_mhz)}MHz: "
+                    "skipping downsweep, starting Auto-OC",
+                )
+                emit_auto_uv_event(
+                    event_callback,
+                    "tier_descent_reused",
+                    **tier_event_details,
+                    source_tier=str(AUTO_UV_MODE_BALANCED),
+                    voltage_mv=int(tier_candidate.voltage_mv),
+                    target_mhz=int(tier_candidate.target_mhz),
+                )
+            else:
+                tier_candidate, tier_final_tail, tier_probe, tier_history = (
+                    run_adaptive_tier_descent(
+                        base_curve,
+                        tier_mode=str(tier_mode),
+                        base_loop_settings=tier_base_loop_settings,
+                        baseline_candidate=tier_baseline_candidate,
+                        initial_stable_outcome=tier_initial_stable_outcome,
+                        fallback_probe=tier_stable_probe,
+                        discovery_summary=tier_discovery_summary,
+                        accumulated_unsafe=accumulated_unsafe,
+                        effective_min_search_voltage_mv=int(
+                            tier_effective_min_search_voltage_mv
+                        ),
+                        runner=tier_runner,
+                        probe_history=probe_history,
+                        min_core_clock_pct=float(tier_min_core_clock_pct),
+                        gpu=gpu,
+                        log=log,
+                    )
+                )
+                if tier_mode == AUTO_UV_MODE_BALANCED:
+                    balanced_donation = BalancedDescentDonation(
+                        candidate=tier_candidate,
+                        tail_rise_bins=int(tier_final_tail),
+                        probe=tier_probe,
+                        history=tier_history,
+                        descent_tail_rise_bins=adaptive_tier_descent_tail_rise_bins(
+                            AUTO_UV_MODE_BALANCED
+                        ),
+                        memory_offset_mhz=tier_memory_offset_mhz,
+                        power_limit_w=positive_int(gpu.power_limit_w),
+                        baseline_voltage_mv=int(
+                            tier_baseline_candidate.voltage_mv
+                        ),
+                        baseline_target_mhz=int(
+                            tier_baseline_candidate.target_mhz
+                        ),
+                    )
+        except AutoUvPowerLimitApplyError:
+            raise
+        except AutoUvError as tier_error:
+            record_tier_failure(
+                tier_mode=str(tier_mode),
+                tier_error=tier_error,
+                stage="descent",
+                event_details=tier_event_details,
+            )
+            continue
+        runs_auto_oc = tier_mode == AUTO_UV_MODE_PERFORMANCE
         # Per-tier final-verification soak: efficiency 1 min, balanced 3 min,
         # performance 5 min by default (an explicit --auto-uv-final-verification-s
         # overrides all tiers). The graduated per-tier lengths already give the
@@ -1003,13 +1255,21 @@ def run_adaptive_tier_scans(
                 log=log,
                 tail_rise_bins=int(tier_final_tail),
                 measured_baseline_clock_mhz=float(
-                    baseline_target.measured_clock_mhz
+                    tier_baseline_target.measured_clock_mhz
                 ),
-                discovery_summary=discovery_summary,
-                baseline_candidate=baseline_candidate,
+                discovery_summary=tier_discovery_summary,
+                baseline_candidate=tier_baseline_candidate,
                 final_verification_duration_s=int(tier_final_duration),
                 event_callback=event_callback,
                 run_performance_auto_oc=runs_auto_oc,
+                run_power_bound_clock_reclaim=(
+                    tier_mode
+                    in {AUTO_UV_MODE_EFFICIENCY, AUTO_UV_MODE_BALANCED}
+                    and probe_indicates_power_saturation(
+                        tier_discovery_summary,
+                        power_limit_w=positive_int(gpu.power_limit_w),
+                    )
+                ),
                 request_reason=f"adaptive-{tier_mode}",
                 auto_uv_mode_override=str(tier_mode),
                 min_core_clock_pct_override=float(tier_min_core_clock_pct),
@@ -1041,6 +1301,12 @@ def run_adaptive_tier_scans(
                 final_profile_tier=str(tier_mode),
                 final_min_core_clock_pct=float(tier_min_core_clock_pct),
                 final_clock_drop_margin_pct=float(tier_clock_drop_margin_pct),
+                final_stable_history=tier_history,
+                final_discovery_summary=tier_discovery_summary,
+                final_baseline_candidate=tier_baseline_candidate,
+                final_measured_baseline_clock_mhz=float(
+                    tier_baseline_target.measured_clock_mhz
+                ),
             )
         except AutoUvFinalChoiceDiscarded:
             any_tier_discarded = True
@@ -1057,26 +1323,14 @@ def run_adaptive_tier_scans(
                 reason="discarded",
             )
             continue
+        except AutoUvPowerLimitApplyError:
+            raise
         except AutoUvError as tier_error:
-            # One tier's failed selection or final must not discard the
-            # other tiers' profiles.
-            last_tier_error = tier_error
-            if tier_mode == AUTO_UV_MODE_BALANCED:
-                # The failed soak condemns the donated endpoint; performance
-                # must prove its own descent instead of adopting it. (A user
-                # DISCARD keeps the donation — the point wasn't condemned.)
-                balanced_donation = None
-            log_phase(
-                log,
-                "auto-uv",
-                f"adaptive {tier_mode} verification failed: {tier_error}; "
-                "continuing with the remaining tiers",
-            )
-            emit_auto_uv_event(
-                event_callback,
-                "tier_skipped",
-                **tier_event_details,
-                reason="verification-failed",
+            record_tier_failure(
+                tier_mode=str(tier_mode),
+                tier_error=tier_error,
+                stage="verification",
+                event_details=tier_event_details,
             )
             continue
         emit_auto_uv_event(
@@ -1112,13 +1366,13 @@ def run_adaptive_tier_descent(
     discovery_summary: AutoUvProbeSummary,
     accumulated_unsafe: list[dict],
     effective_min_search_voltage_mv: int,
-    probe_candidate: Callable[[VfCurveCandidate], VoltageProbeOutcome],
-    stock_power_limit_w: int | None,
+    runner: AutoUvProbeRunner,
+    probe_history: list,
     min_core_clock_pct: float,
     gpu,
     log: Callable[[str], None],
 ) -> tuple[VfCurveCandidate, int, AutoUvProbeSummary | None, list[AutoUvProbeSummary]]:
-    """Run one tier's tailed descent at stock power and return its candidate.
+    """Run one tier's tailed descent under its shipped cap.
 
     Returns ``(candidate, final_tail_rise_bins, probe, tier_history)``. The
     tier's verified/passed probes land in the returned ``tier_history`` (kept
@@ -1131,7 +1385,20 @@ def run_adaptive_tier_descent(
         tail_rise_bins=int(tier_descent_tail),
         min_core_clock_pct=float(min_core_clock_pct),
     )
-    tier_history: list[AutoUvProbeSummary] = []
+    tier_history: list[AutoUvProbeSummary] = (
+        [fallback_probe] if fallback_probe is not None else []
+    )
+
+    def tier_probe_candidate(candidate: VfCurveCandidate) -> VoltageProbeOutcome:
+        retarget_clock_ceiling_for_candidate(gpu.clock_ceiling, candidate)
+        outcome = runner.probe_sweep_candidate(
+            candidate,
+            stable_history=tier_history,
+            phase_label=f"{str(tier_mode)}-candidate",
+        )
+        if outcome.raw_probe is not None:
+            probe_history.append(outcome.raw_probe)
+        return outcome
 
     def tier_write_verified(candidate, outcome) -> None:
         summary = require_probe_summary(outcome)
@@ -1166,16 +1433,14 @@ def run_adaptive_tier_descent(
         tier_history.append(require_probe_summary(outcome))
 
     tier_loop_io = BaseUvLoopIO(
-        probe_candidate=probe_candidate,
+        probe_candidate=tier_probe_candidate,
         write_verified_candidate=tier_write_verified,
         mark_unsafe_candidate=tier_mark_unsafe,
         record_passed_candidate=tier_record_passed,
     )
-    # Descend at STOCK power like the classic scan: a previous tier's reduced
-    # final-verification cap must not throttle this tier's descent (that
-    # dragged the measured-clock ratchet — and the balanced result — ~200MHz
-    # low). Each tier's own reduced cap is applied later, at final verification.
-    reset_power_limit_to_stock(gpu, stock_power_limit_w, log=log)
+    # The tier power limit was applied before its stock/flattened baselines.
+    # Keep it unchanged through every descent probe and final verification so
+    # selection never relies on a power regime the saved profile will not use.
     loop_result = run_preset_uv_loop(
         base_curve,
         settings=tier_settings,
@@ -1209,7 +1474,7 @@ def apply_adaptive_tier_power_limit(
     balanced_pct: float | None,
     explicit_watts: int | None = None,
 ) -> None:
-    """Request this tier's board-power cap for its final verification.
+    """Request this tier's board-power cap for baseline through verification.
 
     An explicit per-tier request (the scan dialog's per-profile power slider)
     wins over the balanced-anchor scaling. A manual scan-wide request stays a
@@ -1230,6 +1495,11 @@ def apply_adaptive_tier_power_limit(
         scan_request_w=scan_request_w,
         balanced_pct=balanced_pct,
     )
+    if tier_watts is None:
+        # A tier without an explicit/table limit restores the scan-wide
+        # request or stock budget instead of inheriting the previous tier's
+        # cap.
+        tier_watts = scan_request_w or stock_power_limit_w
     if tier_watts is None:
         return
     if scan_request_w is not None:
@@ -1319,36 +1589,6 @@ ADAPTIVE_TIER_ORDER = (
     AUTO_UV_MODE_BALANCED,
     AUTO_UV_MODE_PERFORMANCE,
 )
-# The first (deepest, most fragile) profile soaks the full final duration;
-# shallower profiles sit on already-proven edges and get a shorter confirm.
-# The Auto-OC tier is the exception — its climbed point is new territory.
-def reset_power_limit_to_stock(
-    gpu,
-    stock_power_limit_w: int | None,
-    *,
-    log: Callable[[str], None],
-) -> None:
-    """Return the board-power cap to stock before a tier's descent.
-
-    The adaptive scan applies each tier's reduced cap only at that tier's
-    final verification; between tiers the descent must run at the full stock
-    budget so it is not throttled by the previous tier's saved cap."""
-    if stock_power_limit_w is None:
-        return
-    stock_w = int(stock_power_limit_w)
-    if positive_int(gpu.power_limit_w) == stock_w:
-        return
-    apply_power_limit_w = getattr(gpu.gpu, "apply_power_limit_w", None)
-    if not callable(apply_power_limit_w):
-        return
-    try:
-        applied = int(cast(Any, apply_power_limit_w)(stock_w))
-    except Exception as exc:
-        log(f"Auto-UV: could not restore stock power limit for descent: {exc}")
-        return
-    gpu.translated_gpu_policy["power_limit_w"] = applied
-    gpu.requested_power_limit_w = None
-    log(f"Auto-UV: restored {applied}W stock power limit for tier descent")
 
 
 def adaptive_tier_descent_tail_rise_bins(tier_mode: str) -> int:
@@ -1380,6 +1620,9 @@ class BalancedDescentDonation:
     history: list[AutoUvProbeSummary]
     descent_tail_rise_bins: int
     memory_offset_mhz: int
+    power_limit_w: int | None
+    baseline_voltage_mv: int
+    baseline_target_mhz: int
 
 
 def performance_can_reuse_balanced_descent(
@@ -1388,16 +1631,18 @@ def performance_can_reuse_balanced_descent(
     performance_memory_offset_mhz: int,
     performance_min_core_clock_pct: float,
     measured_baseline_clock_mhz: float,
+    performance_baseline_voltage_mv: int,
+    performance_baseline_target_mhz: int,
+    performance_power_limit_w: int | None,
     log: Callable[[str], None],
 ) -> bool:
     """Whether the balanced descent doubles as performance's downsweep.
 
-    Balanced and performance run the same base sweep (same baseline, same
-    rising tail, stock board power — per-tier power caps only apply at final
-    verification), so when the memory offset and tail match, performance's
-    downsweep would re-measure the exact ladder balanced just proved. Reuse
-    skips it and sends performance straight to the Auto-OC climb from where
-    balanced left off. Any input mismatch falls back to a full descent.
+    When Balanced and Performance use the same baseline regime, rising tail,
+    power limit, and memory offset, Performance's downsweep would re-measure
+    the exact ladder Balanced just proved. Reuse skips it and sends
+    Performance straight to the Auto-OC climb. Any input mismatch falls back
+    to a full descent.
 
     Balanced descends under a LOOSER clock-drop allowance than performance
     (the efficiency-weighted blend), so the donated endpoint must also still
@@ -1417,6 +1662,31 @@ def performance_can_reuse_balanced_descent(
             "adaptive performance descending itself: tail "
             f"+{int(performance_tail)} differs from balanced "
             f"+{int(donation.descent_tail_rise_bins)}",
+        )
+        return False
+    if positive_int(performance_power_limit_w) != positive_int(
+        donation.power_limit_w
+    ):
+        log_phase(
+            log,
+            "auto-uv",
+            "adaptive performance descending itself: power limit "
+            f"{_format_power_limit_w(performance_power_limit_w)} differs "
+            f"from balanced {_format_power_limit_w(donation.power_limit_w)}",
+        )
+        return False
+    if (
+        int(performance_baseline_voltage_mv) != int(donation.baseline_voltage_mv)
+        or int(performance_baseline_target_mhz) != int(donation.baseline_target_mhz)
+    ):
+        log_phase(
+            log,
+            "auto-uv",
+            "adaptive performance descending itself: capped baseline "
+            f"{int(performance_baseline_voltage_mv)}mV@"
+            f"{int(performance_baseline_target_mhz)}MHz differs from balanced "
+            f"{int(donation.baseline_voltage_mv)}mV@"
+            f"{int(donation.baseline_target_mhz)}MHz",
         )
         return False
     if int(performance_memory_offset_mhz) != int(donation.memory_offset_mhz):
@@ -1508,6 +1778,7 @@ def select_final_scan_candidate(
     final_verification_duration_s: int,
     event_callback: AutoUvEventCallback | None,
     run_performance_auto_oc: bool,
+    run_power_bound_clock_reclaim: bool = False,
     request_reason: str,
     auto_uv_mode_override: str | None = None,
     min_core_clock_pct_override: float | None = None,
@@ -1526,6 +1797,30 @@ def select_final_scan_candidate(
     final_lock_clock_mhz = int(stable_lock_clock_mhz)
     final_probe = stable_probe
     final_auto_oc_metadata: dict = {}
+
+    if bool(run_power_bound_clock_reclaim):
+        (
+            final_plan,
+            final_voltage_mv,
+            final_lock_clock_mhz,
+            final_probe,
+            final_auto_oc_metadata,
+        ) = select_power_bound_clock_reclaim_candidate(
+            base_curve,
+            auto_uv_mode=selection_mode,
+            stable_plan=final_plan,
+            stable_voltage_mv=int(final_voltage_mv),
+            stable_lock_clock_mhz=int(final_lock_clock_mhz),
+            stable_probe=final_probe,
+            stable_history=stable_history,
+            runner=runner,
+            gpu_name=gpu.translated_gpu_policy.get("gpu_name"),
+            clock_ceiling=gpu.clock_ceiling,
+            probe_history=probe_history,
+            log=log,
+            tail_rise_bins=int(tail_rise_bins),
+            measured_baseline_clock_mhz=float(measured_baseline_clock_mhz),
+        )
 
     if bool(run_performance_auto_oc):
         (
@@ -1597,6 +1892,7 @@ def select_final_scan_candidate(
             stable_history,
             fallback_voltage_mv=int(final_voltage_mv),
         ),
+        lock_clock_mhz=int(final_lock_clock_mhz),
     )
 
     return FinalScanCandidate(
@@ -1620,10 +1916,15 @@ def final_verification_failure_can_offer_retry(
     return str(exc).startswith("final long verification failed:")
 
 
-def apply_requested_power_limit_for_final_verification(gpu, *, log) -> int | None:
+def apply_pending_power_limit(
+    gpu,
+    *,
+    log,
+    purpose: str = "final verification",
+) -> int | None:
     apply_power_limit = getattr(gpu, "apply_requested_power_limit", None)
     if callable(apply_power_limit):
-        applied_power_limit_w = apply_power_limit(log=log)
+        applied_power_limit_w = apply_power_limit(log=log, purpose=str(purpose))
         return (
             int(cast(Any, applied_power_limit_w))
             if applied_power_limit_w is not None
@@ -1720,6 +2021,7 @@ def choose_next_candidate_after_final_failure(
             stable_history,
             fallback_voltage_mv=int(selected_voltage_mv),
         ),
+        lock_clock_mhz=int(selected_lock_clock_mhz),
     )
     return FinalScanCandidate(
         plan=selected_plan,
@@ -1889,7 +2191,7 @@ def run_recovered_previous_crash_selection(
         request_reason="sweep-complete",
     )
 
-    apply_requested_power_limit_for_final_verification(gpu, log=log)
+    apply_pending_power_limit(gpu, log=log)
     return run_final_verification_and_save(
         probe_voltage_candidate=probe_voltage_candidate,
         build_voltage_scan_result=build_voltage_scan_result,
@@ -1930,3 +2232,8 @@ def _format_optional_pct(value: float | None) -> str:
     if value is None:
         return "n/a"
     return f"{float(value):.2f}%"
+
+
+def _format_power_limit_w(value: object) -> str:
+    watts = positive_int(value)
+    return f"{int(watts)}W" if watts is not None else "driver-managed"

--- a/auto_uv/performance_uv_loop.py
+++ b/auto_uv/performance_uv_loop.py
@@ -18,7 +18,12 @@ from auto_uv.curve.performance_sweep_profile import (
 from auto_uv.domain.scan_settings import AutoUvScanSettings
 from auto_uv.probes.runner import AutoUvProbeRunner
 from auto_uv.run.voltage_sweep_state import LowerVoltageSweepResult, VoltageProbeOutcome
-from auto_uv.scan_mode.auto_uv_mode import AUTO_UV_MODE_PERFORMANCE
+from auto_uv.scan_mode.auto_uv_mode import (
+    AUTO_UV_MODE_BALANCED,
+    AUTO_UV_MODE_EFFICIENCY,
+    AUTO_UV_MODE_PERFORMANCE,
+)
+from auto_uv.scan_mode.uv_limits import uv_limit_profile_target_for_gpu
 
 
 def run_performance_uv_loop(
@@ -135,6 +140,92 @@ def select_performance_auto_oc_candidate(
         int(selected.target_mhz),
         None if selected_changed else stable_probe,
         auto_oc_metadata,
+    )
+
+
+def select_power_bound_clock_reclaim_candidate(
+    base_curve: list[dict],
+    *,
+    auto_uv_mode: str,
+    stable_plan: list[dict],
+    stable_voltage_mv: int,
+    stable_lock_clock_mhz: int,
+    stable_probe: AutoUvProbeSummary | None,
+    stable_history: list[AutoUvProbeSummary],
+    runner: AutoUvProbeRunner,
+    gpu_name: object | None,
+    clock_ceiling,
+    probe_history: list[AutoUvProbeSummary],
+    log: Callable[[str], None],
+    tail_rise_bins: int = 0,
+    measured_baseline_clock_mhz: float | int | None = None,
+) -> tuple[list[dict], int, int, AutoUvProbeSummary | None, dict]:
+    """Raise clock at the proven voltage after a capped savings-tier descent."""
+    mode = str(auto_uv_mode)
+    if mode not in {AUTO_UV_MODE_EFFICIENCY, AUTO_UV_MODE_BALANCED}:
+        return (
+            stable_plan,
+            int(stable_voltage_mv),
+            int(stable_lock_clock_mhz),
+            stable_probe,
+            {},
+        )
+    endpoint = uv_limit_profile_target_for_gpu(gpu_name, mode)
+    if endpoint is None or int(endpoint.clock_mhz) <= int(stable_lock_clock_mhz):
+        return (
+            stable_plan,
+            int(stable_voltage_mv),
+            int(stable_lock_clock_mhz),
+            stable_probe,
+            {},
+        )
+    log_phase(
+        log,
+        "clock-reclaim",
+        f"{mode} fixed-voltage climb "
+        f"{int(stable_voltage_mv)}mV@{int(stable_lock_clock_mhz)}MHz -> "
+        f"{int(endpoint.clock_mhz)}MHz",
+    )
+    start_candidate = VfCurveCandidate(
+        label=f"{mode}-clock-reclaim-start",
+        voltage_mv=int(stable_voltage_mv),
+        target_mhz=int(stable_lock_clock_mhz),
+        flattened_plan=stable_plan,
+    )
+    result = run_auto_oc_candidate_search(
+        base_curve=base_curve,
+        start_candidate=start_candidate,
+        start_probe=stable_probe,
+        runner=runner,
+        gpu_name=gpu_name,
+        clock_ceiling=clock_ceiling,
+        probe_history=probe_history,
+        log=log,
+        tail_rise_bins=int(tail_rise_bins),
+        target_voltage_mv=int(stable_voltage_mv),
+        target_clock_mhz=int(endpoint.clock_mhz),
+        measured_baseline_clock_mhz=measured_baseline_clock_mhz,
+        target_profile_id=mode,
+        probe_stable_history=stable_history,
+    )
+    for attempt in getattr(result, "attempts", ()) or ():
+        if attempt.outcome.decision.passed and attempt.outcome.raw_probe is not None:
+            stable_history.append(attempt.outcome.raw_probe)
+    selected = result.selected_candidate
+    selected_changed = int(selected.target_mhz) != int(stable_lock_clock_mhz)
+    metadata = {
+        "clock_reclaim": True,
+        "clock_reclaim_start_mhz": int(stable_lock_clock_mhz),
+        "clock_reclaim_target_mhz": int(endpoint.clock_mhz),
+        "clock_reclaim_selected_mhz": int(selected.target_mhz),
+        "clock_reclaim_voltage_mv": int(stable_voltage_mv),
+    }
+    return (
+        selected.flattened_plan,
+        int(selected.voltage_mv),
+        int(selected.target_mhz),
+        result.selected_probe if selected_changed else stable_probe,
+        metadata,
     )
 
 

--- a/auto_uv/persistence/verified_candidate_result_file.py
+++ b/auto_uv/persistence/verified_candidate_result_file.py
@@ -24,6 +24,7 @@ def write_latest_verified_candidate(
     probe: AutoUvProbeSummary | None,
     base_probe: AutoUvProbeSummary | None = None,
     tail_rise_bins: int = 0,
+    configured_power_limit_w: int | None = None,
 ) -> Path:
     output_path = auto_uv_user_config_dir() / "uv-result" / "auto-uv-latest-verified.json"
     payload = verified_candidate_payload(
@@ -35,6 +36,7 @@ def write_latest_verified_candidate(
         reason="latest-verified",
         label="passed-short-probe",
         tail_rise_bins=int(tail_rise_bins),
+        configured_power_limit_w=configured_power_limit_w,
     )
     path = safe_json_write(output_path, payload)
     append_verified_candidate(payload)
@@ -121,6 +123,7 @@ def verified_candidate_payload(
     base_probe: AutoUvProbeSummary | None = None,
     final_verified: bool = False,
     tail_rise_bins: int = 0,
+    configured_power_limit_w: int | None = None,
 ) -> dict:
     _validate_plan_points(plan)
     flatten_target = build_flatten_target_for_plan(
@@ -143,6 +146,14 @@ def verified_candidate_payload(
         "lock_clock_mhz": int(lock_clock_mhz),
         "candidate_voltage_mv": int(voltage_mv),
         "tail_rise_bins": int(tail_rise_bins),
+        # The board-power regime this candidate was measured under; crash
+        # recovery re-establishes it before re-verifying (None = unlimited
+        # or unrecorded pre-regime cache entry).
+        "configured_power_limit_w": (
+            int(configured_power_limit_w)
+            if configured_power_limit_w is not None
+            else None
+        ),
         "core_oc_mhz": core_oc_mhz(
             lock_clock_mhz=int(lock_clock_mhz),
             base_probe=base_probe,

--- a/auto_uv/probes/live_abort.py
+++ b/auto_uv/probes/live_abort.py
@@ -11,6 +11,7 @@ from auto_uv.domain.user_options import (
     AUTO_UV_STALL_TUNING,
 )
 from .runtime_guardrails import core_clock_below_floor, telemetry_sample_is_busy
+from .stability_decision import perf_cap_reason_indicates_power
 from .summary import mean
 
 
@@ -21,6 +22,7 @@ def telemetry_live_abort_reason(
     proper_run_power_floor_w: float | None,
     target_core_clock_floor_mhz: float | None,
     progress_state: dict,
+    power_limit_w: int | None = None,
 ) -> str | None:
     samples = list(state.get("telemetry_samples") or [])
     busy_samples = [s for s in samples if telemetry_sample_is_busy(s, busy_power_floor_w)]
@@ -52,6 +54,10 @@ def telemetry_live_abort_reason(
     low_live = low_live_clock_abort_reason(
         live_core_clock_mhz=live_clock,
         live_sample_is_busy=latest_busy,
+        live_sample_power_capped=sample_indicates_power_cap(
+            latest,
+            power_limit_w=power_limit_w,
+        ),
         core_clock_samples=clocks,
         target_core_clock_floor_mhz=target_core_clock_floor_mhz,
         progress_state=progress_state,
@@ -64,6 +70,13 @@ def telemetry_live_abort_reason(
         and avg_clock is not None
         and len(clocks) >= AUTO_UV_STALL_TUNING.avg_core_clock_abort_min_samples
         and core_clock_below_floor(avg_clock, target_core_clock_floor_mhz)
+        # A power-governed busy window legitimately averages below the floor;
+        # the post-probe decision re-checks this with full saturation
+        # evidence, so the live abort stays quiet under a power cap.
+        and not busy_samples_mostly_power_capped(
+            busy_samples,
+            power_limit_w=power_limit_w,
+        )
     ):
         return (
             f"telemetry-live-core_clock-avg current={avg_clock:.1f}MHz "
@@ -71,6 +84,54 @@ def telemetry_live_abort_reason(
             f"tolerance={AUTO_UV_CURVE_TUNING.clock_select_tolerance_mhz:.1f}MHz"
         )
     return None
+
+
+def sample_indicates_power_cap(
+    sample,
+    *,
+    power_limit_w: int | None = None,
+    power_saturation_headroom_pct: float = 2.0,
+) -> bool:
+    if sample is None:
+        return False
+    if perf_cap_reason_indicates_power(
+        getattr(sample, "perf_cap_reason", None)
+    ):
+        return True
+    power_w = getattr(sample, "power_w", None)
+    if power_w is None or power_limit_w is None or int(power_limit_w) <= 0:
+        return False
+    saturation_floor_w = float(power_limit_w) * (
+        1.0 - max(0.0, float(power_saturation_headroom_pct)) / 100.0
+    )
+    return float(power_w) >= float(saturation_floor_w)
+
+
+def busy_samples_mostly_power_capped(
+    busy_samples: list,
+    *,
+    capped_fraction: float = 0.5,
+    power_limit_w: int | None = None,
+) -> bool:
+    reason_samples = [
+        sample
+        for sample in busy_samples
+        if getattr(sample, "perf_cap_reason", None) not in (None, "")
+    ]
+    if reason_samples:
+        capped = sum(
+            1 for sample in reason_samples if sample_indicates_power_cap(sample)
+        )
+        if capped / len(reason_samples) >= float(capped_fraction):
+            return True
+    powers = [
+        float(sample.power_w)
+        for sample in busy_samples
+        if getattr(sample, "power_w", None) is not None
+    ]
+    if not powers or power_limit_w is None or int(power_limit_w) <= 0:
+        return False
+    return sum(powers) / len(powers) >= float(power_limit_w) * 0.98
 
 
 def selected_nvidia_gpu_idle_abort_reason(state: dict) -> str | None:
@@ -178,6 +239,7 @@ def low_live_clock_abort_reason(
     core_clock_samples: list[float],
     target_core_clock_floor_mhz: float | None,
     progress_state: dict,
+    live_sample_power_capped: bool = False,
 ) -> str | None:
     if (
         target_core_clock_floor_mhz is None
@@ -188,6 +250,7 @@ def low_live_clock_abort_reason(
     progress_state["low_core_clock_streak"] = (
         int(progress_state.get("low_core_clock_streak", 0)) + 1
         if live_sample_is_busy
+        and not live_sample_power_capped
         and core_clock_below_floor(live_core_clock_mhz, target_core_clock_floor_mhz)
         else 0
     )

--- a/auto_uv/probes/live_abort.py
+++ b/auto_uv/probes/live_abort.py
@@ -112,13 +112,21 @@ def busy_samples_mostly_power_capped(
     *,
     capped_fraction: float = 0.5,
     power_limit_w: int | None = None,
+    min_reason_samples: int = 3,
+    min_reason_coverage: float = 0.5,
 ) -> bool:
     reason_samples = [
         sample
         for sample in busy_samples
         if getattr(sample, "perf_cap_reason", None) not in (None, "")
     ]
-    if reason_samples:
+    # A sparse reason-bearing subset must not speak for the whole busy
+    # window; without enough coverage the decision falls through to the
+    # average-power signal (same evidence rule as the post-probe check).
+    if (
+        len(reason_samples) >= int(min_reason_samples)
+        and len(reason_samples) >= float(min_reason_coverage) * len(busy_samples)
+    ):
         capped = sum(
             1 for sample in reason_samples if sample_indicates_power_cap(sample)
         )

--- a/auto_uv/probes/stability_decision.py
+++ b/auto_uv/probes/stability_decision.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, cast
 
 from auto_uv.domain.types import FailureKind, FailureSeverity, StableRunDecision
 from ..curve.base_load_telemetry import derive_active_power_floor_w
@@ -19,6 +19,8 @@ class StabilityThresholds:
     min_core_clock_pct: float = 85.0
     clock_tolerance_mhz: float = 5.0
     busy_gpu_util_pct: float = 60.0
+    power_saturation_headroom_pct: float = 2.0
+    power_cap_busy_sample_fraction: float = 0.5
 
 
 FATAL_REASON_PREFIXES = (
@@ -318,6 +320,22 @@ def evaluate_loaded_telemetry(
             )
         avg_clock_mhz = sum(clocks) / len(clocks)
         if avg_clock_mhz < floor_mhz - float(thresholds.clock_tolerance_mhz):
+            power_capped, power_cap_evidence = busy_samples_indicate_power_cap(
+                busy_samples,
+                power_limit_w=power_limit_w,
+                thresholds=thresholds,
+            )
+            if power_capped:
+                # A clock shortfall while the power governor holds the board
+                # at its cap is the cap working, not V/F instability. The
+                # exemption disarms itself as an undervolt succeeds: once
+                # power drops off the limit, the clock floor regains full
+                # force, so genuinely demoted clocks still fail here.
+                return _pass(
+                    "loaded telemetry power-walled but stable "
+                    f"avg={avg_clock_mhz:.1f}MHz floor={floor_mhz:.1f}MHz",
+                    log_path=log_path,
+                )
             return _fail(
                 FailureKind.LOW_CLOCK,
                 FailureSeverity.RECOVERABLE,
@@ -326,10 +344,67 @@ def evaluate_loaded_telemetry(
                     "avg_core_clock_mhz": avg_clock_mhz,
                     "floor_mhz": floor_mhz,
                     "busy_samples": len(busy_samples),
+                    **power_cap_evidence,
                 },
                 log_path=log_path,
             )
     return _pass("loaded telemetry stable", log_path=log_path)
+
+
+def busy_samples_indicate_power_cap(
+    busy_samples: list[Any],
+    *,
+    power_limit_w: int | None,
+    thresholds: StabilityThresholds = StabilityThresholds(),
+) -> tuple[bool, dict[str, Any]]:
+    """Whether the busy window ran against the board-power cap.
+
+    Two independent signals, either suffices: the driver's perf-cap reason
+    names a power cap on most busy samples that report one (robust even when
+    per-frame spikes hold the *average* power below the limit), or the
+    average busy power sits within the saturation headroom of the applied
+    limit.
+    """
+    reason_samples = [
+        sample
+        for sample in busy_samples
+        if read_field(sample, "perf_cap_reason") not in (None, "")
+    ]
+    capped_samples = [
+        sample
+        for sample in reason_samples
+        if perf_cap_reason_indicates_power(read_field(sample, "perf_cap_reason"))
+    ]
+    if reason_samples:
+        capped_fraction = len(capped_samples) / len(reason_samples)
+        if capped_fraction >= float(thresholds.power_cap_busy_sample_fraction):
+            return True, {
+                "power_cap_sample_fraction": round(capped_fraction, 3),
+                "power_cap_reason_samples": len(reason_samples),
+            }
+    powers = [
+        float(read_field(sample, "power_w"))
+        for sample in busy_samples
+        if read_field(sample, "power_w") is not None
+    ]
+    if powers and power_limit_w is not None and int(power_limit_w) > 0:
+        avg_power_w = sum(powers) / len(powers)
+        saturation_floor_w = float(power_limit_w) * (
+            1.0 - max(0.0, float(thresholds.power_saturation_headroom_pct)) / 100.0
+        )
+        if avg_power_w >= saturation_floor_w:
+            return True, {
+                "avg_busy_power_w": round(avg_power_w, 1),
+                "power_saturation_floor_w": round(saturation_floor_w, 1),
+            }
+    return False, {}
+
+
+def perf_cap_reason_indicates_power(reason_text: Any) -> bool:
+    reason = str(reason_text or "").lower()
+    return any(
+        "power" in token.strip() for token in reason.replace(",", "+").split("+")
+    )
 
 
 def evaluate_cuda_companion(
@@ -416,7 +491,7 @@ def _benchmark_evidence(benchmark_summary: Any) -> dict[str, Any]:
 def _measurement_telemetry_samples(result: Any) -> list[Any]:
     getter = getattr(result, "measurement_telemetry_samples", None)
     if callable(getter):
-        return list(getter())
+        return list(cast(Iterable[Any], getter()))
     benchmark_samples = read_field(result, "benchmark_telemetry_samples")
     if benchmark_samples is not None:
         return list(benchmark_samples)

--- a/auto_uv/probes/stability_decision.py
+++ b/auto_uv/probes/stability_decision.py
@@ -21,6 +21,11 @@ class StabilityThresholds:
     busy_gpu_util_pct: float = 60.0
     power_saturation_headroom_pct: float = 2.0
     power_cap_busy_sample_fraction: float = 0.5
+    # The perf-cap-reason vote only counts when enough of the busy window
+    # actually reports reasons; a sparse reason-bearing subset must not speak
+    # for the whole run (it falls through to the avg-power signal instead).
+    power_cap_min_reason_samples: int = 3
+    power_cap_min_reason_coverage: float = 0.5
 
 
 FATAL_REASON_PREFIXES = (
@@ -363,7 +368,9 @@ def busy_samples_indicate_power_cap(
     names a power cap on most busy samples that report one (robust even when
     per-frame spikes hold the *average* power below the limit), or the
     average busy power sits within the saturation headroom of the applied
-    limit.
+    limit. The reason vote requires minimum evidence — enough reason-bearing
+    samples covering enough of the busy window — so a lone sw-power sample
+    among reason-less telemetry cannot grant a false power-walled pass.
     """
     reason_samples = [
         sample
@@ -375,7 +382,12 @@ def busy_samples_indicate_power_cap(
         for sample in reason_samples
         if perf_cap_reason_indicates_power(read_field(sample, "perf_cap_reason"))
     ]
-    if reason_samples:
+    reason_vote_qualified = (
+        len(reason_samples) >= int(thresholds.power_cap_min_reason_samples)
+        and len(reason_samples)
+        >= float(thresholds.power_cap_min_reason_coverage) * len(busy_samples)
+    )
+    if reason_vote_qualified:
         capped_fraction = len(capped_samples) / len(reason_samples)
         if capped_fraction >= float(thresholds.power_cap_busy_sample_fraction):
             return True, {

--- a/auto_uv/probes/voltage_probe.py
+++ b/auto_uv/probes/voltage_probe.py
@@ -186,6 +186,7 @@ def probe_voltage_candidate(
             proper_run_power_floor_w=proper_run_power_floor_w,
             target_core_clock_floor_mhz=target_floor_mhz,
             progress_state=progress_state,
+            power_limit_w=power_limit_w,
         )
         if telemetry_abort is not None:
             return telemetry_abort

--- a/auto_uv/run/baseline_probe.py
+++ b/auto_uv/run/baseline_probe.py
@@ -89,16 +89,39 @@ def run_discovery_probe(
         marker_details=marker_details,
         event_callback=event_callback,
     )
+    return run_discovery_probe_with_runner(
+        base_curve,
+        runner=runner,
+        log=log,
+        event_callback=event_callback,
+    )
+
+
+def run_discovery_probe_with_runner(
+    base_curve: list[dict],
+    *,
+    runner: AutoUvProbeRunner,
+    log: Callable[[str], None],
+    event_callback: AutoUvEventCallback | None,
+    label: str = "base default curve",
+) -> tuple[AutoUvProbeSummary, object]:
+    """Measure a stock baseline with an already configured scan runner.
+
+    Adaptive profiles use this entry point after applying each tier's own
+    power and memory policy, so target derivation and later probes share the
+    exact shipped regime.
+    """
+    point = max(editable_base_vf_points(base_curve), key=lambda item: item.target_mhz)
     emit_auto_uv_event(
         event_callback,
         "probe_start",
         stage="base-baseline",
         voltage_mv=int(point.voltage_mv),
         clock_mhz=int(point.target_mhz),
-        label="base default curve",
+        label=str(label),
         elapsed_s=0.0,
         target_duration_s=reference_discovery_q2rtx_duration_s(
-            int(short_probe_base_duration_s)
+            int(runner.short_probe_base_duration_s)
         ),
     )
     summary, result = runner.probe_default_curve(
@@ -119,7 +142,7 @@ def run_discovery_probe(
     log_benchmark(log, phase="discover", probe=summary)
     light_load_diagnostic = selected_nvidia_light_load_diagnostic(
         list(getattr(result, "telemetry_samples", []) or []),
-        power_limit_w=reference_power_limit_w,
+        power_limit_w=runner.power_limit_w,
     )
     if light_load_diagnostic is not None:
         log_phase(log, "discover", light_load_diagnostic)
@@ -128,8 +151,8 @@ def run_discovery_probe(
 
 def baseline_load_reference_power_limit_w(gpu) -> int | None:
     return _positive_power_limit_w(
-        getattr(gpu, "baseline_power_limit_w", None)
-    ) or _positive_power_limit_w(getattr(gpu, "power_limit_w", None))
+        getattr(gpu, "power_limit_w", None)
+    ) or _positive_power_limit_w(getattr(gpu, "baseline_power_limit_w", None))
 
 
 def _positive_power_limit_w(value: object) -> int | None:
@@ -198,6 +221,7 @@ def adjust_baseline_to_measured_clock(
         base_curve,
         probe=stable_probe,
         previous_lock_clock_mhz=int(candidate.target_mhz),
+        power_limit_w=getattr(gpu, "power_limit_w", None),
     )
     if int(measured_target_mhz) == int(candidate.target_mhz):
         return candidate

--- a/auto_uv/run/baseline_probe.py
+++ b/auto_uv/run/baseline_probe.py
@@ -255,6 +255,7 @@ def write_verified_candidate(
     *,
     discovery_summary: AutoUvProbeSummary,
     tail_rise_bins: int = 0,
+    configured_power_limit_w: int | None = None,
 ) -> None:
     effective_tail_rise_bins = int(
         candidate.metadata.get("tail_rise_bins", tail_rise_bins)
@@ -266,6 +267,7 @@ def write_verified_candidate(
         probe=probe,
         base_probe=discovery_summary,
         tail_rise_bins=int(effective_tail_rise_bins),
+        configured_power_limit_w=configured_power_limit_w,
     )
 
 

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -195,8 +195,9 @@ def parse_arguments(argv):
             metavar="W",
             help=(
                 f"Full-scan override: the {tier_label} tier's power limit in "
-                "watts, applied at that tier's final verification and saved "
-                "with its profile. Only meaningful with --auto-uv-mode adaptive."
+                "watts, applied for that tier's baseline, descent, final "
+                "verification, and saved profile. Only meaningful with "
+                "--auto-uv-mode adaptive."
             ),
         )
         auto_uv_group.add_argument(

--- a/docs/features/auto-uv.md
+++ b/docs/features/auto-uv.md
@@ -44,6 +44,15 @@ The GUI offers that one-time setup automatically; from the CLI install it with
   previously stable candidates for final verification instead of throwing the
   work away.
 
+When a tier includes a board-power limit, Auto-UV applies and reads back
+that exact limit before the tier's stock baseline, voltage sweep, and final
+verification. It stops instead of probing if the limit cannot be established.
+On a genuinely power-limited card, the lower measured clock is treated as a
+governor operating point only while sustained cap evidence is present; ordinary
+clock regressions still fail. Efficiency and Balanced may then probe a bounded
+clock climb at the already-proven voltage, without raising the voltage or
+loosening the stability checks.
+
 By default Q2RTX runs through PenguinBurner's managed
 [headless benchmark binary](https://github.com/jpietek/Q2RTX-headless), so no
 desktop display server or compositor wrapper is needed. Render resolution is

--- a/tests/auto_uv/auto_uv_test_data.py
+++ b/tests/auto_uv/auto_uv_test_data.py
@@ -62,6 +62,84 @@ def rtx_5080_20260524_high_oc_base_curve() -> list[dict]:
     ]
 
 
+def rtx_5090_zotac_amp_stock_curve() -> list[dict]:
+    """Captured RTX 5090 (GB202) stock V/F curve, Zotac AMP 600W BIOS.
+
+    Transcribed by script from the decompiled NV-UV reference binary
+    (reverse/nvu-latest-managed-src/.../Algorithms/PresetDatabase.cs,
+    GetZotacAmp5090StockCurve). Load-bearing shape: idle shelf at 180MHz to
+    765mV, a ~12-14MHz/mV cliff through 770-945mV, the knee at ~950mV, then
+    a shallow ~2-3MHz/mV tail to 3195MHz@1240mV. Every realistic lock
+    voltage sits AT or ABOVE the knee with the cliff directly below — the
+    opposite of the 5080 fixture, whose knee (~815mV) is far below its
+    working band.
+    """
+    points = [
+        (450, 180), (460, 180), (465, 180), (470, 180),
+        (475, 180), (485, 180), (490, 180), (495, 180),
+        (500, 180), (510, 180), (515, 180), (520, 180),
+        (525, 180), (535, 180), (540, 180), (545, 180),
+        (550, 180), (560, 180), (565, 180), (570, 180),
+        (575, 180), (585, 180), (590, 180), (595, 180),
+        (600, 180), (610, 180), (615, 180), (620, 180),
+        (625, 180), (635, 180), (640, 180), (645, 180),
+        (650, 180), (660, 180), (665, 180), (670, 180),
+        (675, 180), (685, 180), (690, 180), (695, 180),
+        (700, 180), (710, 180), (715, 180), (720, 180),
+        (725, 180), (735, 180), (740, 180), (745, 180),
+        (750, 180), (760, 180), (765, 180), (770, 202),
+        (775, 285), (785, 375), (790, 457), (795, 547),
+        (800, 630), (810, 712), (815, 802), (820, 885),
+        (825, 975), (835, 1057), (840, 1147), (845, 1230),
+        (850, 1320), (860, 1402), (865, 1492), (870, 1575),
+        (875, 1657), (885, 1747), (890, 1830), (895, 1920),
+        (900, 2002), (910, 2092), (915, 2175), (920, 2257),
+        (925, 2347), (935, 2430), (940, 2520), (945, 2580),
+        (950, 2602), (960, 2617), (965, 2640), (970, 2662),
+        (975, 2677), (985, 2700), (990, 2715), (995, 2737),
+        (1000, 2767), (1010, 2790), (1015, 2805), (1020, 2827),
+        (1025, 2835), (1035, 2850), (1040, 2865), (1045, 2872),
+        (1050, 2887), (1060, 2902), (1065, 2910), (1070, 2925),
+        (1075, 2932), (1085, 2947), (1090, 2955), (1095, 2970),
+        (1100, 2977), (1110, 2992), (1115, 3000), (1120, 3015),
+        (1125, 3022), (1135, 3037), (1140, 3045), (1145, 3052),
+        (1150, 3067), (1160, 3075), (1165, 3082), (1170, 3097),
+        (1175, 3105), (1185, 3112), (1190, 3127), (1195, 3135),
+        (1200, 3142), (1210, 3150), (1215, 3157), (1220, 3165),
+        (1225, 3180), (1235, 3187), (1240, 3195),
+    ]
+    return [
+        {
+            "index": index,
+            "voltage_mv": voltage_mv,
+            "base_mhz": base_mhz,
+            "target_mhz": base_mhz,
+            "new_offset_mhz": 0,
+        }
+        for index, (voltage_mv, base_mhz) in enumerate(points)
+    ]
+
+
+def rtx_5090_steep_synthetic_curve() -> list[dict]:
+    """Synthetic GB202-shaped curve with the captured knee shifted three bins.
+
+    This deliberately varies the knee location without claiming to represent
+    a particular board or silicon sample. It preserves the captured voltage
+    grid and steep-below/shallow-above geometry needed by power-bound tests.
+    """
+    zotac = rtx_5090_zotac_amp_stock_curve()
+    clocks = [point["base_mhz"] for point in zotac]
+    return [
+        {
+            **dict(point),
+            "base_mhz": clocks[max(0, index - 3)],
+            "target_mhz": clocks[max(0, index - 3)],
+            "new_offset_mhz": 0,
+        }
+        for index, point in enumerate(zotac)
+    ]
+
+
 def stable_probe_result(
     *,
     fps: float = 100.0,

--- a/tests/auto_uv/power_governor_sim.py
+++ b/tests/auto_uv/power_governor_sim.py
@@ -1,0 +1,141 @@
+"""Test-only power-governor simulation for power-bound scan scenarios.
+
+Closes the loop the plain probe fakes cannot express: given an APPLIED V/F
+plan, a power model, and a board-power limit, compute where the governor
+settles and synthesize the telemetry a probe would collect there. This is
+what lets the suite state "measured clock is below target BECAUSE of the
+power cap" instead of merely asserting a number.
+
+Model: P(f, V) = idle_w + k * f * (V/1000)^2, plus an explicit synthetic
+spike-reserve margin. Tests exercise several coefficient/margin combinations
+and assert only regime invariants; this helper is not fitted or presented as
+a hardware prediction for any particular 5090.
+
+Test infrastructure only — never product code (the scan must not depend on
+a governor model; it reads real telemetry).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class GovernorPowerModel:
+    dynamic_w_per_mhz_v2: float
+    idle_w: float = 40.0
+    spike_margin_mv: float = 15.0
+
+
+def scenario_5090_power_models() -> tuple[GovernorPowerModel, ...]:
+    """Distinct synthetic response curves used to test invariant behavior."""
+    return (
+        GovernorPowerModel(
+            dynamic_w_per_mhz_v2=0.18,
+            idle_w=30.0,
+            spike_margin_mv=0.0,
+        ),
+        GovernorPowerModel(
+            dynamic_w_per_mhz_v2=0.20,
+            idle_w=40.0,
+            spike_margin_mv=15.0,
+        ),
+        GovernorPowerModel(
+            dynamic_w_per_mhz_v2=0.22,
+            idle_w=50.0,
+            spike_margin_mv=25.0,
+        ),
+    )
+
+
+def point_power_w(
+    model: GovernorPowerModel,
+    *,
+    clock_mhz: float,
+    voltage_mv: float,
+) -> float:
+    volts = float(voltage_mv) / 1000.0
+    return model.idle_w + model.dynamic_w_per_mhz_v2 * float(clock_mhz) * volts * volts
+
+
+def settle_operating_point(
+    plan: list[dict],
+    *,
+    model: GovernorPowerModel,
+    power_limit_w: float,
+) -> dict:
+    """Where the governor parks on ``plan`` under ``power_limit_w``.
+
+    The governor runs the highest-voltage curve point whose power fits the
+    limit; when the limit binds, it additionally backs off by the model's
+    spike margin. Returns voltage_mv/clock_mhz/power_w plus power_capped.
+    """
+    points = sorted(
+        (
+            (int(point["voltage_mv"]), int(point["target_mhz"]))
+            for point in plan
+            if point.get("voltage_mv") is not None
+            and point.get("target_mhz") is not None
+        ),
+        key=lambda item: item[0],
+    )
+    if not points:
+        raise ValueError("plan has no usable V/F points")
+
+    def fits(point: tuple[int, int]) -> bool:
+        voltage_mv, clock_mhz = point
+        return (
+            point_power_w(model, clock_mhz=clock_mhz, voltage_mv=voltage_mv)
+            <= float(power_limit_w)
+        )
+
+    feasible = [point for point in points if fits(point)]
+    power_capped = len(feasible) < len(points)
+    if not feasible:
+        settle_voltage_mv, settle_clock_mhz = points[0]
+    elif not power_capped:
+        settle_voltage_mv, settle_clock_mhz = points[-1]
+    else:
+        top_feasible_voltage_mv = feasible[-1][0]
+        margin_ceiling_mv = top_feasible_voltage_mv - float(model.spike_margin_mv)
+        margined = [point for point in feasible if point[0] <= margin_ceiling_mv]
+        settle_voltage_mv, settle_clock_mhz = (
+            margined[-1] if margined else feasible[0]
+        )
+    return {
+        "voltage_mv": int(settle_voltage_mv),
+        "clock_mhz": int(settle_clock_mhz),
+        "power_w": point_power_w(
+            model,
+            clock_mhz=settle_clock_mhz,
+            voltage_mv=settle_voltage_mv,
+        ),
+        "power_capped": bool(power_capped),
+    }
+
+
+def synthesize_busy_samples(
+    operating_point: dict,
+    *,
+    count: int = 8,
+    first_elapsed_s: float = 6.0,
+) -> list[dict]:
+    """Busy telemetry a probe would collect at the settled operating point.
+
+    Power-capped points carry the driver's sw-power perf-cap reason — the
+    same evidence the real scan reads to distinguish governor descent from
+    silent reliability demotion.
+    """
+    return [
+        {
+            "elapsed_s": float(first_elapsed_s) + float(index),
+            "gpu_util_pct": 99.0,
+            "power_w": float(operating_point["power_w"]),
+            "core_clock_mhz": float(operating_point["clock_mhz"]),
+            "voltage_mv": float(operating_point["voltage_mv"]),
+            "perf_cap_reason": (
+                "sw-power" if operating_point["power_capped"] else "none"
+            ),
+        }
+        for index in range(int(count))
+    ]

--- a/tests/auto_uv/test_auto_oc.py
+++ b/tests/auto_uv/test_auto_oc.py
@@ -134,6 +134,26 @@ def test_auto_oc_ladder_climbs_strictly_by_voltage_on_sparse_bins() -> None:
     assert len({step.voltage_mv for step in ladder}) == len(ladder)
 
 
+def test_auto_oc_ladder_can_reclaim_clock_at_fixed_voltage() -> None:
+    curve = base_curve(850, 950, 5, 2400, 15)
+
+    ladder = build_auto_oc_ladder(
+        curve,
+        start_voltage_mv=900,
+        start_clock_mhz=2400,
+        endpoint_voltage_mv=900,
+        endpoint_clock_mhz=2700,
+        max_steps=4,
+    )
+
+    assert [(step.voltage_mv, step.target_mhz) for step in ladder] == [
+        (900, 2475),
+        (900, 2550),
+        (900, 2625),
+        (900, 2700),
+    ]
+
+
 def test_auto_oc_probe_key_uses_q2rtx_clock_before_fps() -> None:
     lower_fps_higher_clock = _probe(950, 2745, fps=80.0, q2rtx_clock_mhz=2735.0)
     higher_fps_lower_clock = _probe(925, 2670, fps=120.0, q2rtx_clock_mhz=2680.0)
@@ -197,6 +217,56 @@ def test_auto_oc_search_climbs_voltage_and_clock_to_target() -> None:
         925,
         2980,
     )
+
+
+def test_auto_oc_search_reclaims_clock_at_fixed_voltage_with_capped_history() -> None:
+    curve = base_curve(850, 950, 5, 2400, 15)
+    start = VfCurveCandidate("balanced-winner", 900, 2400, curve)
+    baseline = _probe(1000, 2500, fps=90.0)
+    descended = _probe(900, 2400, fps=92.0)
+    tried: list[tuple[int, int]] = []
+    received_histories: list[list[AutoUvProbeSummary]] = []
+
+    class FakeRunner:
+        def probe_candidate(self, candidate, **kwargs):
+            tried.append((candidate.voltage_mv, candidate.target_mhz))
+            received_histories.append(kwargs["stable_history"])
+            return _passed_outcome(
+                _probe(
+                    candidate.voltage_mv,
+                    candidate.target_mhz,
+                    fps=93.0,
+                    q2rtx_clock_mhz=float(candidate.target_mhz),
+                )
+            )
+
+    result = run_auto_oc_candidate_search(
+        base_curve=curve,
+        start_candidate=start,
+        start_probe=descended,
+        runner=FakeRunner(),
+        gpu_name="NVIDIA GeForce RTX 5090",
+        clock_ceiling=None,
+        probe_history=[],
+        log=lambda _message: None,
+        max_interpolation_steps=4,
+        target_voltage_mv=900,
+        target_clock_mhz=2700,
+        target_profile_id="balanced",
+        probe_stable_history=[baseline, descended],
+    )
+
+    assert tried == [
+        (900, 2475),
+        (900, 2550),
+        (900, 2625),
+        (900, 2700),
+    ]
+    assert all(history == [baseline, descended] for history in received_histories)
+    assert (
+        result.selected_candidate.voltage_mv,
+        result.selected_candidate.target_mhz,
+    ) == (900, 2700)
 
 
 def test_auto_oc_search_skips_target_voltage_below_uv_candidate() -> None:

--- a/tests/auto_uv/test_auto_oc.py
+++ b/tests/auto_uv/test_auto_oc.py
@@ -582,3 +582,52 @@ def test_performance_sweep_profile_uses_passed_auto_oc_anchors_below_selection()
     assert by_voltage[900]["target_mhz"] == 1400
     assert by_voltage[925]["target_mhz"] == 1425
     assert by_voltage[950]["target_mhz"] == 1450
+
+
+def test_wall_limited_rung_is_not_adopted_and_stops_the_climb() -> None:
+    # A power-bound card delivers at most the wall clock no matter what lock
+    # the rung requests. The first rung whose request exceeds the wall by
+    # more than the shortfall tolerance must not be adopted as capability
+    # (its lock would overstate the curve), and the climb must stop there —
+    # higher rungs can only measure the same wall.
+    curve = base_curve(850, 955, 5, 2400, 15)
+    start = VfCurveCandidate("reclaim-start", 900, 2415, curve)
+    wall_mhz = 2450.0
+    tried: list[int] = []
+
+    class WallRunner:
+        power_limit_w = 460
+
+        def probe_candidate(self, candidate, **_kwargs):
+            tried.append(int(candidate.target_mhz))
+            measured = min(float(candidate.target_mhz), wall_mhz)
+            probe = _probe(
+                candidate.voltage_mv,
+                candidate.target_mhz,
+                q2rtx_clock_mhz=measured,
+            )
+            if measured < float(candidate.target_mhz):
+                probe.perf_cap_reason = "sw-power"
+            return _passed_outcome(probe)
+
+    result = run_auto_oc_candidate_search(
+        base_curve=curve,
+        start_candidate=start,
+        start_probe=_probe(900, 2415, q2rtx_clock_mhz=2415.0),
+        runner=WallRunner(),
+        gpu_name="NVIDIA GeForce RTX 4090",
+        clock_ceiling=None,
+        probe_history=[],
+        log=lambda _message: None,
+        target_voltage_mv=900,
+        target_clock_mhz=2700,
+    )
+
+    selected = result.selected_candidate
+    # The adopted lock never overstates the wall beyond the tolerance.
+    assert float(selected.target_mhz) <= wall_mhz + 22.5
+    # The climb stopped at the first wall-limited rung instead of walking
+    # the remaining ladder to the 2700MHz endpoint.
+    beyond_tolerance = [t for t in tried if t > wall_mhz + 22.5]
+    assert len(beyond_tolerance) == 1
+    assert max(tried) < 2700

--- a/tests/auto_uv/test_curve_vf_coverage.py
+++ b/tests/auto_uv/test_curve_vf_coverage.py
@@ -210,3 +210,35 @@ def test_lock_clock_takes_min_of_measured_and_previous() -> None:
 
     assert result < 2400
     assert result == min(2400, result)
+
+
+def test_lock_clock_does_not_ratchet_power_capped_measurement() -> None:
+    curve = base_curve(800, 1025, 25, 2000, 30)
+    probe = _probe_summary(avg_core_clock_mhz=2100.0)
+    probe.perf_cap_reason = "sw-power"
+
+    assert (
+        lock_clock_from_probe_loaded_clock(
+            curve,
+            probe=probe,
+            previous_lock_clock_mhz=2400,
+            power_limit_w=575,
+        )
+        == 2400
+    )
+
+
+def test_lock_clock_uses_power_limit_when_perf_cap_reason_is_unavailable() -> None:
+    curve = base_curve(800, 1025, 25, 2000, 30)
+    probe = _probe_summary(avg_core_clock_mhz=2100.0)
+    probe.avg_power_w = 566.0
+
+    assert (
+        lock_clock_from_probe_loaded_clock(
+            curve,
+            probe=probe,
+            previous_lock_clock_mhz=2400,
+            power_limit_w=575,
+        )
+        == 2400
+    )

--- a/tests/auto_uv/test_final_verification_modules.py
+++ b/tests/auto_uv/test_final_verification_modules.py
@@ -260,3 +260,40 @@ def test_verified_candidate_payload_rejects_malformed_plan_point() -> None:
             plan=[], lock_clock_mhz=2700, voltage_mv=900,
             probe=None, reason="r", label="l",
         )
+
+
+def test_verified_candidate_payload_records_power_regime() -> None:
+    from auto_uv.persistence.verified_candidate_result_file import (
+        verified_candidate_payload,
+    )
+
+    point = {
+        "index": 12,
+        "voltage_mv": 900,
+        "base_mhz": 2500,
+        "target_mhz": 2700,
+        "new_offset_mhz": 200,
+    }
+    capped = verified_candidate_payload(
+        plan=[point],
+        lock_clock_mhz=2700,
+        voltage_mv=900,
+        probe=None,
+        reason="r",
+        label="l",
+        configured_power_limit_w=503,
+    )
+    unrecorded = verified_candidate_payload(
+        plan=[point],
+        lock_clock_mhz=2700,
+        voltage_mv=900,
+        probe=None,
+        reason="r",
+        label="l",
+    )
+
+    # Crash recovery reads this to re-establish the measurement regime; the
+    # explicit None distinguishes "no cap" from a pre-regime cache entry
+    # only by absence of the key in truly old files.
+    assert capped["configured_power_limit_w"] == 503
+    assert unrecorded["configured_power_limit_w"] is None

--- a/tests/auto_uv/test_gpu_vf_curve_applier.py
+++ b/tests/auto_uv/test_gpu_vf_curve_applier.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
+
+from auto_uv.domain.types import AutoUvPowerLimitApplyError
 from auto_uv.gpu import gpu_vf_curve_applier
 from runtime.support import nvidia_runtime_defaults as runtime_defaults
 
@@ -70,17 +73,21 @@ def test_open_live_gpu_applier_applies_raised_auto_uv_power_limit(monkeypatch) -
     assert applier.baseline_power_limit_w == 360
     assert applier.requested_power_limit_w == 390
     assert applier.translated_gpu_policy["power_limit_w"] == 390
-    assert logs == ["Auto-UV power limit: applied 390W"]
+    assert logs == [
+        "Auto-UV power limit: applied 390W for discovery and sweep"
+    ]
 
     applier.apply_requested_power_limit(log=logs.append)
 
     assert controllers[0].power_limit_calls == [390]
     assert applier.power_limit_w == 390
     assert applier.translated_gpu_policy["power_limit_w"] == 390
-    assert logs == ["Auto-UV power limit: applied 390W"]
+    assert logs == [
+        "Auto-UV power limit: applied 390W for discovery and sweep"
+    ]
 
 
-def test_open_live_gpu_applier_defers_reduced_auto_uv_power_limit_until_final(
+def test_open_live_gpu_applier_applies_reduced_auto_uv_power_limit_for_scan(
     monkeypatch,
 ) -> None:
     logs: list[str] = []
@@ -92,14 +99,13 @@ def test_open_live_gpu_applier_defers_reduced_auto_uv_power_limit_until_final(
         log=logs.append,
     )
 
-    assert controllers[0].power_limit_calls == []
-    assert applier.power_limit_w == 360
+    assert controllers[0].power_limit_calls == [319]
+    assert applier.power_limit_w == 319
     assert applier.baseline_power_limit_w == 360
     assert applier.requested_power_limit_w == 319
-    assert applier.translated_gpu_policy["power_limit_w"] == 360
+    assert applier.translated_gpu_policy["power_limit_w"] == 319
     assert logs == [
-        "Auto-UV power limit: keeping 360W for discovery/sweep; "
-        "will apply 319W for final verification"
+        "Auto-UV power limit: applied 319W for discovery and sweep"
     ]
 
     applier.apply_requested_power_limit(log=logs.append)
@@ -107,31 +113,29 @@ def test_open_live_gpu_applier_defers_reduced_auto_uv_power_limit_until_final(
     assert controllers[0].power_limit_calls == [319]
     assert applier.power_limit_w == 319
     assert applier.translated_gpu_policy["power_limit_w"] == 319
-    assert logs[-1] == "Auto-UV power limit: applied 319W for final verification"
+    assert logs == [
+        "Auto-UV power limit: applied 319W for discovery and sweep"
+    ]
 
 
-def test_open_live_gpu_applier_continues_when_raised_power_limit_is_rejected(
+def test_open_live_gpu_applier_stops_when_raised_power_limit_is_rejected(
     monkeypatch,
 ) -> None:
     logs: list[str] = []
     controllers = _patch_power_environment(monkeypatch, error=_POWER_LIMIT_ERROR)
 
-    applier = gpu_vf_curve_applier.open_live_gpu_vf_curve_applier(
-        gpu_index=0,
-        runtime_options={"auto_uv_power_limit_w": 390},
-        log=logs.append,
-    )
+    with pytest.raises(
+        AutoUvPowerLimitApplyError,
+        match="scan stopped before probing",
+    ):
+        gpu_vf_curve_applier.open_live_gpu_vf_curve_applier(
+            gpu_index=0,
+            runtime_options={"auto_uv_power_limit_w": 390},
+            log=logs.append,
+        )
 
     assert controllers[0].power_limit_calls == [390]
-    assert applier.power_limit_w is None
-    assert applier.requested_power_limit_w is None
-    assert "power_limit_w" not in applier.translated_gpu_policy
-    assert logs == [
-        "Auto-UV power limit: unable to apply 390W; "
-        "continuing without saved power limit: "
-        "nvmlDeviceSetPowerManagementLimit failed with NVML error 3: "
-        "Not Supported"
-    ]
+    assert logs == []
 
 
 def test_laptop_fixed_power_limit_is_platform_managed_and_not_saved(
@@ -170,7 +174,7 @@ def test_laptop_fixed_power_limit_is_platform_managed_and_not_saved(
     assert applier.apply_requested_power_limit(log=logs.append) is None
     assert controllers[0].power_limit_calls == []
     assert logs == [
-        "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+        "Auto-UV power limit: skipped fixed write for final verification on mobile GPU; "
         "continuing without saved power limit"
     ]
 
@@ -217,12 +221,12 @@ def test_pci_identified_mobile_gpu_never_writes_or_saves_fixed_power_limit(
     assert applier.apply_requested_power_limit(log=logs.append) is None
     assert controllers[0].power_limit_calls == []
     assert logs[-1] == (
-        "Auto-UV power limit: skipped final fixed write on mobile GPU; "
+        "Auto-UV power limit: skipped fixed write for final verification on mobile GPU; "
         "continuing without saved power limit"
     )
 
 
-def test_final_power_limit_rejection_is_not_fatal_and_not_saved() -> None:
+def test_tier_power_limit_rejection_is_fatal_and_preserves_known_cap() -> None:
     logs: list[str] = []
 
     class FakePolicyController:
@@ -246,18 +250,80 @@ def test_final_power_limit_rejection_is_not_fatal_and_not_saved() -> None:
         requested_power_limit_w=43,
     )
 
-    assert applier.apply_requested_power_limit(log=logs.append) is None
+    with pytest.raises(
+        AutoUvPowerLimitApplyError,
+        match="probing under an unknown power regime",
+    ):
+        applier.apply_requested_power_limit(log=logs.append)
 
     assert policy_controller.power_limit_calls == [43]
-    assert applier.power_limit_w is None
+    assert applier.power_limit_w == 360
     assert applier.requested_power_limit_w is None
-    assert "power_limit_w" not in applier.translated_gpu_policy
-    assert logs == [
-        "Auto-UV power limit: unable to apply 43W for final verification; "
-        "continuing without saved power limit: "
-        "nvmlDeviceSetPowerManagementLimit failed with NVML error 3: "
-        "Not Supported"
-    ]
+    assert applier.translated_gpu_policy["power_limit_w"] == 360
+    assert logs == []
+
+
+def test_power_limit_readback_mismatch_stops_before_policy_is_updated() -> None:
+    class FakePolicyController:
+        def apply_power_limit_w(self, power_limit_w):
+            return int(power_limit_w)
+
+        def capabilities(self, *, refresh):
+            assert refresh
+            return cast(
+                Any,
+                type(
+                    "Caps",
+                    (),
+                    {
+                        "power": type(
+                            "Power",
+                            (),
+                            {"current_w": 300.0, "enforced_w": 300.0},
+                        )()
+                    },
+                )(),
+            )
+
+    applier = gpu_vf_curve_applier.LiveGpuVfCurveApplier(
+        gpu_index=0,
+        gpu=cast(Any, FakePolicyController()),
+        runtime_default_plan=[],
+        translated_gpu_policy={"power_limit_w": 360},
+        baseline_power_limit_w=360,
+        requested_power_limit_w=320,
+    )
+
+    with pytest.raises(AutoUvPowerLimitApplyError, match="read-back mismatch"):
+        applier.apply_requested_power_limit(log=lambda _message: None)
+
+    assert applier.power_limit_w == 360
+    assert applier.requested_power_limit_w is None
+
+
+def test_power_limit_readback_error_stops_before_policy_is_updated() -> None:
+    class FakePolicyController:
+        def apply_power_limit_w(self, power_limit_w):
+            return int(power_limit_w)
+
+        def capabilities(self, *, refresh):
+            assert refresh
+            raise RuntimeError("daemon read-back unavailable")
+
+    applier = gpu_vf_curve_applier.LiveGpuVfCurveApplier(
+        gpu_index=0,
+        gpu=cast(Any, FakePolicyController()),
+        runtime_default_plan=[],
+        translated_gpu_policy={"power_limit_w": 360},
+        baseline_power_limit_w=360,
+        requested_power_limit_w=320,
+    )
+
+    with pytest.raises(AutoUvPowerLimitApplyError, match="unable to read back"):
+        applier.apply_requested_power_limit(log=lambda _message: None)
+
+    assert applier.power_limit_w == 360
+    assert applier.requested_power_limit_w is None
 
 
 class _MemoryOffsetPolicyController:

--- a/tests/auto_uv/test_main_loop.py
+++ b/tests/auto_uv/test_main_loop.py
@@ -10,6 +10,7 @@ import pytest
 
 from auto_uv.domain.types import (
     AutoUvError,
+    AutoUvPowerLimitApplyError,
     AutoUvProbeSummary,
     FailureKind,
     FailureSeverity,
@@ -83,6 +84,8 @@ def test_discovery_probe_runner_uses_live_voltage_reader_keyword(monkeypatch) ->
             captured["reader"] = reader
             captured["live_voltage_reader"] = live_voltage_reader
             captured["kwargs"] = kwargs
+            self.power_limit_w = kwargs["power_limit_w"]
+            self.short_probe_base_duration_s = kwargs["short_probe_base_duration_s"]
 
         def probe_default_curve(self, *, base_curve, label_voltage_mv, label_clock_mhz):
             captured["base_curve"] = base_curve
@@ -114,7 +117,7 @@ def test_discovery_probe_runner_uses_live_voltage_reader_keyword(monkeypatch) ->
 
     assert captured["live_voltage_reader"] is FakeGpu.live_voltage_reader
     assert captured["label_voltage_mv"] == 1000
-    assert captured["kwargs"]["power_limit_w"] == 360
+    assert captured["kwargs"]["power_limit_w"] == 390
 
 
 def test_discovery_probe_logs_selected_gpu_light_load_diagnostic(monkeypatch) -> None:
@@ -127,8 +130,9 @@ def test_discovery_probe_logs_selected_gpu_light_load_diagnostic(monkeypatch) ->
         power_limit_w = 110
 
     class FakeRunner:
-        def __init__(self, **_kwargs):
-            return None
+        def __init__(self, **kwargs):
+            self.power_limit_w = kwargs["power_limit_w"]
+            self.short_probe_base_duration_s = kwargs["short_probe_base_duration_s"]
 
         def probe_default_curve(self, *, base_curve, label_voltage_mv, label_clock_mhz):
             _ = base_curve, label_voltage_mv, label_clock_mhz
@@ -2178,6 +2182,68 @@ def test_select_performance_auto_oc_candidate_returns_oc_metadata(monkeypatch) -
     assert oc_metadata["auto_oc_limit_mhz"] == 380
 
 
+def test_power_bound_clock_reclaim_uses_fixed_voltage_tier_target(monkeypatch) -> None:
+    curve = base_curve(850, 1000, 25, 2000, 40)
+    stable_probe = _summary(900, 2400)
+    reclaimed_probe = _summary(900, 2550)
+    stable_history = [_summary(1000, 2500), stable_probe]
+    captured: dict[str, Any] = {}
+    passed_attempt = SimpleNamespace(
+        outcome=SimpleNamespace(
+            decision=SimpleNamespace(passed=True),
+            raw_probe=reclaimed_probe,
+        )
+    )
+
+    def fake_search(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            selected_candidate=VfCurveCandidate("reclaimed", 900, 2550, curve),
+            selected_probe=reclaimed_probe,
+            attempts=(passed_attempt,),
+        )
+
+    monkeypatch.setattr(
+        performance_uv_loop,
+        "run_auto_oc_candidate_search",
+        fake_search,
+    )
+
+    plan, voltage_mv, clock_mhz, probe, metadata = (
+        performance_uv_loop.select_power_bound_clock_reclaim_candidate(
+            curve,
+            auto_uv_mode="balanced",
+            stable_plan=curve,
+            stable_voltage_mv=900,
+            stable_lock_clock_mhz=2400,
+            stable_probe=stable_probe,
+            stable_history=stable_history,
+            runner=object(),
+            gpu_name="NVIDIA GeForce RTX 5090",
+            clock_ceiling=None,
+            probe_history=[],
+            log=lambda _message: None,
+            tail_rise_bins=4,
+            measured_baseline_clock_mhz=2500,
+        )
+    )
+
+    assert plan is curve
+    assert (voltage_mv, clock_mhz, probe) == (900, 2550, reclaimed_probe)
+    assert captured["target_voltage_mv"] == 900
+    assert captured["target_clock_mhz"] == 2900
+    assert captured["target_profile_id"] == "balanced"
+    assert captured["probe_stable_history"] is stable_history
+    assert stable_history[-1] is reclaimed_probe
+    assert metadata == {
+        "clock_reclaim": True,
+        "clock_reclaim_start_mhz": 2400,
+        "clock_reclaim_target_mhz": 2900,
+        "clock_reclaim_selected_mhz": 2550,
+        "clock_reclaim_voltage_mv": 900,
+    }
+
+
 # --- orchestration: discovery / baseline failure guards -------------------
 
 
@@ -2679,7 +2745,6 @@ def test_adaptive_tier_progress_events_are_chronological(monkeypatch) -> None:
         baseline_target=SimpleNamespace(measured_clock_mhz=2400),
         effective_min_search_voltage_mv=800,
         unsafe_entries=[],
-        probe_candidate=lambda _candidate: None,
         finish_with_final_verification=fake_finish,
         event_callback=lambda event, payload: events.append((event, payload)),
         log=lambda _message: None,
@@ -2759,12 +2824,18 @@ def test_performance_can_reuse_balanced_descent_gate() -> None:
             history=[],
             descent_tail_rise_bins=int(descent_tail),
             memory_offset_mhz=int(memory_offset_mhz),
+            power_limit_w=360,
+            baseline_voltage_mv=1000,
+            baseline_target_mhz=2400,
         )
 
     logs: list[str] = []
     gate_kwargs: dict[str, Any] = dict(
         performance_min_core_clock_pct=94.6,
         measured_baseline_clock_mhz=2742.5,
+        performance_baseline_voltage_mv=1000,
+        performance_baseline_target_mhz=2400,
+        performance_power_limit_w=360,
         log=logs.append,
     )
     # No balanced descent to donate (balanced never ran or crashed out).
@@ -2777,6 +2848,21 @@ def test_performance_can_reuse_balanced_descent_gate() -> None:
         donation(descent_tail=performance_tail, memory_offset_mhz=6000),
         performance_memory_offset_mhz=6000,
         **gate_kwargs,
+    )
+    # The same curve inputs under a different cap are a different experiment.
+    mismatched_power_kwargs = dict(gate_kwargs)
+    mismatched_power_kwargs["performance_power_limit_w"] = 300
+    assert not performance_can_reuse_balanced_descent(
+        donation(descent_tail=performance_tail, memory_offset_mhz=6000),
+        performance_memory_offset_mhz=6000,
+        **mismatched_power_kwargs,
+    )
+    mismatched_baseline_kwargs = dict(gate_kwargs)
+    mismatched_baseline_kwargs["performance_baseline_target_mhz"] = 2415
+    assert not performance_can_reuse_balanced_descent(
+        donation(descent_tail=performance_tail, memory_offset_mhz=6000),
+        performance_memory_offset_mhz=6000,
+        **mismatched_baseline_kwargs,
     )
     # A diverging per-tier memory offset changes the physics of the descent.
     assert not performance_can_reuse_balanced_descent(
@@ -2811,6 +2897,8 @@ def test_performance_can_reuse_balanced_descent_gate() -> None:
         **gate_kwargs,
     )
     assert any("memory offset" in line for line in logs)
+    assert any("power limit" in line for line in logs)
+    assert any("capped baseline" in line for line in logs)
     assert any("tail" in line for line in logs)
     assert any("clock floor" in line for line in logs)
 
@@ -2869,7 +2957,6 @@ def _adaptive_scan_kwargs(*, events, descent_calls, runtime_options=None):
         baseline_target=SimpleNamespace(measured_clock_mhz=2400),
         effective_min_search_voltage_mv=800,
         unsafe_entries=[],
-        probe_candidate=lambda _candidate: None,
         finish_with_final_verification=fake_finish,
         event_callback=lambda event, payload: events.append((event, payload)),
         log=lambda _message: None,
@@ -3007,6 +3094,390 @@ def test_adaptive_performance_descends_when_memory_offsets_differ(
     assert not [event for event, _ in events if event == "tier_descent_reused"]
 
 
+def test_adaptive_tier_cap_is_live_before_its_baseline_and_descent(
+    monkeypatch,
+) -> None:
+    events: list = []
+    descent_calls: list[str] = []
+    main_loop, fake_descent, kwargs = _adaptive_scan_kwargs(
+        events=events,
+        descent_calls=descent_calls,
+        runtime_options={
+            "auto_uv_efficiency_power_limit_w": 250,
+            "auto_uv_balanced_power_limit_w": 300,
+            "auto_uv_performance_power_limit_w": 360,
+        },
+    )
+
+    class FakeGpu:
+        baseline_power_limit_w = 360
+
+        def __init__(self) -> None:
+            self.translated_gpu_policy = {
+                "gpu_name": "Test GPU",
+                "power_limit_w": 360,
+            }
+            self.requested_power_limit_w = None
+            self.policy_controller = SimpleNamespace(
+                get_memory_clock_offset_range_mhz=lambda: (0, 4000)
+            )
+            self.gpu = SimpleNamespace(
+                apply_clock_offsets=lambda mem_clk_vf_offset_mhz: {
+                    "mem_clk_vf_offset_readback_mhz": int(
+                        mem_clk_vf_offset_mhz
+                    )
+                }
+            )
+
+        @property
+        def power_limit_w(self):
+            return self.translated_gpu_policy.get("power_limit_w")
+
+        def clamp_power_limit_w(self, watts):
+            return int(watts)
+
+        def apply_requested_power_limit(self, *, log, purpose):
+            assert purpose.endswith("scan")
+            watts = int(self.requested_power_limit_w)
+            self.translated_gpu_policy["power_limit_w"] = watts
+            self.requested_power_limit_w = None
+            log(f"applied {watts}W")
+            return watts
+
+    gpu = FakeGpu()
+    kwargs["gpu"] = gpu
+    kwargs["base_loop_settings"] = main_loop.AutoUvScanSettings(
+        start_voltage_mv=1000,
+        min_search_voltage_mv=800,
+        baseline_core_clock_mhz=2500.0,
+    )
+    baseline_caps: list[tuple[str, int]] = []
+
+    def prepare_tier_baseline(*, tier_mode, tier_runner, **_kwargs):
+        baseline_caps.append((tier_mode, int(gpu.power_limit_w)))
+        probe = SimpleNamespace(avg_core_clock_mhz=2500.0, avg_voltage_mv=900.0)
+        return main_loop.AdaptiveTierBaseline(
+            runner=tier_runner,
+            candidate=VfCurveCandidate(f"{tier_mode}-baseline", 1000, 2500, []),
+            target=SimpleNamespace(measured_clock_mhz=2500.0),
+            outcome=None,
+            stable_probe=probe,
+            discovery_summary=probe,
+            min_search_voltage_mv=800,
+        )
+
+    kwargs["prepare_tier_baseline"] = prepare_tier_baseline
+
+    def fake_selection(**selection_kwargs):
+        return SimpleNamespace(
+            plan=list(selection_kwargs["stable_plan"]),
+            voltage_mv=int(selection_kwargs["stable_voltage_mv"]),
+            lock_clock_mhz=int(selection_kwargs["stable_lock_clock_mhz"]),
+            probe=selection_kwargs["stable_probe"],
+            verification_duration_s=int(
+                selection_kwargs["final_verification_duration_s"]
+            ),
+            tail_rise_bins=int(selection_kwargs["tail_rise_bins"]),
+            auto_oc_metadata={},
+        )
+
+    monkeypatch.setattr(main_loop, "run_adaptive_tier_descent", fake_descent)
+    monkeypatch.setattr(main_loop, "select_final_scan_candidate", fake_selection)
+
+    main_loop.run_adaptive_tier_scans(**kwargs)
+
+    assert baseline_caps == [
+        ("efficiency", 250),
+        ("balanced", 300),
+        ("performance", 360),
+    ]
+    # Balanced cannot donate a descent measured under a different cap.
+    assert descent_calls == ["efficiency", "balanced", "performance"]
+
+
+def test_rtx_5090_tier_cap_is_constant_across_every_phase(monkeypatch) -> None:
+    events: list = []
+    descent_calls: list[str] = []
+    main_loop, _fake_descent, kwargs = _adaptive_scan_kwargs(
+        events=events,
+        descent_calls=descent_calls,
+    )
+
+    class FakeGpu:
+        baseline_power_limit_w = 575
+
+        def __init__(self) -> None:
+            self.translated_gpu_policy = {
+                "gpu_name": "NVIDIA GeForce RTX 5090",
+                "power_limit_w": 575,
+            }
+            self.requested_power_limit_w = None
+            self.policy_controller = SimpleNamespace(
+                get_memory_clock_offset_range_mhz=lambda: (0, 4000)
+            )
+            self.gpu = SimpleNamespace(
+                apply_clock_offsets=lambda mem_clk_vf_offset_mhz: {
+                    "mem_clk_vf_offset_readback_mhz": int(
+                        mem_clk_vf_offset_mhz
+                    )
+                }
+            )
+
+        @property
+        def power_limit_w(self):
+            return self.translated_gpu_policy.get("power_limit_w")
+
+        def clamp_power_limit_w(self, watts):
+            return int(watts)
+
+        def apply_requested_power_limit(self, *, log, purpose):
+            watts = int(self.requested_power_limit_w)
+            self.translated_gpu_policy["power_limit_w"] = watts
+            self.requested_power_limit_w = None
+            log(f"{purpose}: {watts}W")
+            return watts
+
+    gpu = FakeGpu()
+    kwargs["gpu"] = gpu
+    kwargs["base_loop_settings"] = main_loop.AutoUvScanSettings(
+        start_voltage_mv=1000,
+        min_search_voltage_mv=800,
+        baseline_core_clock_mhz=2500.0,
+    )
+    phases: list[tuple[str, str, int]] = []
+    reclaim_flags: list[tuple[str, bool]] = []
+
+    def prepare_tier_baseline(*, tier_mode, tier_runner, **_kwargs):
+        phases.append((tier_mode, "stock-and-flat-baseline", int(gpu.power_limit_w)))
+        probe = SimpleNamespace(
+            avg_core_clock_mhz=2500.0,
+            avg_voltage_mv=900.0,
+            perf_cap_reason="sw-power",
+        )
+        return main_loop.AdaptiveTierBaseline(
+            runner=tier_runner,
+            candidate=VfCurveCandidate(f"{tier_mode}-baseline", 1000, 2500, []),
+            target=SimpleNamespace(measured_clock_mhz=2500.0),
+            outcome=None,
+            stable_probe=probe,
+            discovery_summary=probe,
+            min_search_voltage_mv=800,
+        )
+
+    def fake_descent(_base_curve, *, tier_mode, **_kwargs):
+        phases.append((tier_mode, "descent", int(gpu.power_limit_w)))
+        candidate = VfCurveCandidate(tier_mode, 900, 2500, [])
+        probe = SimpleNamespace(avg_core_clock_mhz=2500.0)
+        return candidate, 4, probe, [probe]
+
+    def fake_selection(**selection_kwargs):
+        tier = selection_kwargs["auto_uv_mode_override"]
+        phases.append((tier, "selection", int(gpu.power_limit_w)))
+        reclaim_flags.append(
+            (tier, bool(selection_kwargs["run_power_bound_clock_reclaim"]))
+        )
+        return SimpleNamespace(
+            plan=list(selection_kwargs["stable_plan"]),
+            voltage_mv=int(selection_kwargs["stable_voltage_mv"]),
+            lock_clock_mhz=int(selection_kwargs["stable_lock_clock_mhz"]),
+            probe=selection_kwargs["stable_probe"],
+            verification_duration_s=int(
+                selection_kwargs["final_verification_duration_s"]
+            ),
+            tail_rise_bins=int(selection_kwargs["tail_rise_bins"]),
+            auto_oc_metadata={},
+        )
+
+    def fake_finish(**finish_kwargs):
+        tier = finish_kwargs["final_profile_tier"]
+        phases.append((tier, "final-verification", int(gpu.power_limit_w)))
+        return SimpleNamespace(
+            final_voltage_mv=int(finish_kwargs["final_stable_voltage_mv"]),
+            lock_clock_mhz=int(finish_kwargs["final_stable_lock_clock_mhz"]),
+        )
+
+    kwargs["prepare_tier_baseline"] = prepare_tier_baseline
+    kwargs["finish_with_final_verification"] = fake_finish
+    monkeypatch.setattr(main_loop, "run_adaptive_tier_descent", fake_descent)
+    monkeypatch.setattr(main_loop, "select_final_scan_candidate", fake_selection)
+
+    main_loop.run_adaptive_tier_scans(**kwargs)
+
+    assert phases == [
+        (tier, phase, watts)
+        for tier, watts in (
+            ("efficiency", 430),
+            ("balanced", 503),
+            ("performance", 575),
+        )
+        for phase in (
+            "stock-and-flat-baseline",
+            "descent",
+            "selection",
+            "final-verification",
+        )
+    ]
+    assert reclaim_flags == [
+        ("efficiency", True),
+        ("balanced", True),
+        ("performance", False),
+    ]
+
+
+def test_adaptive_baseline_failure_skips_only_that_tier(monkeypatch) -> None:
+    events: list = []
+    descent_calls: list[str] = []
+    main_loop, fake_descent, kwargs = _adaptive_scan_kwargs(
+        events=events,
+        descent_calls=descent_calls,
+        runtime_options={"auto_uv_performance_memory_offset_mhz": 1000},
+    )
+    selected_tiers: list[str] = []
+
+    def prepare_tier_baseline(*, tier_mode, tier_runner, **_kwargs):
+        if tier_mode == "efficiency":
+            raise AutoUvError("capped flattened baseline failed")
+        probe = SimpleNamespace(avg_core_clock_mhz=2500.0, avg_voltage_mv=900.0)
+        return main_loop.AdaptiveTierBaseline(
+            runner=tier_runner,
+            candidate=VfCurveCandidate(f"{tier_mode}-baseline", 1000, 2500, []),
+            target=SimpleNamespace(measured_clock_mhz=2500.0),
+            outcome=None,
+            stable_probe=probe,
+            discovery_summary=probe,
+            min_search_voltage_mv=800,
+        )
+
+    def fake_selection(**selection_kwargs):
+        selected_tiers.append(selection_kwargs["auto_uv_mode_override"])
+        return SimpleNamespace(
+            plan=list(selection_kwargs["stable_plan"]),
+            voltage_mv=int(selection_kwargs["stable_voltage_mv"]),
+            lock_clock_mhz=int(selection_kwargs["stable_lock_clock_mhz"]),
+            probe=selection_kwargs["stable_probe"],
+            verification_duration_s=int(
+                selection_kwargs["final_verification_duration_s"]
+            ),
+            tail_rise_bins=int(selection_kwargs["tail_rise_bins"]),
+            auto_oc_metadata={},
+        )
+
+    kwargs["prepare_tier_baseline"] = prepare_tier_baseline
+    kwargs["base_loop_settings"] = main_loop.AutoUvScanSettings(
+        start_voltage_mv=1000,
+        min_search_voltage_mv=800,
+        baseline_core_clock_mhz=2500.0,
+    )
+    monkeypatch.setattr(main_loop, "run_adaptive_tier_descent", fake_descent)
+    monkeypatch.setattr(main_loop, "select_final_scan_candidate", fake_selection)
+    monkeypatch.setattr(
+        main_loop, "apply_adaptive_tier_power_limit", lambda *_a, **_k: None
+    )
+
+    main_loop.run_adaptive_tier_scans(**kwargs)
+
+    assert descent_calls == ["balanced", "performance"]
+    assert selected_tiers == ["balanced", "performance"]
+    skipped = [payload for event, payload in events if event == "tier_skipped"]
+    assert [(item["tier"], item["reason"]) for item in skipped] == [
+        ("efficiency", "baseline-failed")
+    ]
+
+
+def test_adaptive_power_limit_failure_aborts_before_tier_baseline(monkeypatch) -> None:
+    events: list = []
+    descent_calls: list[str] = []
+    main_loop, fake_descent, kwargs = _adaptive_scan_kwargs(
+        events=events,
+        descent_calls=descent_calls,
+        runtime_options={
+            "auto_uv_efficiency_power_limit_w": 250,
+            "auto_uv_balanced_power_limit_w": 300,
+            "auto_uv_performance_power_limit_w": 360,
+        },
+    )
+
+    class FakeGpu:
+        baseline_power_limit_w = 360
+
+        def __init__(self) -> None:
+            self.translated_gpu_policy = {
+                "gpu_name": "Test GPU",
+                "power_limit_w": 360,
+            }
+            self.requested_power_limit_w = None
+            self.policy_controller = SimpleNamespace(
+                get_memory_clock_offset_range_mhz=lambda: (0, 4000)
+            )
+            self.gpu = SimpleNamespace(
+                apply_clock_offsets=lambda mem_clk_vf_offset_mhz: {
+                    "mem_clk_vf_offset_readback_mhz": int(
+                        mem_clk_vf_offset_mhz
+                    )
+                }
+            )
+
+        @property
+        def power_limit_w(self):
+            return self.translated_gpu_policy.get("power_limit_w")
+
+        def clamp_power_limit_w(self, watts):
+            return int(watts)
+
+        def apply_requested_power_limit(self, *, log, purpose):
+            watts = int(self.requested_power_limit_w)
+            if watts == 300:
+                raise AutoUvPowerLimitApplyError("503W-style tier cap write failed")
+            self.translated_gpu_policy["power_limit_w"] = watts
+            self.requested_power_limit_w = None
+            return watts
+
+    gpu = FakeGpu()
+    kwargs["gpu"] = gpu
+    baselines: list[str] = []
+
+    def prepare_tier_baseline(*, tier_mode, tier_runner, **_kwargs):
+        baselines.append(tier_mode)
+        probe = SimpleNamespace(avg_core_clock_mhz=2500.0, avg_voltage_mv=900.0)
+        return main_loop.AdaptiveTierBaseline(
+            runner=tier_runner,
+            candidate=VfCurveCandidate(f"{tier_mode}-baseline", 1000, 2500, []),
+            target=SimpleNamespace(measured_clock_mhz=2500.0),
+            outcome=None,
+            stable_probe=probe,
+            discovery_summary=probe,
+            min_search_voltage_mv=800,
+        )
+
+    kwargs["prepare_tier_baseline"] = prepare_tier_baseline
+    kwargs["base_loop_settings"] = main_loop.AutoUvScanSettings(
+        start_voltage_mv=1000,
+        min_search_voltage_mv=800,
+        baseline_core_clock_mhz=2500.0,
+    )
+    monkeypatch.setattr(main_loop, "run_adaptive_tier_descent", fake_descent)
+    monkeypatch.setattr(
+        main_loop,
+        "select_final_scan_candidate",
+        lambda **selection_kwargs: SimpleNamespace(
+            plan=list(selection_kwargs["stable_plan"]),
+            voltage_mv=int(selection_kwargs["stable_voltage_mv"]),
+            lock_clock_mhz=int(selection_kwargs["stable_lock_clock_mhz"]),
+            probe=selection_kwargs["stable_probe"],
+            verification_duration_s=int(
+                selection_kwargs["final_verification_duration_s"]
+            ),
+            tail_rise_bins=int(selection_kwargs["tail_rise_bins"]),
+            auto_oc_metadata={},
+        ),
+    )
+
+    with pytest.raises(AutoUvPowerLimitApplyError, match="tier cap write failed"):
+        main_loop.run_adaptive_tier_scans(**kwargs)
+
+    assert baselines == ["efficiency"]
+
+
 def test_clamp_power_limit_keeps_request_inside_card_range() -> None:
     from auto_uv.gpu.gpu_vf_curve_applier import LiveGpuVfCurveApplier
 
@@ -3100,6 +3571,7 @@ def test_apply_adaptive_tier_power_limit_explicit_watts_wins() -> None:
     gpu = SimpleNamespace(
         requested_power_limit_w=None,
         clamp_power_limit_w=lambda watts: max(300, min(400, int(watts))),
+        translated_gpu_policy={"gpu_name": "Unknown GPU"},
     )
     # An explicit per-tier request bypasses the balanced-anchor scaling
     # (clamped to the card's NVML range).
@@ -3134,6 +3606,18 @@ def test_apply_adaptive_tier_power_limit_explicit_watts_wins() -> None:
         explicit_watts=390,
     )
     assert gpu.requested_power_limit_w == 320
+
+    # A tier without a table/explicit request restores stock instead of
+    # inheriting the previous tier's reduced cap.
+    apply_adaptive_tier_power_limit(
+        gpu,
+        tier_mode="balanced",
+        stock_power_limit_w=360,
+        scan_request_w=None,
+        balanced_pct=None,
+        explicit_watts=None,
+    )
+    assert gpu.requested_power_limit_w == 360
 
 
 def test_full_scan_open_paths_fall_back_to_per_tier_options() -> None:
@@ -3369,7 +3853,6 @@ def test_adaptive_tiers_flow_per_tier_limits_into_probe_and_selection(
         baseline_target=SimpleNamespace(measured_clock_mhz=2400),
         effective_min_search_voltage_mv=800,
         unsafe_entries=[],
-        probe_candidate=lambda _candidate: None,
         finish_with_final_verification=fake_finish,
         event_callback=lambda event, payload: events.append((event, payload)),
         log=lambda _message: None,
@@ -3387,3 +3870,52 @@ def test_adaptive_tiers_flow_per_tier_limits_into_probe_and_selection(
     assert [floor for floor, _margin in finish_margins] == [85.0, 94.0, 94.6]
     # Each tier's explicit power request is applied before its verification.
     assert tier_power_requests == [250, 300, 360]
+
+
+def test_power_capped_fps_failure_keeps_saved_candidate_ladder(monkeypatch) -> None:
+    messages: list[str] = []
+    chooser_calls: list[dict] = []
+    monkeypatch.setattr(
+        undervolt_main_loop,
+        "choose_next_final_verification_candidate_after_failure",
+        lambda **kwargs: chooser_calls.append(kwargs) or None,
+    )
+    failed_selection = undervolt_main_loop.FinalScanCandidate(
+        plan=[],
+        voltage_mv=1000,
+        lock_clock_mhz=2595,
+        probe=None,
+        verification_duration_s=60,
+        auto_oc_metadata={},
+        tail_rise_bins=2,
+    )
+
+    failed_error = AutoUvError(
+        "final long verification failed: benchmark average FPS below floor"
+    )
+    failed_error.power_capped = True
+    selection = undervolt_main_loop.choose_next_candidate_after_final_failure(
+        base_curve=[],
+        settings=SimpleNamespace(
+            auto_uv_mode="balanced",
+            min_performance_core_clock_pct=94.0,
+        ),
+        stable_plan=[],
+        stable_voltage_mv=1000,
+        stable_lock_clock_mhz=2595,
+        stable_history=[],
+        discovery_summary=None,
+        baseline_candidate=VfCurveCandidate("baseline", 1000, 2595, []),
+        final_verification_duration_s=60,
+        short_probe_base_duration_s=10,
+        failed_error=failed_error,
+        failed_selection=failed_selection,
+        run_profile_tier="balanced",
+        log=messages.append,
+        event_callback=None,
+        tail_rise_bins=2,
+    )
+
+    assert selection is None
+    assert len(chooser_calls) == 1
+    assert any("offering saved candidates" in message for message in messages)

--- a/tests/auto_uv/test_power_bound_5090.py
+++ b/tests/auto_uv/test_power_bound_5090.py
@@ -1,0 +1,315 @@
+"""Power-bound 5090 scenarios: captured geometry plus synthetic governors.
+
+The simulator explains causality (a configured cap can make measured clock
+differ from the curve target) without claiming to predict a particular board.
+Product cap values and orchestration parity are tested separately against the
+real PenguinBurner tier logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from auto_uv.curve.base_load_flatten_target import choose_base_load_flatten_target
+from auto_uv.curve.measured_probe_lock_clock import lock_clock_from_probe_loaded_clock
+from auto_uv.curve.shipped_plan import restore_stock_below_validated_floor
+from auto_uv.curve.vf_curve_flattening import build_flattened_plan
+from auto_uv.domain.types import AutoUvProbeSummary, FailureKind
+from auto_uv.probes.stability_decision import (
+    StabilityThresholds,
+    evaluate_loaded_telemetry,
+)
+from auto_uv_test_data import (
+    rtx_5080_20260524_high_oc_base_curve,
+    rtx_5090_steep_synthetic_curve,
+    rtx_5090_zotac_amp_stock_curve,
+)
+from power_governor_sim import (
+    GovernorPowerModel,
+    scenario_5090_power_models,
+    settle_operating_point,
+    synthesize_busy_samples,
+)
+
+EFFICIENCY_CAP_W = 430
+BALANCED_CAP_W = 503
+PERFORMANCE_CAP_W = 575
+
+
+def _editable_targets(plan: list[dict]) -> list[tuple[int, int]]:
+    return sorted(
+        (int(point["voltage_mv"]), int(point["target_mhz"]))
+        for point in plan
+        if not point.get("preserve_base")
+    )
+
+
+def _probe(
+    *,
+    avg_core_clock_mhz: float,
+    avg_power_w: float,
+    perf_cap_reason: str | None,
+) -> AutoUvProbeSummary:
+    return AutoUvProbeSummary(
+        candidate_voltage_mv=1000,
+        lock_clock_mhz=2595,
+        live_voltage_before_mv=1000,
+        live_voltage_after_mv=1000,
+        avg_voltage_mv=950.0,
+        frames_per_run=1000,
+        avg_seconds_per_run=10.0,
+        avg_fps=100.0,
+        min_fps=100.0,
+        max_fps=100.0,
+        avg_power_w=float(avg_power_w),
+        max_power_w=float(avg_power_w) + 10.0,
+        avg_temperature_c=74.0,
+        max_temperature_c=76.0,
+        avg_fan_speed_pct=60.0,
+        max_fan_speed_pct=85.0,
+        avg_core_clock_mhz=float(avg_core_clock_mhz),
+        efficiency_fps_per_w=0.2,
+        efficiency_mhz_per_w=4.6,
+        watts_per_mhz=0.21,
+        used_companion_load=True,
+        result_reason="stable run",
+        log_path=Path("/tmp/q2rtx.log"),
+        perf_cap_reason=perf_cap_reason,
+    )
+
+
+@pytest.mark.parametrize("model", scenario_5090_power_models())
+def test_s1_capped_baseline_targets_what_the_cap_allows(
+    model: GovernorPowerModel,
+) -> None:
+    curve = rtx_5090_steep_synthetic_curve()
+
+    settle = settle_operating_point(curve, model=model, power_limit_w=BALANCED_CAP_W)
+
+    # The curve's top point is unreachable: the governor parks in the knee
+    # band, hundreds of MHz below the top target.
+    assert settle["power_capped"]
+    assert settle["voltage_mv"] < max(p["voltage_mv"] for p in curve)
+    assert settle["clock_mhz"] < max(p["target_mhz"] for p in curve)
+
+    target = choose_base_load_flatten_target(
+        curve,
+        synthesize_busy_samples(settle),
+        power_limit_w=BALANCED_CAP_W,
+        fallback_clock_mhz=None,
+    )
+
+    # Target derivation under the shipped cap is honest by construction:
+    # the flat target is the snapped settled clock, not a stock-limit clock.
+    assert target.target_clock_mhz == (settle["clock_mhz"] // 15) * 15
+
+
+@pytest.mark.parametrize("model", scenario_5090_power_models())
+def test_s2_honest_target_flat_holds_its_clock_under_the_cap(
+    model: GovernorPowerModel,
+) -> None:
+    curve = rtx_5090_steep_synthetic_curve()
+    baseline = settle_operating_point(curve, model=model, power_limit_w=BALANCED_CAP_W)
+    lock_clock_mhz = (baseline["clock_mhz"] // 15) * 15
+    plan = build_flattened_plan(
+        curve,
+        lock_clock_mhz=lock_clock_mhz,
+        candidate_voltage_mv=int(baseline["voltage_mv"]),
+    )
+
+    settle = settle_operating_point(plan, model=model, power_limit_w=BALANCED_CAP_W)
+    decision = evaluate_loaded_telemetry(
+        synthesize_busy_samples(settle),
+        baseline_power_w=float(baseline["power_w"]),
+        baseline_core_clock_mhz=float(lock_clock_mhz),
+        power_limit_w=BALANCED_CAP_W,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    # A cap-derived flat is cheap enough that the governor holds the full
+    # lock clock (it parks on the flat, above the lock voltage if it likes).
+    assert settle["clock_mhz"] == lock_clock_mhz
+    assert decision.passed
+
+
+@pytest.mark.parametrize("model", scenario_5090_power_models())
+def test_product_tier_caps_order_synthetic_operating_points(
+    model: GovernorPowerModel,
+) -> None:
+    curve = rtx_5090_steep_synthetic_curve()
+    points = [
+        settle_operating_point(curve, model=model, power_limit_w=cap_w)
+        for cap_w in (EFFICIENCY_CAP_W, BALANCED_CAP_W, PERFORMANCE_CAP_W)
+    ]
+
+    assert all(point["power_capped"] for point in points)
+    assert [point["clock_mhz"] for point in points] == sorted(
+        point["clock_mhz"] for point in points
+    )
+    assert [point["voltage_mv"] for point in points] == sorted(
+        point["voltage_mv"] for point in points
+    )
+
+
+def test_s3_ratchet_keeps_target_when_probe_was_power_capped() -> None:
+    curve = rtx_5090_steep_synthetic_curve()
+    probe = _probe(
+        avg_core_clock_mhz=2418.5,
+        avg_power_w=553.0,
+        perf_cap_reason="sw-power",
+    )
+
+    # The field scan turned this exact probe into a 2595 -> 2418 ratchet.
+    assert (
+        lock_clock_from_probe_loaded_clock(
+            curve,
+            probe=probe,
+            previous_lock_clock_mhz=2595,
+            power_limit_w=575,
+        )
+        == 2595
+    )
+
+
+def test_s4_changed_cap_moves_operation_below_lock_without_predicting_hardware() -> None:
+    # Illustrate the old regime mismatch with actual PenguinBurner tier caps:
+    # a target selected at the 575W Performance budget is then operated at the
+    # 430W Efficiency budget. This is not a replay of the Reddit card because
+    # its configured final power limit is unknown.
+    curve = rtx_5090_steep_synthetic_curve()
+    model = scenario_5090_power_models()[1]
+    shipped = restore_stock_below_validated_floor(
+        build_flattened_plan(
+            curve,
+            lock_clock_mhz=2595,
+            candidate_voltage_mv=1000,
+        ),
+        floor_voltage_mv=1000,
+        lock_clock_mhz=2595,
+    )
+
+    settle = settle_operating_point(
+        shipped, model=model, power_limit_w=EFFICIENCY_CAP_W
+    )
+
+    assert settle["voltage_mv"] < 1000
+    assert settle["clock_mhz"] < 2595
+    assert settle["power_capped"]
+
+    decision = evaluate_loaded_telemetry(
+        synthesize_busy_samples(settle),
+        baseline_power_w=500.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=EFFICIENCY_CAP_W,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    # The saturation-aware floor recognizes governor descent. The full probe
+    # path still enforces same-cap FPS and crash/companion-load decisions.
+    assert decision.passed
+    assert "power-walled but stable" in decision.reason
+
+
+def test_s5_shipped_plan_shape_is_monotonic_and_clamped() -> None:
+    curve = rtx_5090_steep_synthetic_curve()
+    shipped = restore_stock_below_validated_floor(
+        build_flattened_plan(
+            curve,
+            lock_clock_mhz=2595,
+            candidate_voltage_mv=1000,
+        ),
+        floor_voltage_mv=1000,
+        lock_clock_mhz=2595,
+    )
+    stock_by_voltage = {
+        int(point["voltage_mv"]): int(point["base_mhz"]) for point in curve
+    }
+
+    targets = _editable_targets(shipped)
+    assert all(
+        earlier[1] <= later[1] for earlier, later in zip(targets, targets[1:])
+    ), "shipped 5090 plan must be monotonic"
+
+    below_floor = [(v, t) for v, t in targets if v < 1000]
+    assert below_floor
+    assert all(t <= stock_by_voltage[v] for v, t in below_floor)
+    assert all(t <= 2595 - 15 for t in (pair[1] for pair in below_floor))
+    # The clamp must actually bite: the weak curve's stock exceeds the
+    # below-lock ceiling in the band just under the floor (the old raw-stock
+    # graft drew the non-monotonic bump exactly there).
+    assert any(
+        stock_by_voltage[v] > 2595 - 15 and t == 2595 - 15 for v, t in below_floor
+    )
+
+
+def test_s6_5080_control_clamp_is_a_no_op() -> None:
+    curve = rtx_5080_20260524_high_oc_base_curve()
+    plan = build_flattened_plan(
+        curve,
+        lock_clock_mhz=2730,
+        candidate_voltage_mv=1000,
+    )
+    stock_by_voltage = {
+        int(point["voltage_mv"]): int(point["base_mhz"]) for point in curve
+    }
+
+    shipped = restore_stock_below_validated_floor(
+        plan,
+        floor_voltage_mv=1000,
+        lock_clock_mhz=2730,
+    )
+
+    # On the gentle 5080 curve stock never crosses the below-lock ceiling,
+    # so the power-bound clamp ships byte-identical raw stock below floor.
+    below_floor = [
+        (int(p["voltage_mv"]), int(p["target_mhz"]))
+        for p in shipped
+        if not p.get("preserve_base") and int(p["voltage_mv"]) < 1000
+    ]
+    assert below_floor
+    assert all(t == stock_by_voltage[v] for v, t in below_floor)
+
+
+def test_s7_negative_control_demotion_still_fails() -> None:
+    # Same low clock as S4, but power is far off the cap and the driver
+    # reports no power cap: silent reliability demotion must keep failing.
+    curve = rtx_5090_steep_synthetic_curve()
+    model = scenario_5090_power_models()[1]
+    baseline = settle_operating_point(curve, model=model, power_limit_w=BALANCED_CAP_W)
+    demoted_samples = [
+        {**sample, "power_w": 350.0, "core_clock_mhz": 1900.0, "perf_cap_reason": "none"}
+        for sample in synthesize_busy_samples(
+            {**baseline, "power_capped": False}
+        )
+    ]
+
+    decision = evaluate_loaded_telemetry(
+        demoted_samples,
+        baseline_power_w=float(baseline["power_w"]),
+        baseline_core_clock_mhz=float(baseline["clock_mhz"]),
+        power_limit_w=BALANCED_CAP_W,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert not decision.passed
+    assert decision.failure_kind is FailureKind.LOW_CLOCK
+
+
+def test_zotac_capture_matches_crosschecked_anchors() -> None:
+    curve = rtx_5090_zotac_amp_stock_curve()
+    anchors = {int(p["voltage_mv"]): int(p["base_mhz"]) for p in curve}
+
+    assert len(curve) == 127
+    assert anchors[850] == 1320
+    assert anchors[900] == 2002
+    assert anchors[950] == 2602
+    assert anchors[1000] == 2767
+    assert anchors[1240] == 3195
+    # The structural signature: cliff below the knee, shelf above it.
+    assert (anchors[950] - anchors[900]) / 50 > 10.0
+    assert (anchors[1000] - anchors[950]) / 50 < 4.0

--- a/tests/auto_uv/test_probe_stability_decision.py
+++ b/tests/auto_uv/test_probe_stability_decision.py
@@ -353,6 +353,108 @@ def test_telemetry_derives_power_floor_when_baseline_power_absent() -> None:
     assert decision.reason == "loaded telemetry stable"
 
 
+# --- power-cap-aware clock floor (power-bound regime, e.g. RTX 5090) ---
+
+
+def _busy_sample(
+    clock_mhz: float,
+    *,
+    power_w: float = 450.0,
+    perf_cap_reason: str | None = None,
+) -> dict:
+    return {
+        "elapsed_s": 6.0,
+        "power_w": power_w,
+        "core_clock_mhz": clock_mhz,
+        "gpu_util_pct": 99.0,
+        "perf_cap_reason": perf_cap_reason,
+    }
+
+
+def test_low_clock_passes_when_busy_samples_report_power_cap() -> None:
+    # The field failure shape: avg 2111 vs a 94%-of-2595 floor, driver naming
+    # sw-power on the busy window while average draw sits below the limit
+    # (per-frame spikes hit the cap, the average droops).
+    decision = evaluate_loaded_telemetry(
+        [_busy_sample(2111.0, power_w=453.0, perf_cap_reason="sw-power")] * 4,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert decision.passed
+    assert "power-walled but stable" in decision.reason
+
+
+def test_low_clock_passes_when_average_power_pins_the_limit() -> None:
+    # No perf-cap telemetry at all; saturation proven by avg power within the
+    # 2% headroom of the applied limit.
+    decision = evaluate_loaded_telemetry(
+        [_busy_sample(2111.0, power_w=512.0)] * 4,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert decision.passed
+    assert "power-walled but stable" in decision.reason
+
+
+def test_low_clock_still_fails_for_reliability_demotion() -> None:
+    # Same clock shortfall, but power is off the cap and the driver names a
+    # reliability cap: silent V/F demotion must keep failing (S7).
+    decision = evaluate_loaded_telemetry(
+        [_busy_sample(2111.0, power_w=430.0, perf_cap_reason="sw-reliability")] * 4,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert not decision.passed
+    assert decision.failure_kind is FailureKind.LOW_CLOCK
+    assert decision.reason == "average busy core clock below floor"
+
+
+def test_power_cap_exemption_disarms_when_cap_stops_binding() -> None:
+    # Once an undervolt frees power headroom (power off the limit, driver
+    # reports no cap), a still-low clock is real instability again.
+    decision = evaluate_loaded_telemetry(
+        [_busy_sample(2111.0, power_w=400.0, perf_cap_reason="none")] * 4,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert not decision.passed
+    assert decision.failure_kind is FailureKind.LOW_CLOCK
+
+
+def test_minority_power_cap_samples_do_not_exempt_low_clock() -> None:
+    samples = [
+        _busy_sample(2111.0, power_w=430.0, perf_cap_reason="sw-power"),
+        *[_busy_sample(2111.0, power_w=430.0, perf_cap_reason="none")] * 3,
+    ]
+    decision = evaluate_loaded_telemetry(
+        samples,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert not decision.passed
+    assert decision.failure_kind is FailureKind.LOW_CLOCK
+
+
 # --- coverage: evaluate_cuda_companion failure branch ---
 
 

--- a/tests/auto_uv/test_probe_stability_decision.py
+++ b/tests/auto_uv/test_probe_stability_decision.py
@@ -483,3 +483,45 @@ def test_sample_is_busy_false_when_power_below_floor_and_util_low() -> None:
     sample = {"gpu_util_pct": 10.0, "power_w": 50.0}
 
     assert not sample_is_busy(sample, busy_power_floor_w=100.0, busy_gpu_util_pct=60.0)
+
+
+def test_sparse_power_cap_reasons_cannot_speak_for_the_window() -> None:
+    # One sw-power sample among nineteen reason-less busy samples previously
+    # yielded a 100% capped fraction (reason-less samples were excluded from
+    # the denominator) and a false power-walled pass. The minimum-evidence
+    # guard makes the reason vote abstain; power is far off the cap, so the
+    # low clock fails as the real demotion it is.
+    samples = [
+        _busy_sample(2111.0, power_w=430.0, perf_cap_reason="sw-power"),
+        *[_busy_sample(2111.0, power_w=430.0, perf_cap_reason=None)] * 19,
+    ]
+    decision = evaluate_loaded_telemetry(
+        samples,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert not decision.passed
+    assert decision.failure_kind is FailureKind.LOW_CLOCK
+
+
+def test_reason_vote_needs_minimum_sample_count() -> None:
+    # Two capped samples out of two reason-bearing (100% fraction, full
+    # coverage of a two-sample window) still abstain below the three-sample
+    # minimum; the avg-power signal then decides — here power pins the
+    # limit, so the exemption is granted by the power path instead.
+    samples = [_busy_sample(2111.0, power_w=512.0, perf_cap_reason="sw-power")] * 2
+    decision = evaluate_loaded_telemetry(
+        samples,
+        baseline_power_w=553.0,
+        baseline_core_clock_mhz=2595.0,
+        power_limit_w=517,
+        thresholds=StabilityThresholds(min_core_clock_pct=94.0),
+        log_path=None,
+    )
+
+    assert decision.passed
+    assert "power-walled but stable" in decision.reason

--- a/tests/auto_uv/test_q2rtx_live_abort_rules.py
+++ b/tests/auto_uv/test_q2rtx_live_abort_rules.py
@@ -314,6 +314,84 @@ def test_telemetry_abort_reports_avg_core_clock_below_floor() -> None:
     assert "floor=2000.0MHz" in reason
 
 
+def test_live_low_clock_aborts_suppressed_under_power_cap() -> None:
+    # Both the live-streak rule and the average rule stay quiet while the
+    # driver names sw-power on the busy window: a power-governed clock below
+    # the floor is the cap working, not instability.
+    streak = AUTO_UV_METRIC_TUNING.target_core_clock_low_streak_samples
+    min_samples = max(
+        AUTO_UV_STALL_TUNING.live_core_clock_abort_min_samples,
+        AUTO_UV_STALL_TUNING.avg_core_clock_abort_min_samples,
+    )
+    samples = [
+        TelemetrySample(
+            elapsed_s=float(i),
+            gpu_util_pct=95.0,
+            power_w=450.0,
+            core_clock_mhz=2111.0,
+            perf_cap_reason="sw-power",
+        )
+        for i in range(6, 6 + min_samples + 1)
+    ]
+    progress_state: dict = {}
+
+    reason = None
+    for _ in range(streak + 1):
+        reason = telemetry_live_abort_reason(
+            {
+                "elapsed_s": 30.0,
+                "latest_sample": samples[-1],
+                "telemetry_samples": samples,
+            },
+            busy_power_floor_w=60.0,
+            proper_run_power_floor_w=None,
+            target_core_clock_floor_mhz=2439.0,
+            progress_state=progress_state,
+        )
+
+    assert reason is None
+    assert progress_state["low_core_clock_streak"] == 0
+
+
+def test_live_low_clock_aborts_suppressed_by_near_limit_power() -> None:
+    # Some drivers omit throttle-reason telemetry. Average busy power within
+    # the same 2% saturation window used by the post-probe decision must still
+    # let that decision run instead of aborting the workload early.
+    streak = AUTO_UV_METRIC_TUNING.target_core_clock_low_streak_samples
+    min_samples = max(
+        AUTO_UV_STALL_TUNING.live_core_clock_abort_min_samples,
+        AUTO_UV_STALL_TUNING.avg_core_clock_abort_min_samples,
+    )
+    samples = [
+        _sample(
+            float(i),
+            gpu_util_pct=95.0,
+            power_w=510.0,
+            core_clock_mhz=2111.0,
+        )
+        for i in range(6, 6 + min_samples + 1)
+    ]
+    progress_state: dict = {}
+
+    reason = None
+    for _ in range(streak + 1):
+        reason = telemetry_live_abort_reason(
+            {
+                "elapsed_s": 30.0,
+                "latest_sample": samples[-1],
+                "telemetry_samples": samples,
+            },
+            busy_power_floor_w=60.0,
+            proper_run_power_floor_w=None,
+            target_core_clock_floor_mhz=2439.0,
+            progress_state=progress_state,
+            power_limit_w=517,
+        )
+
+    assert reason is None
+    assert progress_state["low_core_clock_streak"] == 0
+
+
 def test_telemetry_abort_passes_when_everything_healthy() -> None:
     n = AUTO_UV_STALL_TUNING.avg_core_clock_abort_min_samples + 1
     samples = [

--- a/tests/auto_uv/test_q2rtx_live_abort_rules.py
+++ b/tests/auto_uv/test_q2rtx_live_abort_rules.py
@@ -413,3 +413,36 @@ def test_telemetry_abort_passes_when_everything_healthy() -> None:
         )
         is None
     )
+
+
+def test_sparse_power_cap_reasons_do_not_suppress_live_low_clock_abort() -> None:
+    # Only one busy sample carries a sw-power reason among many reason-less
+    # ones: the suppression must abstain (minimum-evidence guard) and the
+    # average-clock abort still fires on the collapsed clock.
+    n = AUTO_UV_STALL_TUNING.avg_core_clock_abort_min_samples + 3
+    samples = [
+        TelemetrySample(
+            elapsed_s=float(i),
+            gpu_util_pct=95.0,
+            power_w=120.0,
+            core_clock_mhz=210.0,
+            perf_cap_reason="sw-power" if i == 6 else None,
+        )
+        for i in range(6, 6 + n)
+    ]
+    progress_state: dict = {}
+
+    reason = telemetry_live_abort_reason(
+        {
+            "elapsed_s": 30.0,
+            "latest_sample": samples[-1],
+            "telemetry_samples": samples,
+        },
+        busy_power_floor_w=60.0,
+        proper_run_power_floor_w=None,
+        target_core_clock_floor_mhz=2000.0,
+        progress_state=progress_state,
+    )
+
+    assert reason is not None
+    assert reason.startswith("telemetry-live-core_clock-avg")

--- a/tests/auto_uv/test_shipped_plan.py
+++ b/tests/auto_uv/test_shipped_plan.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from auto_uv.curve.shipped_plan import (
+    assert_monotonic_editable_targets,
     restore_stock_below_validated_floor,
     validated_floor_voltage_mv,
 )
+from auto_uv.curve.vf_curve_flattening import build_flattened_plan
+from auto_uv.domain.types import AutoUvError
+from auto_uv_test_data import rtx_5080_20260524_high_oc_base_curve
 
 
 def _point(voltage_mv, base_mhz, target_mhz, preserve_base=False):
@@ -35,7 +41,11 @@ def test_below_floor_bins_ship_stock() -> None:
         _point(940, 2500, 2950),
     ]
 
-    shipped = restore_stock_below_validated_floor(plan, floor_voltage_mv=850)
+    shipped = restore_stock_below_validated_floor(
+        plan,
+        floor_voltage_mv=850,
+        lock_clock_mhz=2639,
+    )
 
     by_voltage = {point["voltage_mv"]: point for point in shipped}
     assert by_voltage[825]["target_mhz"] == 2047
@@ -50,6 +60,79 @@ def test_below_floor_bins_ship_stock() -> None:
     assert by_voltage[450]["target_mhz"] == 180
     # The input plan is not mutated.
     assert plan[1]["target_mhz"] == 2415
+
+
+def test_steep_stock_curve_is_clamped_below_lock_without_downward_edge() -> None:
+    plan = [
+        _point(925, 2347, 2580),
+        _point(950, 2602, 2580),
+        _point(975, 2677, 2580),
+        # Restoring this 5090-like stock point raw created the field-report
+        # triangle: 2695MHz at 995mV followed by 2595MHz at 1000mV.
+        _point(995, 2695, 2580),
+        _point(1000, 2767, 2595),
+        _point(1025, 2827, 2610),
+    ]
+
+    shipped = restore_stock_below_validated_floor(
+        plan,
+        floor_voltage_mv=1000,
+        lock_clock_mhz=2595,
+    )
+
+    targets = {
+        int(point["voltage_mv"]): int(point["target_mhz"]) for point in shipped
+    }
+    assert targets[925] == 2347
+    assert targets[950] == 2580
+    assert targets[975] == 2580
+    assert targets[995] == 2580
+    assert targets[1000] == 2595
+    assert all(
+        left <= right
+        for left, right in zip(targets.values(), list(targets.values())[1:])
+    )
+    # The clamp never raises an unvalidated point above stock.
+    assert all(
+        int(point["target_mhz"]) <= int(point["base_mhz"])
+        for point in shipped
+        if int(point["voltage_mv"]) < 1000
+    )
+
+
+def test_non_monotonic_validated_region_is_rejected() -> None:
+    with pytest.raises(AutoUvError, match="refusing to ship non-monotonic"):
+        assert_monotonic_editable_targets(
+            [
+                _point(950, 2500, 2600),
+                _point(975, 2550, 2580),
+            ]
+        )
+
+
+def test_5080_fixture_keeps_the_existing_stock_restoration_result() -> None:
+    base_curve = rtx_5080_20260524_high_oc_base_curve()
+    plan = build_flattened_plan(
+        base_curve,
+        lock_clock_mhz=2805,
+        candidate_voltage_mv=1025,
+        tail_rise_bins=4,
+    )
+    expected = []
+    for point in plan:
+        restored = dict(point)
+        if int(point["voltage_mv"]) < 950:
+            restored["target_mhz"] = int(point["base_mhz"])
+            restored["new_offset_mhz"] = 0
+        expected.append(restored)
+
+    shipped = restore_stock_below_validated_floor(
+        plan,
+        floor_voltage_mv=950,
+        lock_clock_mhz=2805,
+    )
+
+    assert shipped == expected
 
 
 def test_validated_floor_is_deepest_passed_probe() -> None:

--- a/tests/auto_uv/test_uv_limits.py
+++ b/tests/auto_uv/test_uv_limits.py
@@ -85,6 +85,29 @@ def test_power_limit_pct_reduces_savings_tiers_and_keeps_performance_full() -> N
     ) == pytest.approx(100.0)
 
 
+def test_rtx_5090_power_limit_percentages_and_575w_tier_caps() -> None:
+    from auto_uv.main_loop import adaptive_tier_power_limit_w
+
+    gpu_name = "NVIDIA GeForce RTX 5090"
+    percentages = {
+        tier: uv_limit_power_limit_pct_for_gpu(gpu_name, profile_id=tier)
+        for tier in ("efficiency", "balanced", "performance")
+    }
+
+    assert percentages == pytest.approx(
+        {"efficiency": 74.8, "balanced": 87.4, "performance": 100.0}
+    )
+    assert {
+        tier: adaptive_tier_power_limit_w(
+            power_limit_pct=percentage,
+            baseline_power_limit_w=575,
+            scan_request_w=None,
+            balanced_pct=percentages["balanced"],
+        )
+        for tier, percentage in percentages.items()
+    } == {"efficiency": 430, "balanced": 503, "performance": 575}
+
+
 def test_power_limit_pct_ampere_efficiency_takes_fixed_reduction() -> None:
     # 80% stored - 12% reduction = 70.4; balanced halfway to full = 85.2.
     assert uv_limit_power_limit_pct_for_gpu(

--- a/ui/dialogs/scan_tuning.py
+++ b/ui/dialogs/scan_tuning.py
@@ -455,9 +455,10 @@ def select_scan_tuning(
             text="Power limit",
             widget=power_widget,
             tooltip=(
-                "Power limit in watts applied at this profile's final "
-                "verification and saved with its profile. The range comes "
-                "from NVML for the selected GPU; the default position is "
+                "Power limit in watts applied to this profile's stock "
+                "baseline, descent, final verification, and saved profile. "
+                "The range comes from NVML for the selected GPU; the "
+                "default position is "
                 "preset-aware (savings-biased presets cap below stock, "
                 "Performance keeps the stock budget)."
             ),
@@ -612,9 +613,9 @@ def select_scan_tuning(
     # A full scan reuses the Balanced downsweep for Performance only when
     # both tiers descend at the same memory clock, so in that scope the two
     # memory boxes mirror each other. Efficiency stays independent, and the
-    # power limit and clock drop stay per-tier: descents run at stock power,
-    # and the engine gate validates the donated endpoint against
-    # Performance's clock floor itself, falling back to a full descent.
+    # power limit and clock drop stay per-tier. A Balanced descent may be
+    # donated only when Performance uses the same power and memory policy;
+    # otherwise Performance runs its own capped baseline and descent.
     balanced_memory_spin = tier_controls[AUTO_UV_PRESET_BALANCED]["memory"]
     performance_memory_spin = tier_controls[AUTO_UV_PRESET_PERFORMANCE]["memory"]
 


### PR DESCRIPTION
## What

Auto-UV completed on voltage-limited cards (5080-class) but failed terminally on power-limited ones — field report: an RTX 5090 scan ratcheted its target 2595→2418MHz, then died at final verification with "average busy core clock below floor" (the governor parked at 923mV/2111MHz on the raw-stock segment below the validated floor, judged against a floor derived at a different power limit) and no recoverable candidate.

Two commits:

1. **Engine** — validate power-bound GPUs in their shipped power regime:
   - **Power-limit parity:** each adaptive tier applies its board-power cap *before* its own stock/flattened baselines and holds it through descent and final verification. Fail-closed with NVML read-back (`AutoUvPowerLimitApplyError`) so no tier probes under an unknown regime; mobile GPUs keep the graceful skip. Balanced→Performance descent donation now also requires a matching power limit.
   - **Shipped below-floor clamp:** bins under the validated floor ship at `min(stock, lock−gap)` instead of raw stock; non-monotonic editable curves are refused. Byte-identical on gentle (5080-class) curves — asserted by test.
   - **Saturation-aware decisions:** a below-floor busy average while the busy window proves the power cap (majority sw-power perf-cap reasons, or avg busy power within 2% of the applied limit) passes as "power-walled but stable"; live low-clock aborts stay quiet under the same evidence. The exemption self-disarms once power leaves the limit, so silent reliability demotion still fails (negative controls included). The measured-clock ratchet no longer adopts power-capped measurements.
   - **Efficiency/Balanced bounded clock climb** at the proven voltage — converts power headroom into clocks without loosening stability checks.
2. **Test toolset** — the captured 127-point GB202 stock curve (script-transcribed from the decompiled NV-UV reference binary, anchor-asserted) plus a synthetic steep variant, a test-only power-governor simulator, the S1–S7 power-bound scenario suite, and pinned 5090 per-tier power caps (430/503/575W).

## Why

On a power-bound card the governor operates *below* the lock voltage — a region the scan previously shaped one way during probes (soft plateau) and another way in the shipped plan (raw stock cliff), while measuring targets at a power limit the profile would never ship with. Design rationale and the full failure analysis live in `specs/auto-uv-5090-power-bound.md` (working spec, intentionally untracked).

## Impact

- Power-bound cards get honest targets, a working descent, and profiles whose below-lock shape was actually operated during probing.
- Voltage-limited cards: no behavioral change — the clamp is a no-op on gentle curves (tested byte-identical), saturation gates never fire without cap evidence, and existing suite behavior is preserved.
- Scans on genuinely power-bound cards run longer (the descent now proceeds instead of failing early) — that is the feature working.
- New user-facing docs paragraph in `docs/features/auto-uv.md`; CLI help and scan-dialog tooltips updated to match the new power-limit timing.

## Checks

- Full suite: **1748 passed** (commit 1 also verified standalone green: 1732).
- `scripts/check-feature-static-analysis.sh`: clean.
- **Live hardware validation has NOT been run.** Owed before release: an end-to-end scan on the 5080 host at default settings (no-regression) and with a forced-low power slider (exercises the power-bound path on real hardware), plus ideally a field re-run on a real 5090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)