### PR TITLE
Auto-UV: read counted hardware brake evidence, not the summarized reason

### DIFF
--- a/auto_uv/curve/measured_probe_lock_clock.py
+++ b/auto_uv/curve/measured_probe_lock_clock.py
@@ -57,6 +57,13 @@ def probe_indicates_power_saturation(
     # that the board's power-delivery protection is already limiting clocks.
     # Do not keep climbing merely because board power is below the software
     # cap: EDPp/OCP can assert before that aggregate limit is reached.
+    #
+    # Read the counted samples first: the brake is transient by nature, and
+    # the summarizer drops a minority power token from ``perf_cap_reason``
+    # entirely, so a real brake reaches this decision only through the count
+    # that survives summarization.
+    if int(getattr(probe, "hw_power_brake_samples", 0) or 0) > 0:
+        return True
     if "hw-power-brake" in perf_cap_tokens:
         return True
     if not require_power_evidence and any(

--- a/auto_uv/probes/summary.py
+++ b/auto_uv/probes/summary.py
@@ -177,7 +177,11 @@ def summarize_loaded_perf_cap_reason(
 
 
 def count_hw_power_brake_samples(samples: Sequence) -> int:
-    """Loaded samples where the power-delivery hardware asserted its brake.
+    """Samples where the power-delivery hardware asserted its brake.
+
+    Counted over whatever window the caller passes — the probe summary reports
+    it across the probe's telemetry, the stability decision across the busy
+    window — so read the paired total before comparing two coverage figures.
 
     ``hw-power-brake`` is not the configured power limit doing its job — it is
     an external protection signal (EDPp/OCP) from the board's power delivery.

--- a/tests/auto_uv/power_governor_sim.py
+++ b/tests/auto_uv/power_governor_sim.py
@@ -71,6 +71,12 @@ class GovernorPowerModel:
     # A second, non-power cap reason mixed into capped samples (thermal), so
     # scenarios can prove a thermal cap never buys a power-wall exemption.
     secondary_cap_reason: str | None = None
+    # Board power-delivery protection (EDPp/OCP): fraction of busy samples on
+    # which the hardware brake asserts. Deliberately independent of the
+    # software cap — a board trips its brake on transients while aggregate
+    # draw sits well under the configured limit — and typically sparse, which
+    # is what makes it disappear from a summarized perf-cap reason.
+    brake_duty: float = 0.0
     # Report the power cap even when the board is not at its wall. Blackwell
     # does this: the 2026-08-04 log summarizes sw-power on a probe drawing
     # 287W under a 319W cap, so the reason token alone is weaker evidence
@@ -260,10 +266,15 @@ def synthesize_busy_samples(
     silent reliability demotion. Passing ``model`` adds that model's jitter
     and perf-cap duty cycle; without it the samples are flat and always
     labeled, which is the well-behaved control case.
+
+    A model's ``brake_duty`` mixes in the board's hw-power-brake bit on its
+    own schedule, so a scenario can express a protection brake firing while
+    the software cap is nowhere near reached.
     """
     jitter_clock = float(getattr(model, "clock_jitter_mhz", 0.0) or 0.0)
     jitter_power = float(getattr(model, "power_jitter_w", 0.0) or 0.0)
     duty = float(getattr(model, "cap_reason_duty", 1.0) or 1.0)
+    brake_duty = float(getattr(model, "brake_duty", 0.0) or 0.0)
     idle_reason = getattr(model, "idle_cap_reason", "none") if model else "none"
     secondary = getattr(model, "secondary_cap_reason", None) if model else None
     samples: list[dict] = []
@@ -273,10 +284,14 @@ def synthesize_busy_samples(
             getattr(model, "reports_power_cap_off_the_wall", False)
         )
         capped = names_cap and _duty_cycle_hit(index, duty)
+        tokens: list[str] = []
         if capped:
-            reason = f"sw-power+{secondary}" if secondary else "sw-power"
-        else:
-            reason = idle_reason
+            tokens.append("sw-power")
+            if secondary:
+                tokens.append(str(secondary))
+        if _duty_cycle_hit(index, brake_duty):
+            tokens.append("hw-power-brake")
+        reason = "+".join(tokens) if tokens else idle_reason
         samples.append(
             {
                 "elapsed_s": float(first_elapsed_s) + float(index),

--- a/tests/auto_uv/test_power_bound_5090_loop.py
+++ b/tests/auto_uv/test_power_bound_5090_loop.py
@@ -19,6 +19,7 @@ from typing import Any, cast
 from auto_uv.auto_oc.search import AUTO_OC_WALL_SHORTFALL_TOLERANCE_MHZ
 from auto_uv.balanced_uv_loop import run_balanced_uv_loop
 from auto_uv.base_uv_loop import BaseUvLoopIO
+from auto_uv.curve.measured_probe_lock_clock import probe_indicates_power_saturation
 from auto_uv.curve.vf_curve_flattening import build_flattened_plan
 from auto_uv.domain.scan_settings import AutoUvScanSettings
 from auto_uv.domain.types import FailureKind, VfCurveCandidate
@@ -213,6 +214,75 @@ def test_vdroop_shortfall_alone_does_not_end_the_climb() -> None:
     )
     assert not any(probe["power_capped"] for probe in harness.probes)
     assert selected_clock_mhz > start_clock_mhz
+
+
+def test_sparse_hardware_brake_ends_the_climb_the_summary_no_longer_names() -> None:
+    """The board's protection brake must stop a climb even when it is sparse.
+
+    Same scenario as the droop test above — generous cap, nothing saturates —
+    with the one difference that the board asserts hw-power-brake on a
+    minority of samples. The brake is transient by nature, so the summarizer's
+    reason vote drops it from ``perf_cap_reason`` entirely; only the counted
+    samples survive. Reading the lossy string here let the climb keep asking
+    for clocks the power delivery had already refused.
+    """
+    droop_only = GovernorPowerModel(
+        dynamic_w_per_mhz_v2=0.20,
+        idle_w=40.0,
+        spike_margin_mv=0.0,
+        vdroop_mv=25.0,
+        clock_jitter_mhz=20.0,
+    )
+    braked = replace(droop_only, brake_duty=0.2)
+    curve = rtx_5090_steep_synthetic_curve()
+    descended_voltage_mv = 925
+    start_clock_mhz = 2400
+    start = _candidate(
+        curve, voltage_mv=descended_voltage_mv, clock_mhz=start_clock_mhz
+    )
+
+    selected: dict[str, int] = {}
+    for name, model in (("droop-only", droop_only), ("braked", braked)):
+        # A cap so generous nothing saturates: no sw-power, no near-limit
+        # average power. The brake is the only power evidence in play.
+        harness = _harness(model, power_limit_w=2000, curve=curve)
+        harness.baseline_core_clock_mhz = float(
+            harness.operating_point(list(start.flattened_plan))["clock_mhz"]
+        )
+        start_probe = harness.probe(start).raw_probe
+        assert start_probe is not None
+        if model is braked:
+            # The evidence the decision has to run on: counted, not named.
+            assert start_probe.hw_power_brake_samples > 0
+            assert "brake" not in str(start_probe.perf_cap_reason or "")
+            assert probe_indicates_power_saturation(
+                start_probe,
+                power_limit_w=2000,
+                require_power_evidence=True,
+            )
+        _plan, _voltage_mv, selected_clock_mhz, _probe, _metadata = (
+            select_power_bound_clock_reclaim_candidate(
+                curve,
+                auto_uv_mode="balanced",
+                stable_plan=list(start.flattened_plan),
+                stable_voltage_mv=descended_voltage_mv,
+                stable_lock_clock_mhz=start_clock_mhz,
+                stable_probe=start_probe,
+                stable_history=[],
+                runner=cast(Any, harness),
+                gpu_name=GPU_NAME,
+                clock_ceiling=None,
+                probe_history=[],
+                log=lambda _message: None,
+            )
+        )
+        assert not any(probe["power_capped"] for probe in harness.probes)
+        selected[name] = int(selected_clock_mhz)
+
+    assert selected["droop-only"] > start_clock_mhz, (
+        "control must still climb, otherwise the brake proves nothing"
+    )
+    assert selected["braked"] < selected["droop-only"]
 
 
 def test_descent_walks_down_instead_of_stopping_at_the_capped_clock() -> None:


### PR DESCRIPTION
## What changed

`probe_indicates_power_saturation` now reads `hw_power_brake_samples` before
falling back to the summarized `perf_cap_reason` string.

## Why

c6500be added a power-brake rule to that helper, but tested the summarized
reason string — which is exactly where a brake disappears.
`summarize_loaded_perf_cap_reason(..., require_sw_power_dominant=True)` strips
every power-named token (brake included) once the reason vote falls under its
coverage bar, and an EDPp/OCP protection brake is transient by nature, so it is
almost always the minority. Reproduced against the real summarizer, 3 braked
samples out of 20:

```
perf_cap_reason        = 'none'
hw_power_brake_samples = 3
saturated(require_power_evidence=True) = False
```

The count added by 9eecf38 is the evidence that survives summarization, so the
decision reads it.

## User/developer impact

- The Auto-OC clock-reclaim climb now ends when the board's power delivery has
  already refused the clock, instead of continuing to request higher rungs
  while the brake fires. Aggregate board power can sit far below the configured
  software cap while this happens — that is the whole point of the brake bit.
- The measured-clock ratchet guard stops treating a braked probe as unsaturated.
- No change on boards that never assert the brake (`hw_power_brake_samples` is 0),
  which is every run observed on the test host to date.
- `count_hw_power_brake_samples`'s docstring no longer claims it counts loaded
  samples; it counts whatever window the caller passes (probe telemetry in the
  summary, busy window in the stability decision).

## Tests

`power_governor_sim` grows `brake_duty`, so the brake is expressible end to end
instead of only via hand-built probes — which is how this gap slipped through
(`test_hw_power_brake_stops_climb_below_software_power_limit` sets
`probe.perf_cap_reason` directly, bypassing the summarizer).

The new scenario is the existing droop-only climb with one difference: the board
brakes on a minority of samples. The droop-only control must still climb; the
braked run must stop earlier. Verified red before the fix:

```
E   assert False
E    +  where False = probe_indicates_power_saturation(AutoUvProbeSummary(...,
E        perf_cap_reason='none', hw_power_brake_samples=2, ...))
```

## Checks run

- `python -m pytest tests/ -q` → 1775 passed
- `scripts/check-feature-static-analysis.sh` → compileall, ruff, vulture, import
  and facade scans clean; advisory repo-wide pyright unchanged at 271 pre-existing
  diagnostics, none in the touched files
- Live: not validated on hardware — no board on this host has asserted the brake
  bit in any scan so far, same limitation 9eecf38 recorded. A full adaptive
  3-tier scan on the fixed build is running now; it exercises the reclaim path
  but is not expected to trip a brake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)