### PR TITLE
Release 0.7.7

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -61,18 +61,41 @@ jobs:
           PENGUIN_BURNER_REQUIRE_NATIVE_LAYER: "1"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_BUILD: "cp312-manylinux_x86_64"
-          CIBW_ENVIRONMENT: "PENGUIN_BURNER_REQUIRE_NATIVE_LAYER=1"
+          CIBW_ENVIRONMENT: "PENGUIN_BURNER_REQUIRE_NATIVE_LAYER=1 PENGUIN_BURNER_REQUIRE_NVAPI_SHIM=1 PENGUIN_BURNER_REQUIRE_DAEMON=1 CARGO_HOME=/opt/rust/cargo RUSTUP_HOME=/opt/rust/rustup PATH=/opt/rust/cargo/bin:$PATH"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
           CIBW_BEFORE_ALL_LINUX: |
             if command -v dnf >/dev/null 2>&1; then
-              dnf install -y vulkan-headers
+              dnf install -y epel-release
+              dnf install -y vulkan-headers mingw64-gcc-c++ mingw64-winpthreads-static
             else
-              yum install -y vulkan-headers
+              yum install -y epel-release
+              yum install -y vulkan-headers mingw64-gcc-c++ mingw64-winpthreads-static
             fi
+            export RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.82.0 --no-modify-path
         run: python -m cibuildwheel --platform linux --output-dir dist
 
       - name: Check package metadata
         run: python -m twine check dist/*
+
+      - name: Check required native payloads
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import zipfile
+
+          wheel = next(Path("dist").glob("*.whl"))
+          required = {
+              "Vulkan layer": "overlay/native_layer/libVkLayer_penguinburner_latency.so",
+              "NVAPI shim": "overlay/nvapi_shim/nvapi64.dll",
+              "burnerd": "runtime/daemon_bin/penguin-burnerd",
+          }
+          with zipfile.ZipFile(wheel) as archive:
+              names = archive.namelist()
+              for label, suffix in required.items():
+                  if not any(name.endswith(suffix) for name in names):
+                      raise SystemExit(f"missing required {label}: {suffix}")
+          PY
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ automatic undervolting & overclocking with adaptive per-game tuning targets.
 
 **One scan. Three verified GPU profiles.**
 
-- **Efficiency** — undervolt and underclock. RTX 5080: 850 mV · 2460 MHz · 233 W.
-- **Balanced** — undervolt and maintain clock. RTX 5080: 850 mV · 2639 MHz · 267 W.
-- **Performance** — undervolt and overclock. RTX 5080: 915 mV · 2980 MHz · 310 W.
+- **Efficiency** — deepest savings. RTX 5080: 850 mV · 2800 MHz target /
+  2625 MHz loaded · 254 W.
+- **Balanced** — maintain more loaded clock. RTX 5080: 860 mV · 2775 MHz
+  target / 2745 MHz loaded · 272 W.
+- **Performance** — undervolt and overclock. RTX 5080: 925 mV · 2980 MHz
+  target / 2977 MHz loaded · 313 W.
 
-For scale: the same RTX 5080 at stock runs 2734 MHz at **341 W** under the
-same load. The factory curve burns 74 W more than Balanced for 4% clock —
-that is the inefficiency Auto-UV removes.
+For scale: the same RTX 5080 at stock uses about **341 W** under the same load.
+Balanced held roughly the same loaded clock at 272 W — about 69 W less.
 
-Verified RTX 5080 examples; every GPU differs. Pre-optimized targets are
-included for RTX 30, 40, and 50 series cards.
+Verified RTX 5080 examples; every GPU differs. A requested target can exceed
+the loaded clock when voltage droop or the power governor intervenes.
+Pre-optimized targets are included for RTX 30, 40, and 50 series cards.
 
 ## Install
 
@@ -267,10 +270,10 @@ from the Profiles view. See
 Auto-UV makes real hardware changes — enabling persistence mode, setting board
 power limits, writing core/memory V/F offsets, and taking over fan control.
 
-The **Balanced** and **Efficiency** Auto-UV profiles are ultra-defensive.
-Balanced at most retains the card's stock clock, probing gently for lower
-voltage. Efficiency just follows the stock curve on the first pass — lowering
-power consumption by reducing clock — then undervolts only very slightly.
+The **Balanced** and **Efficiency** Auto-UV profiles use conservative voltage
+floors and board-power caps. Efficiency accepts the deepest loaded-clock drop,
+then may reclaim stable clock without raising its proven voltage. Balanced
+keeps more loaded clock with a higher voltage and power budget.
 
 **Performance** is the profile that pushes past stock: it undervolts and then
 overclocks. On my RTX 5080, during the OC phase I sometimes get a "Vulkan device

--- a/burnerd/Cargo.lock
+++ b/burnerd/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "penguin-burnerd"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "libc",

--- a/burnerd/Cargo.toml
+++ b/burnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penguin-burnerd"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 rust-version = "1.82"
 license = "GPL-3.0-only"

--- a/docs/features/auto-uv.md
+++ b/docs/features/auto-uv.md
@@ -105,7 +105,7 @@ directly to [adaptive UV tiers](./adaptive-uv.md):
 
 | Preset | Tail-rise bins | Extra |
 | --- | --- | --- |
-| Efficiency | `0` (flat) | lowest power |
+| Efficiency | `0` (flat) | lowest tier power; bounded fixed-voltage clock reclaim on power-bound baselines |
 | Balanced | `4` | moderate clock tail |
 | Performance | `6` | adds an Auto-OC ladder (raises V+clock to targets) |
 

--- a/docs/release-notes-0.7.7.md
+++ b/docs/release-notes-0.7.7.md
@@ -1,0 +1,21 @@
+<!-- Cut together with the pyproject.toml / burnerd Cargo.toml version bump. -->
+
+# PenguinBurner 0.7.7
+
+- Fixes RTX 5090-class and other power-limited Auto-UV scenarios, including
+  measured power walls, hardware brake evidence, capped-baseline clock reclaim,
+  and safe candidate reuse
+  ([#36](https://github.com/jpietek/PenguinBurner/pull/36),
+  [#37](https://github.com/jpietek/PenguinBurner/pull/37) by
+  [@jpietek](https://github.com/jpietek)).
+- Skips unsupported fixed power writes on mobile GPUs while preserving V/F and
+  memory tuning ([#31](https://github.com/jpietek/PenguinBurner/pull/31) by
+  [@MihneaTeodorStoica](https://github.com/MihneaTeodorStoica)).
+- Improves saved-profile verification, adds memory-offset editing, and shows the
+  curve with the live GPU position
+  ([#32](https://github.com/jpietek/PenguinBurner/pull/32),
+  [#33](https://github.com/jpietek/PenguinBurner/pull/33),
+  [#34](https://github.com/jpietek/PenguinBurner/pull/34), and
+  [#35](https://github.com/jpietek/PenguinBurner/pull/35) by
+  [@nanomad](https://github.com/nanomad)).
+- Keeps the silent fan curve selected across Auto-UV scans.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: PenguinBurner contributors
 
 pkgname=penguin-burner
-pkgver=0.7.6
+pkgver=0.7.7
 pkgrel=1
 pkgdesc='NVIDIA GPU automatic undervolting and fine tuning tool'
 arch=('x86_64')

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -48,7 +48,7 @@ are never committed to Git.
 From a clean checkout containing the release tag and Debian signing key:
 
 ```bash
-scripts/publish-ppa.sh 0.7.6
+scripts/publish-ppa.sh 0.7.7
 ```
 
 That one command builds and validates both Questing and Resolute source

--- a/packaging/flatpak/io.github.jpietek.PenguinBurner.metainfo.xml
+++ b/packaging/flatpak/io.github.jpietek.PenguinBurner.metainfo.xml
@@ -20,6 +20,7 @@
   </developer>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.7.7" date="2026-08-06" />
     <release version="0.7.6" date="2026-07-15" />
     <release version="0.7.5" date="2026-07-15" />
     <release version="0.7.4" date="2026-07-14" />

--- a/packaging/rpm/penguin-burner.spec
+++ b/packaging/rpm/penguin-burner.spec
@@ -1,5 +1,5 @@
 Name:           penguin-burner
-Version:        0.7.6
+Version:        0.7.7
 Release:        1%{?dist}
 Summary:        NVIDIA GPU automatic undervolting and fine tuning tool
 
@@ -107,6 +107,11 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.jpietek.Pen
 %{_datadir}/penguin-burner/penguin_burner.sh
 
 %changelog
+* Thu Aug 06 2026 PenguinBurner contributors <noreply@github.com> - 0.7.7-1
+- Fix RTX 5090-class and other power-limited Auto-UV scan scenarios.
+- Skip unsupported fixed power writes on mobile GPUs.
+- Improve saved-profile verification and memory-offset editing.
+
 * Wed Jul 15 2026 PenguinBurner contributors <noreply@github.com> - 0.7.6-1
 - Install or update the hardware service before the Auto-UV setup dialog
   opens, instead of showing a generic GPU with no limits.

--- a/profiles/uv/memory_offset_edit.py
+++ b/profiles/uv/memory_offset_edit.py
@@ -20,8 +20,11 @@ _EXCLUDED_PARENT_KEYS = {
 
 
 def editable_memory_offset_from_profile(profile: dict) -> int | None:
+    raw_offset = profile.get("memory_offset_mhz")
+    if raw_offset is None:
+        return None
     try:
-        return round(float(profile.get("memory_offset_mhz")))
+        return round(float(raw_offset))
     except (TypeError, ValueError):
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguin-burner"
-version = "0.7.6"
+version = "0.7.7"
 description = "NVIDIA GPU tuning tool for Linux: automatic and adaptive undervolting, an in-game monitoring overlay with PC latency and pre-frame-generation FPS, plus MSI Afterburner imports and LACT exports"
 requires-python = ">=3.11"
 dynamic = ["readme"]

--- a/ui/controllers/command.py
+++ b/ui/controllers/command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+from typing import Callable
 
 
 class CommandController:
@@ -10,8 +11,10 @@ class CommandController:
         self.process = None
         self.kind = ""
         self.command: list[str] = []
-        self.on_output = lambda _text: None
-        self.on_finished = lambda _kind, _exit_code, _exit_status: None
+        self.on_output: Callable[..., None] = lambda _text: None
+        self.on_finished: Callable[..., None] = (
+            lambda _kind, _exit_code, _exit_status: None
+        )
 
     def is_running(self) -> bool:
         return self.process is not None

--- a/ui/controllers/scan.py
+++ b/ui/controllers/scan.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import json
 import os
 import signal
+from typing import Callable
 
 
 class ScanController:
@@ -14,10 +15,12 @@ class ScanController:
         self.process = None
         self.stop_requested = False
         self._buffer = ""
-        self.on_output = lambda _text: None
-        self.on_event = lambda _payload: None
-        self.on_human_line = lambda _line: None
-        self.on_finished = lambda _exit_code, _exit_status, _stopped: None
+        self.on_output: Callable[..., None] = lambda _text: None
+        self.on_event: Callable[..., None] = lambda _payload: None
+        self.on_human_line: Callable[..., None] = lambda _line: None
+        self.on_finished: Callable[..., None] = (
+            lambda _exit_code, _exit_status, _stopped: None
+        )
 
     def is_running(self) -> bool:
         return self.process is not None

--- a/ui/controllers/verify.py
+++ b/ui/controllers/verify.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import json
 import os
 import signal
+from typing import Callable
 
 from ui.features.tuning.verify import elapsed_from_line
 from ui.features.tuning.verify import progress_percent
@@ -19,12 +20,14 @@ class VerifyController:
         self.last_elapsed_s = 0.0
         self.stop_requested = False
         self._buffer = ""
-        self.on_output = lambda _text: None
-        self.on_telemetry = lambda _payload: None
-        self.on_progress = (
+        self.on_output: Callable[..., None] = lambda _text: None
+        self.on_telemetry: Callable[..., None] = lambda _payload: None
+        self.on_progress: Callable[..., None] = (
             lambda _percent, *, elapsed_s=None, target_s=None, detail="": None
         )
-        self.on_finished = lambda _exit_code, _exit_status, _stopped: None
+        self.on_finished: Callable[..., None] = (
+            lambda _exit_code, _exit_status, _stopped: None
+        )
 
     def is_running(self) -> bool:
         return self.process is not None

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+from typing import Any
 
 from common.penguin_burner_paths import default_user_config_dir
 from curve_editors.uv.vf_curve_manual_editor import editable_anchor_from_profile
@@ -50,6 +51,39 @@ from ui.features.tuning.verify import workload_label
 
 
 class ProfileActionsMixin:
+    QtCore: Any
+    QtGui: Any
+    QtWidgets: Any
+    pg: Any
+    window: Any
+    tabs: Any
+    auto_uv_tab_index: int
+    profile_list: Any
+    profile_summaries: list[dict]
+    log_view: Any
+    controls: Any
+    errors: Any
+    header: Any
+    curve_tabs: Any
+    vf_plot: Any
+    scan_controller: Any
+    command_controller: Any
+    verify_controller: Any
+    gpu_index: int | None
+    last_auto_uv_candidate_id: str
+
+    def _workflow_running(self) -> bool:
+        raise NotImplementedError
+
+    def _load_profiles(self) -> None:
+        raise NotImplementedError
+
+    def _persist_silent_fan_preference(self, checked: bool) -> None:
+        raise NotImplementedError
+
+    def _set_profile_actions_enabled(self, enabled: bool) -> None:
+        raise NotImplementedError
+
     def _apply_profile_action(self) -> str:
         # Apply always targets the already-root daemon. Persistence is a daemon
         # API flag on that request; checking for the host unit from a Flatpak is


### PR DESCRIPTION
## Summary
- bump Python, Rust, and distro metadata to 0.7.7
- add concise linked release notes for PRs 31 through 37
- require the Vulkan layer, NVAPI shim, and burnerd in release wheels
- clarify RTX 5080 Efficiency target versus loaded-clock behavior

## Checks
- python -m pytest tests/ -q: 1775 passed
- Rust tests: 231 passed, 2 live-GPU tests ignored
- scripts/check-feature-static-analysis.sh: passed; no touched-file Pyright errors
- scripts/check-release-version.sh 0.7.7: passed
- sdist and manylinux wheel: twine check passed; native payloads verified

## Live validation
- Reviewed the August 4 and August 6 RTX 5080 full-scan results; no new hardware scan was run for this release commit.
- RTX 5090 behavior is covered by software scenarios, not a live 5090 run.