### PR TITLE
Deep-sleep (RTD3) gate: let hybrid-laptop dGPUs reach D3cold with the daemon running

### DIFF
--- a/burnerd/build.rs
+++ b/burnerd/build.rs
@@ -1,0 +1,26 @@
+//! Embed a git build id so a running daemon is identifiable at commit
+//! granularity. `version` alone (0.7.8 across a whole PR branch) let a stale
+//! /usr/libexec binary impersonate a fresh build through three debugging
+//! rounds of issue #30; the id in the startup journal line and the `status`
+//! response makes "which build is actually running" a one-command check.
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when the checkout's head moves; both paths are absent in sdist
+    // builds, where cargo ignores the stale-path directives.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    let build_id = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty())
+        // Non-git trees (sdist/tarball builds) still build; they just cannot
+        // claim a commit.
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=PENGUIN_BURNERD_BUILD_ID={build_id}");
+}

--- a/burnerd/src/api.rs
+++ b/burnerd/src/api.rs
@@ -54,6 +54,10 @@ pub struct StatusResult {
     pub state: String,
     pub active_job: Option<ActiveJob>,
     pub version: String,
+    /// Short git commit of this build ("unknown" for non-git source trees).
+    /// The package version alone cannot distinguish builds within a release
+    /// cycle, which let a stale installed daemon pass for a fresh one.
+    pub build: String,
     pub protocol_major: u32,
     pub protocol_minor: u32,
     pub capabilities: &'static [&'static str],
@@ -93,6 +97,7 @@ impl StatusResult {
             state: state.into(),
             active_job,
             version: env!("CARGO_PKG_VERSION").to_string(),
+            build: env!("PENGUIN_BURNERD_BUILD_ID").to_string(),
             protocol_major: PROTOCOL_MAJOR,
             protocol_minor: PROTOCOL_MINOR,
             capabilities: DAEMON_CAPABILITIES,
@@ -412,8 +417,9 @@ mod tests {
         assert_eq!(
             text,
             format!(
-                "{{\"ok\":true,\"result\":{{\"state\":\"idle\",\"active_job\":null,\"version\":\"{}\",\"protocol_major\":2,\"protocol_minor\":0,\"capabilities\":[\"deep-sleep-status-v1\",\"energy-savings-v1\",\"game-runtime-v1\",\"gpu-capabilities-v1\",\"gpu-telemetry-v1\",\"gpu-vf-snapshot-v1\",\"gpu-writes-v1\",\"runtime-spec-v1\",\"scan-stream-v1\",\"verification-stream-v1\"]}}}}",
+                "{{\"ok\":true,\"result\":{{\"state\":\"idle\",\"active_job\":null,\"version\":\"{}\",\"build\":\"{}\",\"protocol_major\":2,\"protocol_minor\":0,\"capabilities\":[\"deep-sleep-status-v1\",\"energy-savings-v1\",\"game-runtime-v1\",\"gpu-capabilities-v1\",\"gpu-telemetry-v1\",\"gpu-vf-snapshot-v1\",\"gpu-writes-v1\",\"runtime-spec-v1\",\"scan-stream-v1\",\"verification-stream-v1\"]}}}}",
                 env!("CARGO_PKG_VERSION"),
+                env!("PENGUIN_BURNERD_BUILD_ID"),
             )
         );
     }

--- a/burnerd/src/api.rs
+++ b/burnerd/src/api.rs
@@ -19,6 +19,7 @@ use crate::supervisor::{self, Supervisor};
 pub const PROTOCOL_MAJOR: u32 = 2;
 pub const PROTOCOL_MINOR: u32 = 0;
 pub const DAEMON_CAPABILITIES: &[&str] = &[
+    "deep-sleep-status-v1",
     "energy-savings-v1",
     "game-runtime-v1",
     "gpu-capabilities-v1",
@@ -60,6 +61,8 @@ pub struct StatusResult {
     pub game_runtime: Option<GameRuntimeStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub energy_savings: Option<EnergySavingsStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deep_sleep: Option<crate::rtd3::DeepSleepStatus>,
 }
 
 #[derive(Debug, Serialize)]
@@ -95,6 +98,7 @@ impl StatusResult {
             capabilities: DAEMON_CAPABILITIES,
             game_runtime: None,
             energy_savings: None,
+            deep_sleep: None,
         }
     }
 
@@ -105,6 +109,11 @@ impl StatusResult {
 
     pub fn with_energy_savings(mut self, energy_savings: Option<EnergySavingsStatus>) -> Self {
         self.energy_savings = energy_savings;
+        self
+    }
+
+    pub fn with_deep_sleep(mut self, deep_sleep: Option<crate::rtd3::DeepSleepStatus>) -> Self {
+        self.deep_sleep = deep_sleep;
         self
     }
 }
@@ -403,7 +412,7 @@ mod tests {
         assert_eq!(
             text,
             format!(
-                "{{\"ok\":true,\"result\":{{\"state\":\"idle\",\"active_job\":null,\"version\":\"{}\",\"protocol_major\":2,\"protocol_minor\":0,\"capabilities\":[\"energy-savings-v1\",\"game-runtime-v1\",\"gpu-capabilities-v1\",\"gpu-telemetry-v1\",\"gpu-vf-snapshot-v1\",\"gpu-writes-v1\",\"runtime-spec-v1\",\"scan-stream-v1\",\"verification-stream-v1\"]}}}}",
+                "{{\"ok\":true,\"result\":{{\"state\":\"idle\",\"active_job\":null,\"version\":\"{}\",\"protocol_major\":2,\"protocol_minor\":0,\"capabilities\":[\"deep-sleep-status-v1\",\"energy-savings-v1\",\"game-runtime-v1\",\"gpu-capabilities-v1\",\"gpu-telemetry-v1\",\"gpu-vf-snapshot-v1\",\"gpu-writes-v1\",\"runtime-spec-v1\",\"scan-stream-v1\",\"verification-stream-v1\"]}}}}",
                 env!("CARGO_PKG_VERSION"),
             )
         );

--- a/burnerd/src/gpu/backend.rs
+++ b/burnerd/src/gpu/backend.rs
@@ -9,8 +9,8 @@ use nvml_wrapper::{Device, Nvml};
 use super::nvapi::{NvapiVfSession, NvapiVoltageSession};
 use super::{
     mw_to_w_float, mw_to_w_round, snap_core_clock_mhz, snap_core_clock_range, w_to_mw_round,
-    AppliedOffsets, ClockOffsets, ClockType, GpuBackend, GpuError, GpuIdentity, GpuMemoryInfo,
-    GpuResult, PowerLimits, RangeSnapResult, SnapResult, VfPoint, VfSummary,
+    AppliedOffsets, ClockOffsets, ClockType, GpuBackend, GpuContextPids, GpuError, GpuIdentity,
+    GpuMemoryInfo, GpuResult, PowerLimits, RangeSnapResult, SnapResult, VfPoint, VfSummary,
 };
 
 pub struct NvmlBackend {
@@ -187,7 +187,13 @@ impl GpuBackend for NvmlBackend {
             .map(|reasons| reasons.bits())
     }
 
-    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>> {
+    fn gpu_context_pids(&self) -> GpuResult<GpuContextPids> {
+        fn pids(processes: Vec<nvml_wrapper::struct_wrappers::device::ProcessInfo>) -> Vec<u32> {
+            let mut pids: Vec<u32> = processes.into_iter().map(|process| process.pid).collect();
+            pids.sort_unstable();
+            pids.dedup();
+            pids
+        }
         let device = self.device()?;
         let graphics = device
             .running_graphics_processes()
@@ -195,14 +201,10 @@ impl GpuBackend for NvmlBackend {
         let compute = device
             .running_compute_processes()
             .map_err(|error| runtime_error("nvmlDeviceGetComputeRunningProcesses_v3", error))?;
-        let mut pids: Vec<u32> = graphics
-            .into_iter()
-            .chain(compute)
-            .map(|process| process.pid)
-            .collect();
-        pids.sort_unstable();
-        pids.dedup();
-        Ok(pids)
+        Ok(GpuContextPids {
+            graphics: pids(graphics),
+            compute: pids(compute),
+        })
     }
 
     #[allow(deprecated)]

--- a/burnerd/src/gpu/backend.rs
+++ b/burnerd/src/gpu/backend.rs
@@ -20,6 +20,31 @@ pub struct NvmlBackend {
     vf: Option<NvapiVfSession>,
 }
 
+#[derive(Debug)]
+pub(crate) enum ContextProbeError {
+    Query(GpuError),
+    Shutdown {
+        shutdown: GpuError,
+        query: Option<GpuError>,
+    },
+}
+
+impl std::fmt::Display for ContextProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Query(error) => error.fmt(formatter),
+            Self::Shutdown {
+                shutdown,
+                query: Some(query),
+            } => write!(formatter, "{shutdown}; context query also failed: {query}"),
+            Self::Shutdown {
+                shutdown,
+                query: None,
+            } => shutdown.fmt(formatter),
+        }
+    }
+}
+
 impl NvmlBackend {
     pub fn open(gpu_index: u32) -> GpuResult<Self> {
         let nvml = Nvml::init().map_err(|error| runtime_error("nvmlInit_v2", error))?;
@@ -64,6 +89,58 @@ impl NvmlBackend {
             .ok()
             .map(|offset| offset.clock_offset_mhz))
     }
+}
+
+/// One context-only NVML observation for the RTD3 watcher. The local `Nvml`
+/// owns the driver session and is dropped before this function returns; unlike
+/// `NvmlBackend::open`, this does not initialize either hidden NVAPI session.
+pub(crate) fn context_pids_ephemeral(
+    gpu_index: u32,
+) -> Result<GpuContextPids, ContextProbeError> {
+    let nvml = Nvml::init()
+        .map_err(|error| runtime_error("nvmlInit_v2", error))
+        .map_err(ContextProbeError::Query)?;
+    let query_result = nvml
+        .device_by_index(gpu_index)
+        .map_err(|error| runtime_error("nvmlDeviceGetHandleByIndex_v2", error))
+        .and_then(|device| query_context_pids(&device));
+    let shutdown_result = nvml
+        .shutdown()
+        .map_err(|error| runtime_error("nvmlShutdown", error));
+    finish_context_probe(query_result, shutdown_result)
+}
+
+fn finish_context_probe(
+    query_result: GpuResult<GpuContextPids>,
+    shutdown_result: GpuResult<()>,
+) -> Result<GpuContextPids, ContextProbeError> {
+    match (query_result, shutdown_result) {
+        (query_result, Err(shutdown)) => Err(ContextProbeError::Shutdown {
+            shutdown,
+            query: query_result.err(),
+        }),
+        (Err(error), Ok(())) => Err(ContextProbeError::Query(error)),
+        (Ok(contexts), Ok(())) => Ok(contexts),
+    }
+}
+
+fn query_context_pids(device: &Device<'_>) -> GpuResult<GpuContextPids> {
+    fn pids(processes: Vec<nvml_wrapper::struct_wrappers::device::ProcessInfo>) -> Vec<u32> {
+        let mut pids: Vec<u32> = processes.into_iter().map(|process| process.pid).collect();
+        pids.sort_unstable();
+        pids.dedup();
+        pids
+    }
+    let graphics = device
+        .running_graphics_processes()
+        .map_err(|error| runtime_error("nvmlDeviceGetGraphicsRunningProcesses_v3", error))?;
+    let compute = device
+        .running_compute_processes()
+        .map_err(|error| runtime_error("nvmlDeviceGetComputeRunningProcesses_v3", error))?;
+    Ok(GpuContextPids {
+        graphics: pids(graphics),
+        compute: pids(compute),
+    })
 }
 
 impl GpuBackend for NvmlBackend {
@@ -188,23 +265,8 @@ impl GpuBackend for NvmlBackend {
     }
 
     fn gpu_context_pids(&self) -> GpuResult<GpuContextPids> {
-        fn pids(processes: Vec<nvml_wrapper::struct_wrappers::device::ProcessInfo>) -> Vec<u32> {
-            let mut pids: Vec<u32> = processes.into_iter().map(|process| process.pid).collect();
-            pids.sort_unstable();
-            pids.dedup();
-            pids
-        }
         let device = self.device()?;
-        let graphics = device
-            .running_graphics_processes()
-            .map_err(|error| runtime_error("nvmlDeviceGetGraphicsRunningProcesses_v3", error))?;
-        let compute = device
-            .running_compute_processes()
-            .map_err(|error| runtime_error("nvmlDeviceGetComputeRunningProcesses_v3", error))?;
-        Ok(GpuContextPids {
-            graphics: pids(graphics),
-            compute: pids(compute),
-        })
+        query_context_pids(&device)
     }
 
     #[allow(deprecated)]
@@ -527,6 +589,30 @@ mod tests {
         assert_eq!(
             policy_error("nvmlDeviceSetClockOffsets", NvmlError::NotSupported).to_string(),
             "nvmlDeviceSetClockOffsets failed with NVML error 3: the requested operation is not available on the target device"
+        );
+    }
+
+    #[test]
+    fn ephemeral_probe_surfaces_shutdown_failure_after_a_successful_query() {
+        let result = finish_context_probe(
+            Ok(GpuContextPids::default()),
+            Err(GpuError::other("mock nvmlShutdown failure", 0)),
+        );
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "mock nvmlShutdown failure"
+        );
+    }
+
+    #[test]
+    fn ephemeral_probe_preserves_shutdown_failure_when_the_query_also_fails() {
+        let result = finish_context_probe(
+            Err(GpuError::other("mock context query failure", 0)),
+            Err(GpuError::other("mock nvmlShutdown failure", 0)),
+        );
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "mock nvmlShutdown failure; context query also failed: mock context query failure"
         );
     }
 }

--- a/burnerd/src/gpu/backend.rs
+++ b/burnerd/src/gpu/backend.rs
@@ -187,6 +187,24 @@ impl GpuBackend for NvmlBackend {
             .map(|reasons| reasons.bits())
     }
 
+    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>> {
+        let device = self.device()?;
+        let graphics = device
+            .running_graphics_processes()
+            .map_err(|error| runtime_error("nvmlDeviceGetGraphicsRunningProcesses_v3", error))?;
+        let compute = device
+            .running_compute_processes()
+            .map_err(|error| runtime_error("nvmlDeviceGetComputeRunningProcesses_v3", error))?;
+        let mut pids: Vec<u32> = graphics
+            .into_iter()
+            .chain(compute)
+            .map(|process| process.pid)
+            .collect();
+        pids.sort_unstable();
+        pids.dedup();
+        Ok(pids)
+    }
+
     #[allow(deprecated)]
     fn query_power_limits(&self) -> PowerLimits {
         let Ok(device) = self.device() else {

--- a/burnerd/src/gpu/context.rs
+++ b/burnerd/src/gpu/context.rs
@@ -1,0 +1,54 @@
+//! Short-lived GPU-context observation for the RTD3 watcher.
+//!
+//! Unlike the general GPU RPC backend, one call owns one context-only NVML
+//! session and drops it before returning. It never opens hidden NVAPI sessions
+//! and never enters the shared RPC registry.
+
+use std::env;
+use std::path::PathBuf;
+
+use super::{backend, mock::MockGpu, GpuBackend, GpuContextPids, GpuError};
+
+pub(crate) use backend::ContextProbeError;
+
+const MOCK_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU";
+const MOCK_FAIL_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU_FAIL";
+const MOCK_CONTEXT_PIDS_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS";
+const MOCK_LIFETIME_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU_LIFETIME_FILE";
+
+/// Observe live graphics/compute contexts without retaining NVIDIA state.
+/// The production and test adapters both finish their complete open/query/drop
+/// lifetime before this function returns, including query-error paths.
+pub(crate) fn context_pids_ephemeral(
+    gpu_index: u32,
+) -> Result<GpuContextPids, ContextProbeError> {
+    if env::var_os(MOCK_ENV).is_some_and(|value| !value.is_empty()) {
+        return mock_context_pids_ephemeral(gpu_index);
+    }
+    backend::context_pids_ephemeral(gpu_index)
+}
+
+fn mock_context_pids_ephemeral(
+    gpu_index: u32,
+) -> Result<GpuContextPids, ContextProbeError> {
+    let mut mock = MockGpu::new();
+    mock.gpu_index = gpu_index;
+    mock.context_pids_file = env::var_os(MOCK_CONTEXT_PIDS_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    if let Some(path) = env::var_os(MOCK_LIFETIME_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        mock.track_lifetime(path);
+    }
+    if env::var(MOCK_FAIL_ENV).as_deref() == Ok("gpu_context_pids") {
+        mock.inject_failure(
+            "gpu_context_pids",
+            GpuError::other("gpu_context_pids mock failure", 0),
+        );
+    }
+    let result = mock.gpu_context_pids();
+    drop(mock);
+    result.map_err(ContextProbeError::Query)
+}

--- a/burnerd/src/gpu/mock.rs
+++ b/burnerd/src/gpu/mock.rs
@@ -12,8 +12,9 @@ use std::path::PathBuf;
 
 use super::{
     snap_core_clock_mhz, snap_core_clock_range, vf_editable_core_points, vf_find_nearest,
-    vf_summary_of, AppliedOffsets, ClockOffsets, ClockType, GpuBackend, GpuError, GpuIdentity,
-    GpuMemoryInfo, GpuResult, PowerLimits, RangeSnapResult, SnapResult, VfPoint, VfSummary,
+    vf_summary_of, AppliedOffsets, ClockOffsets, ClockType, GpuBackend, GpuContextPids, GpuError,
+    GpuIdentity, GpuMemoryInfo, GpuResult, PowerLimits, RangeSnapResult, SnapResult, VfPoint,
+    VfSummary,
 };
 
 /// One recorded privileged operation, in call order.
@@ -94,10 +95,12 @@ pub struct MockGpu {
     pub vf_points: Vec<VfPoint>,
 
     /// Canned `gpu_context_pids` answer.
-    pub context_pids: Vec<u32>,
+    pub context_pids: GpuContextPids,
     /// Integration-test seam: when set, `gpu_context_pids` re-reads this file
     /// on every call (missing file → no contexts), so a test can stage and
     /// remove GPU clients while the daemon runs. Overrides `context_pids`.
+    /// Format: whitespace-separated tokens where `graphics` / `compute`
+    /// select the kind for subsequent PIDs (default `graphics`).
     pub context_pids_file: Option<PathBuf>,
 
     ops: RefCell<Vec<MockOp>>,
@@ -140,7 +143,7 @@ impl Default for MockGpu {
             voltage_uv: None,
             vf_available: false,
             vf_points: Vec::new(),
-            context_pids: Vec::new(),
+            context_pids: GpuContextPids::default(),
             context_pids_file: None,
             ops: RefCell::new(Vec::new()),
             failures: RefCell::new(HashMap::new()),
@@ -252,10 +255,10 @@ impl GpuBackend for MockGpu {
         self.throttle_mask
     }
 
-    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>> {
+    fn gpu_context_pids(&self) -> GpuResult<GpuContextPids> {
         self.fail("gpu_context_pids")?;
         match &self.context_pids_file {
-            Some(path) => Ok(parse_pid_list(
+            Some(path) => Ok(parse_context_pid_list(
                 &std::fs::read_to_string(path).unwrap_or_default(),
             )),
             None => Ok(self.context_pids.clone()),
@@ -454,12 +457,29 @@ impl GpuBackend for MockGpu {
     }
 }
 
-/// Whitespace-separated PID list from the `context_pids_file` seam; non-PID
+/// Whitespace-separated token list from the `context_pids_file` seam. The
+/// tokens `graphics` and `compute` select the kind for the PIDs that follow
+/// (default `graphics`, so a bare PID list stays valid); other non-PID
 /// tokens are ignored.
-fn parse_pid_list(text: &str) -> Vec<u32> {
-    text.split_whitespace()
-        .filter_map(|token| token.parse().ok())
-        .collect()
+fn parse_context_pid_list(text: &str) -> GpuContextPids {
+    let mut pids = GpuContextPids::default();
+    let mut compute = false;
+    for token in text.split_whitespace() {
+        match token {
+            "graphics" => compute = false,
+            "compute" => compute = true,
+            token => {
+                if let Ok(pid) = token.parse() {
+                    if compute {
+                        pids.compute.push(pid);
+                    } else {
+                        pids.graphics.push(pid);
+                    }
+                }
+            }
+        }
+    }
+    pids
 }
 
 #[cfg(test)]
@@ -469,17 +489,24 @@ mod tests {
     #[test]
     fn context_pids_come_from_the_canned_field_or_the_file_seam() {
         let mut mock = MockGpu::new();
-        assert_eq!(mock.gpu_context_pids().unwrap(), Vec::<u32>::new());
-        mock.context_pids = vec![4242];
-        assert_eq!(mock.gpu_context_pids().unwrap(), vec![4242]);
+        assert_eq!(mock.gpu_context_pids().unwrap(), GpuContextPids::default());
+        mock.context_pids.graphics = vec![4242];
+        assert_eq!(mock.gpu_context_pids().unwrap().graphics, vec![4242]);
 
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("pids");
         mock.context_pids_file = Some(file.clone());
         // Missing file: the seam reports no contexts (overriding the canned field).
-        assert_eq!(mock.gpu_context_pids().unwrap(), Vec::<u32>::new());
-        std::fs::write(&file, "123 456\nnot-a-pid\n").unwrap();
-        assert_eq!(mock.gpu_context_pids().unwrap(), vec![123, 456]);
+        assert_eq!(mock.gpu_context_pids().unwrap(), GpuContextPids::default());
+        // Bare PIDs default to graphics; kind tokens switch the target list.
+        std::fs::write(&file, "123 456\nnot-a-pid\ncompute 789\ngraphics 321\n").unwrap();
+        assert_eq!(
+            mock.gpu_context_pids().unwrap(),
+            GpuContextPids {
+                graphics: vec![123, 456, 321],
+                compute: vec![789],
+            }
+        );
     }
 
     #[test]

--- a/burnerd/src/gpu/mock.rs
+++ b/burnerd/src/gpu/mock.rs
@@ -102,6 +102,10 @@ pub struct MockGpu {
     /// Format: whitespace-separated tokens where `graphics` / `compute`
     /// select the kind for subsequent PIDs (default `graphics`).
     pub context_pids_file: Option<PathBuf>,
+    /// Integration-test seam: a three-field `opens closes live` file updated
+    /// when a mock NVIDIA session is acquired and dropped. Production never
+    /// sets it.
+    lifetime_file: Option<PathBuf>,
 
     ops: RefCell<Vec<MockOp>>,
     failures: RefCell<HashMap<&'static str, GpuError>>,
@@ -145,6 +149,7 @@ impl Default for MockGpu {
             vf_points: Vec::new(),
             context_pids: GpuContextPids::default(),
             context_pids_file: None,
+            lifetime_file: None,
             ops: RefCell::new(Vec::new()),
             failures: RefCell::new(HashMap::new()),
             on_temperature: RefCell::new(None),
@@ -175,6 +180,13 @@ impl MockGpu {
         self.ops.borrow().clone()
     }
 
+    /// Begin tracking this mock instance as one live NVIDIA session.
+    pub(crate) fn track_lifetime(&mut self, path: PathBuf) {
+        let (opens, closes, live) = read_lifetime_state(&path);
+        write_lifetime_state(&path, opens + 1, closes, live + 1);
+        self.lifetime_file = Some(path);
+    }
+
     fn record(&self, op: MockOp) {
         self.ops.borrow_mut().push(op);
     }
@@ -184,6 +196,35 @@ impl MockGpu {
             Some(err) => Err(err.clone()),
             None => Ok(()),
         }
+    }
+}
+
+impl Drop for MockGpu {
+    fn drop(&mut self) {
+        let Some(path) = &self.lifetime_file else {
+            return;
+        };
+        let (opens, closes, live) = read_lifetime_state(path);
+        write_lifetime_state(path, opens, closes + 1, live.saturating_sub(1));
+    }
+}
+
+fn write_lifetime_state(path: &std::path::Path, opens: u64, closes: u64, live: u64) {
+    let temporary = path.with_extension("tmp");
+    if std::fs::write(&temporary, format!("{opens} {closes} {live}\n")).is_ok() {
+        let _ = std::fs::rename(temporary, path);
+    }
+}
+
+fn read_lifetime_state(path: &std::path::Path) -> (u64, u64, u64) {
+    let values: Vec<u64> = std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    match values.as_slice() {
+        [opens, closes, live] => (*opens, *closes, *live),
+        _ => (0, 0, 0),
     }
 }
 

--- a/burnerd/src/gpu/mock.rs
+++ b/burnerd/src/gpu/mock.rs
@@ -8,6 +8,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use super::{
     snap_core_clock_mhz, snap_core_clock_range, vf_editable_core_points, vf_find_nearest,
@@ -92,6 +93,13 @@ pub struct MockGpu {
     pub vf_available: bool,
     pub vf_points: Vec<VfPoint>,
 
+    /// Canned `gpu_context_pids` answer.
+    pub context_pids: Vec<u32>,
+    /// Integration-test seam: when set, `gpu_context_pids` re-reads this file
+    /// on every call (missing file → no contexts), so a test can stage and
+    /// remove GPU clients while the daemon runs. Overrides `context_pids`.
+    pub context_pids_file: Option<PathBuf>,
+
     ops: RefCell<Vec<MockOp>>,
     failures: RefCell<HashMap<&'static str, GpuError>>,
     /// Test hook run on every `temperature_c` read — lets engine-loop tests
@@ -132,6 +140,8 @@ impl Default for MockGpu {
             voltage_uv: None,
             vf_available: false,
             vf_points: Vec::new(),
+            context_pids: Vec::new(),
+            context_pids_file: None,
             ops: RefCell::new(Vec::new()),
             failures: RefCell::new(HashMap::new()),
             on_temperature: RefCell::new(None),
@@ -240,6 +250,16 @@ impl GpuBackend for MockGpu {
 
     fn throttle_reason_mask(&self) -> Option<u64> {
         self.throttle_mask
+    }
+
+    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>> {
+        self.fail("gpu_context_pids")?;
+        match &self.context_pids_file {
+            Some(path) => Ok(parse_pid_list(
+                &std::fs::read_to_string(path).unwrap_or_default(),
+            )),
+            None => Ok(self.context_pids.clone()),
+        }
     }
 
     fn query_power_limits(&self) -> PowerLimits {
@@ -434,9 +454,33 @@ impl GpuBackend for MockGpu {
     }
 }
 
+/// Whitespace-separated PID list from the `context_pids_file` seam; non-PID
+/// tokens are ignored.
+fn parse_pid_list(text: &str) -> Vec<u32> {
+    text.split_whitespace()
+        .filter_map(|token| token.parse().ok())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn context_pids_come_from_the_canned_field_or_the_file_seam() {
+        let mut mock = MockGpu::new();
+        assert_eq!(mock.gpu_context_pids().unwrap(), Vec::<u32>::new());
+        mock.context_pids = vec![4242];
+        assert_eq!(mock.gpu_context_pids().unwrap(), vec![4242]);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("pids");
+        mock.context_pids_file = Some(file.clone());
+        // Missing file: the seam reports no contexts (overriding the canned field).
+        assert_eq!(mock.gpu_context_pids().unwrap(), Vec::<u32>::new());
+        std::fs::write(&file, "123 456\nnot-a-pid\n").unwrap();
+        assert_eq!(mock.gpu_context_pids().unwrap(), vec![123, 456]);
+    }
 
     #[test]
     fn records_writes_in_order() {

--- a/burnerd/src/gpu/mod.rs
+++ b/burnerd/src/gpu/mod.rs
@@ -220,6 +220,15 @@ impl std::error::Error for GpuError {}
 /// Convenience alias for backend results.
 pub type GpuResult<T> = Result<T, GpuError>;
 
+/// PIDs holding a live GPU context, split by context kind. Each list is
+/// sorted and deduplicated; a process with both context kinds appears in
+/// both lists.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GpuContextPids {
+    pub graphics: Vec<u32>,
+    pub compute: Vec<u32>,
+}
+
 /// The narrow GPU backend contract: hardware facts and privileged operations.
 ///
 /// Every fallible operation returns [`GpuError`]; best-effort reads that the
@@ -245,10 +254,11 @@ pub trait GpuBackend {
     fn gpu_utilization_pct(&self) -> Option<u32>;
     fn clock_info_mhz(&self, clock_type: ClockType) -> Option<u32>;
     fn throttle_reason_mask(&self) -> Option<u64>;
-    /// PIDs holding a live graphics or compute context on this GPU. The
-    /// accurate "GPU in use" signal on fine-grained RTD3 laptops, where an
-    /// idly open `/dev/nvidia<N>` fd does not keep the GPU awake.
-    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>>;
+    /// PIDs holding a live graphics or compute context on this GPU, split by
+    /// kind. The accurate "GPU in use" signal on fine-grained RTD3 laptops,
+    /// where an idly open `/dev/nvidia<N>` fd does not keep the GPU awake;
+    /// the split feeds the `deep_sleep.gpu_clients` debug stats.
+    fn gpu_context_pids(&self) -> GpuResult<GpuContextPids>;
 
     // --- power / persistence ----------------------------------------------
     fn query_power_limits(&self) -> PowerLimits;

--- a/burnerd/src/gpu/mod.rs
+++ b/burnerd/src/gpu/mod.rs
@@ -245,6 +245,10 @@ pub trait GpuBackend {
     fn gpu_utilization_pct(&self) -> Option<u32>;
     fn clock_info_mhz(&self, clock_type: ClockType) -> Option<u32>;
     fn throttle_reason_mask(&self) -> Option<u64>;
+    /// PIDs holding a live graphics or compute context on this GPU. The
+    /// accurate "GPU in use" signal on fine-grained RTD3 laptops, where an
+    /// idly open `/dev/nvidia<N>` fd does not keep the GPU awake.
+    fn gpu_context_pids(&self) -> GpuResult<Vec<u32>>;
 
     // --- power / persistence ----------------------------------------------
     fn query_power_limits(&self) -> PowerLimits;

--- a/burnerd/src/gpu/mod.rs
+++ b/burnerd/src/gpu/mod.rs
@@ -8,6 +8,7 @@
 //! error-message text are preserved verbatim (see `port-notes/03-nvml-ffi.md`).
 
 mod backend;
+pub(crate) mod context;
 mod nvapi;
 
 // Compiled into the binary (not test-gated) because it also backs the

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -33,6 +33,9 @@ use crate::gpu::{
 
 const MOCK_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU";
 const MOCK_FAIL_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU_FAIL";
+/// Path of a PID-list file the mock re-reads on every `gpu_context_pids` call,
+/// so integration tests can stage and remove GPU contexts while the daemon runs.
+const MOCK_CONTEXT_PIDS_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS";
 
 /// method → request fields allowed besides `method`. Also the method registry:
 /// a name missing here is "unknown daemon method".
@@ -131,6 +134,20 @@ pub fn release_idle_backends(ttl: Duration) -> usize {
     before - registry.len()
 }
 
+/// PIDs holding a live graphics/compute context on `gpu_index`, for the
+/// deep-sleep watcher's fine-grained "GPU in use" signal. Uses (and lazily
+/// opens) the shared registry backend; the entry's last-used stamp lets
+/// `release_idle_backends` sweep it once the watcher stops asking.
+pub fn context_pids(gpu_index: u32) -> Result<Vec<u32>, String> {
+    let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
+    let position = registry_position(&mut registry, gpu_index)?;
+    let backend: &dyn GpuBackend = match &registry[position].backend {
+        RpcBackend::Real(backend) => backend.as_ref(),
+        RpcBackend::Mock(backend) => backend.as_ref(),
+    };
+    backend.gpu_context_pids().map_err(|err| err.to_string())
+}
+
 fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {
     if env::var_os(MOCK_ENV).is_some_and(|v| !v.is_empty()) {
         let mut mock = MockGpu::new();
@@ -189,6 +206,9 @@ fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {
             base_voltage_uv: 900_000,
             current_offset_khz: 120_000,
         }];
+        mock.context_pids_file = env::var_os(MOCK_CONTEXT_PIDS_ENV)
+            .filter(|v| !v.is_empty())
+            .map(std::path::PathBuf::from);
         if let Ok(method) = env::var(MOCK_FAIL_ENV) {
             if !method.is_empty() {
                 let message = format!("{method} mock failure");

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -134,6 +134,17 @@ pub fn release_idle_backends(ttl: Duration) -> usize {
     before - registry.len()
 }
 
+/// Backends open right now — the daemon's own GPU hold count. Surfaced in the
+/// deep-sleep status because the watcher's client sample excludes the daemon's
+/// pid: without this number a daemon-held NVML session (a polling GUI's
+/// telemetry backend) reads as "no clients" while it pins the GPU.
+pub fn open_backend_count() -> usize {
+    REGISTRY
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .len()
+}
+
 fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {
     if env::var_os(MOCK_ENV).is_some_and(|v| !v.is_empty()) {
         let mut mock = MockGpu::new();

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde_json::{json, Map, Value};
 
 use crate::gpu::{
-    mock::MockGpu, ClockType, GpuBackend, GpuContextPids, GpuError, GpuIdentity, GpuMemoryInfo,
+    mock::MockGpu, ClockType, GpuBackend, GpuError, GpuIdentity, GpuMemoryInfo,
     NvmlBackend, VfPoint,
 };
 
@@ -132,21 +132,6 @@ pub fn release_idle_backends(ttl: Duration) -> usize {
     let before = registry.len();
     registry.retain(|entry| entry.last_used.elapsed() < ttl);
     before - registry.len()
-}
-
-/// PIDs holding a live graphics/compute context on `gpu_index`, split by
-/// kind, for the deep-sleep watcher's fine-grained "GPU in use" signal and
-/// its `gpu_clients` debug stats. Uses (and lazily opens) the shared registry
-/// backend; the entry's last-used stamp lets `release_idle_backends` sweep it
-/// once the watcher stops asking.
-pub fn context_pids(gpu_index: u32) -> Result<GpuContextPids, String> {
-    let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
-    let position = registry_position(&mut registry, gpu_index)?;
-    let backend: &dyn GpuBackend = match &registry[position].backend {
-        RpcBackend::Real(backend) => backend.as_ref(),
-        RpcBackend::Mock(backend) => backend.as_ref(),
-    };
-    backend.gpu_context_pids().map_err(|err| err.to_string())
 }
 
 fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -22,7 +22,7 @@
 
 use std::env;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Map, Value};
 
@@ -109,8 +109,27 @@ enum RpcBackend {
 // threaded Python daemon call these drivers from arbitrary handler threads).
 unsafe impl Send for RpcBackend {}
 
-/// Lazy per-`gpu_index` backends, kept for the daemon's lifetime.
-static REGISTRY: Mutex<Vec<(u32, RpcBackend)>> = Mutex::new(Vec::new());
+struct RegistryEntry {
+    gpu_index: u32,
+    backend: RpcBackend,
+    last_used: Instant,
+}
+
+/// Lazy per-`gpu_index` backends. On desktops they live for the daemon's
+/// lifetime; while the deep-sleep gate is armed the rtd3 watcher drops idle
+/// entries (`release_idle_backends`) so a one-off telemetry query cannot pin
+/// the GPU in D0 forever. Dropping a real entry closes NVML and the hidden
+/// NVAPI sessions via their `Drop` impls; the next request simply reopens.
+static REGISTRY: Mutex<Vec<RegistryEntry>> = Mutex::new(Vec::new());
+
+/// Drop backends that have not served a request within `ttl`. Returns how
+/// many were released. Called only while the deep-sleep gate is armed.
+pub fn release_idle_backends(ttl: Duration) -> usize {
+    let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
+    let before = registry.len();
+    registry.retain(|entry| entry.last_used.elapsed() < ttl);
+    before - registry.len()
+}
 
 fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {
     if env::var_os(MOCK_ENV).is_some_and(|v| !v.is_empty()) {
@@ -186,6 +205,28 @@ fn open_backend(gpu_index: u32) -> Result<RpcBackend, String> {
         .map_err(|err| err.to_string())
 }
 
+/// Find (or lazily open) the backend for `gpu_index`, stamping its last-use
+/// time so `release_idle_backends` measures idleness from the newest request.
+fn registry_position(registry: &mut Vec<RegistryEntry>, gpu_index: u32) -> Result<usize, String> {
+    match registry
+        .iter()
+        .position(|entry| entry.gpu_index == gpu_index)
+    {
+        Some(position) => {
+            registry[position].last_used = Instant::now();
+            Ok(position)
+        }
+        None => {
+            registry.push(RegistryEntry {
+                gpu_index,
+                backend: open_backend(gpu_index)?,
+                last_used: Instant::now(),
+            });
+            Ok(registry.len() - 1)
+        }
+    }
+}
+
 /// A fully-parsed, validated GPU write. Parsing is pure (no backend), so every
 /// field-validation error is returned BEFORE any NVML/NVAPI init.
 enum GpuWrite {
@@ -230,15 +271,9 @@ pub fn handle(method: &str, request: &Map<String, Value>) -> Result<Value, Strin
     let write = parse(method, request)?;
 
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
-    let position = match registry.iter().position(|(index, _)| *index == gpu_index) {
-        Some(position) => position,
-        None => {
-            registry.push((gpu_index, open_backend(gpu_index)?));
-            registry.len() - 1
-        }
-    };
+    let position = registry_position(&mut registry, gpu_index)?;
 
-    match &registry[position].1 {
+    match &registry[position].backend {
         RpcBackend::Real(backend) => execute(backend.as_ref(), write),
         // Test seam only: echo the ops recorded during this call back to the
         // integration test (its sole cross-process channel). Never runs in prod.
@@ -266,14 +301,8 @@ pub fn is_read_method(method: &str) -> bool {
 
 fn read(gpu_index: u32, method: &str) -> Result<Value, String> {
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
-    let position = match registry.iter().position(|(index, _)| *index == gpu_index) {
-        Some(position) => position,
-        None => {
-            registry.push((gpu_index, open_backend(gpu_index)?));
-            registry.len() - 1
-        }
-    };
-    let backend: &dyn GpuBackend = match &registry[position].1 {
+    let position = registry_position(&mut registry, gpu_index)?;
+    let backend: &dyn GpuBackend = match &registry[position].backend {
         RpcBackend::Real(backend) => backend.as_ref(),
         RpcBackend::Mock(backend) => backend.as_ref(),
     };
@@ -421,24 +450,18 @@ fn unix_time_ns() -> u64 {
 pub fn probe_power_limit_support(request: &Map<String, Value>) -> Result<Value, String> {
     let gpu_index = request_gpu_index(request)?;
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
-    let position = match registry.iter().position(|(index, _)| *index == gpu_index) {
-        Some(position) => position,
-        None => match open_backend(gpu_index) {
-            Ok(backend) => {
-                registry.push((gpu_index, backend));
-                registry.len() - 1
-            }
-            Err(err) => {
-                return Ok(json!({
-                    "gpu_index": gpu_index,
-                    "supported": false,
-                    "reason": err,
-                }));
-            }
-        },
+    let position = match registry_position(&mut registry, gpu_index) {
+        Ok(position) => position,
+        Err(err) => {
+            return Ok(json!({
+                "gpu_index": gpu_index,
+                "supported": false,
+                "reason": err,
+            }));
+        }
     };
 
-    match &registry[position].1 {
+    match &registry[position].backend {
         RpcBackend::Real(backend) => probe_power_limit_backend(gpu_index, backend.as_ref()),
         RpcBackend::Mock(mock) => {
             let before = mock.recorded().len();

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -27,8 +27,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde_json::{json, Map, Value};
 
 use crate::gpu::{
-    mock::MockGpu, ClockType, GpuBackend, GpuError, GpuIdentity, GpuMemoryInfo, NvmlBackend,
-    VfPoint,
+    mock::MockGpu, ClockType, GpuBackend, GpuContextPids, GpuError, GpuIdentity, GpuMemoryInfo,
+    NvmlBackend, VfPoint,
 };
 
 const MOCK_ENV: &str = "PENGUIN_BURNERD_TEST_MOCK_GPU";
@@ -134,11 +134,12 @@ pub fn release_idle_backends(ttl: Duration) -> usize {
     before - registry.len()
 }
 
-/// PIDs holding a live graphics/compute context on `gpu_index`, for the
-/// deep-sleep watcher's fine-grained "GPU in use" signal. Uses (and lazily
-/// opens) the shared registry backend; the entry's last-used stamp lets
-/// `release_idle_backends` sweep it once the watcher stops asking.
-pub fn context_pids(gpu_index: u32) -> Result<Vec<u32>, String> {
+/// PIDs holding a live graphics/compute context on `gpu_index`, split by
+/// kind, for the deep-sleep watcher's fine-grained "GPU in use" signal and
+/// its `gpu_clients` debug stats. Uses (and lazily opens) the shared registry
+/// backend; the entry's last-used stamp lets `release_idle_backends` sweep it
+/// once the watcher stops asking.
+pub fn context_pids(gpu_index: u32) -> Result<GpuContextPids, String> {
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
     let position = registry_position(&mut registry, gpu_index)?;
     let backend: &dyn GpuBackend = match &registry[position].backend {

--- a/burnerd/src/gpu_rpc.rs
+++ b/burnerd/src/gpu_rpc.rs
@@ -116,14 +116,14 @@ struct RegistryEntry {
 }
 
 /// Lazy per-`gpu_index` backends. On desktops they live for the daemon's
-/// lifetime; while the deep-sleep gate is armed the rtd3 watcher drops idle
+/// lifetime; in Mobile or Unknown mode the RTD3 watcher drops idle
 /// entries (`release_idle_backends`) so a one-off telemetry query cannot pin
 /// the GPU in D0 forever. Dropping a real entry closes NVML and the hidden
 /// NVAPI sessions via their `Drop` impls; the next request simply reopens.
 static REGISTRY: Mutex<Vec<RegistryEntry>> = Mutex::new(Vec::new());
 
 /// Drop backends that have not served a request within `ttl`. Returns how
-/// many were released. Called only while the deep-sleep gate is armed.
+/// many were released. Called only while deep-sleep protection is active.
 pub fn release_idle_backends(ttl: Duration) -> usize {
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
     let before = registry.len();
@@ -269,6 +269,11 @@ pub fn handle(method: &str, request: &Map<String, Value>) -> Result<Value, Strin
         return read(gpu_index, method);
     }
     let write = parse(method, request)?;
+    if matches!(&write, GpuWrite::EnablePersistence) && crate::rtd3::protects_deep_sleep() {
+        return Err(
+            "GPU persistence mode is unavailable in Mobile or Unknown deep-sleep mode".to_string(),
+        );
+    }
 
     let mut registry = REGISTRY.lock().unwrap_or_else(|poison| poison.into_inner());
     let position = registry_position(&mut registry, gpu_index)?;

--- a/burnerd/src/main.rs
+++ b/burnerd/src/main.rs
@@ -41,8 +41,9 @@ fn run() -> i32 {
     };
 
     logging::info(&format!(
-        "penguin-burnerd {} starting",
-        env!("CARGO_PKG_VERSION")
+        "penguin-burnerd {} ({}) starting",
+        env!("CARGO_PKG_VERSION"),
+        env!("PENGUIN_BURNERD_BUILD_ID"),
     ));
 
     // Register before spawning the autostart engine so every termination

--- a/burnerd/src/main.rs
+++ b/burnerd/src/main.rs
@@ -6,6 +6,7 @@ mod gpu_rpc;
 mod logging;
 mod paths;
 mod profile;
+mod rtd3;
 mod scan;
 mod server;
 mod supervisor;
@@ -57,8 +58,10 @@ fn run() -> i32 {
     let sup = Arc::new(Mutex::new(Supervisor::new()));
 
     // Start the persisted runtime profile before binding the socket (parity with
-    // `serve_daemon_api`, which runs autostart first).
-    supervisor::start_autostart_if_configured(&sup);
+    // `serve_daemon_api`, which runs autostart first). On RTD3 laptops the
+    // deep-sleep gate defers this until the GPU is actually in use, so a
+    // sleeping dGPU is never woken (and then pinned) just to apply a profile.
+    rtd3::watch::startup(&sup);
     supervisor::start_game_watch_monitor(&sup);
 
     // Route SIGINT/SIGTERM to a dedicated thread that performs a clean shutdown.

--- a/burnerd/src/profile/mod.rs
+++ b/burnerd/src/profile/mod.rs
@@ -452,9 +452,16 @@ fn run_with_backend(
 
     // VF-curve policy: persistence → memory → VF → power → clock ceiling
     // (mem before VF: a mem-offset write wipes the per-point VF table).
+    // Persistence mode is a documented RTD3 blocker, so it is suppressed
+    // whenever the deep-sleep gate is armed; the profile is reapplied on wake
+    // instead of relying on the driver staying initialized.
+    let enable_persistence_mode = spec.policy.enable_persistence_mode && !crate::rtd3::is_armed();
+    if spec.policy.enable_persistence_mode && !enable_persistence_mode {
+        log("Deep sleep armed: skipping GPU persistence mode (it blocks runtime D3)");
+    }
     let vf_policy = apply::configure_runtime_spec_policy(
         backend,
-        spec.policy.enable_persistence_mode,
+        enable_persistence_mode,
         spec.mode,
         initial_curve,
         &mut log,

--- a/burnerd/src/profile/mod.rs
+++ b/burnerd/src/profile/mod.rs
@@ -453,7 +453,7 @@ fn run_with_backend(
     // VF-curve policy: persistence → memory → VF → power → clock ceiling
     // (mem before VF: a mem-offset write wipes the per-point VF table).
     // Persistence mode is a documented RTD3 blocker, so it is suppressed
-    // while the deep-sleep gate is armed or still undecided; the profile is
+    // in Mobile or Unknown deep-sleep mode; the profile is
     // reapplied on wake instead of relying on the driver staying initialized.
     let enable_persistence_mode =
         spec.policy.enable_persistence_mode && !crate::rtd3::suppress_persistence();

--- a/burnerd/src/profile/mod.rs
+++ b/burnerd/src/profile/mod.rs
@@ -453,11 +453,12 @@ fn run_with_backend(
     // VF-curve policy: persistence → memory → VF → power → clock ceiling
     // (mem before VF: a mem-offset write wipes the per-point VF table).
     // Persistence mode is a documented RTD3 blocker, so it is suppressed
-    // whenever the deep-sleep gate is armed; the profile is reapplied on wake
-    // instead of relying on the driver staying initialized.
-    let enable_persistence_mode = spec.policy.enable_persistence_mode && !crate::rtd3::is_armed();
+    // while the deep-sleep gate is armed or still undecided; the profile is
+    // reapplied on wake instead of relying on the driver staying initialized.
+    let enable_persistence_mode =
+        spec.policy.enable_persistence_mode && !crate::rtd3::suppress_persistence();
     if spec.policy.enable_persistence_mode && !enable_persistence_mode {
-        log("Deep sleep armed: skipping GPU persistence mode (it blocks runtime D3)");
+        log("Deep sleep: skipping GPU persistence mode (it blocks runtime D3)");
     }
     let vf_policy = apply::configure_runtime_spec_policy(
         backend,
@@ -513,7 +514,7 @@ fn run_with_backend(
     run_fan_control_loop(
         backend,
         gpu_index,
-        spec.policy.enable_persistence_mode,
+        enable_persistence_mode,
         fan_config,
         fan_control_enabled,
         vf_policy,
@@ -567,7 +568,7 @@ impl Drop for EngineCleanup<'_> {
 fn run_fan_control_loop(
     backend: &dyn GpuBackend,
     gpu_index: u32,
-    _enable_persistence_mode: bool,
+    enable_persistence_mode: bool,
     fan_config: FanConfig,
     fan_control_enabled: bool,
     vf_policy: VfPolicyResult<'_>,
@@ -632,7 +633,7 @@ fn run_fan_control_loop(
 
     log_startup(
         gpu_index,
-        _enable_persistence_mode,
+        enable_persistence_mode,
         &gpu_policy_text,
         fan_control_enabled,
         fan_count,

--- a/burnerd/src/rtd3/clients.rs
+++ b/burnerd/src/rtd3/clients.rs
@@ -2,7 +2,9 @@
 //!
 //! The module hides both the client-evidence rules and the cadence of NVIDIA
 //! queries. Fine-grained idle observations are latched in deferred mode so the
-//! watcher cannot keep a GPU awake by periodically observing it.
+//! watcher cannot keep a GPU awake by periodically observing it; a latch that
+//! survives [`LATCH_REPROBE_TICKS`] awake ticks expires into one fresh probe
+//! so an already-latched holder that starts real work is still noticed.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -36,9 +38,21 @@ pub(crate) enum ClientVerdict {
     Pending,
 }
 
+/// Latched ticks (1 Hz, counted only while awake and deferred) after which
+/// one fresh probe re-arms. An already-latched fd holder that starts real GPU
+/// work never changes the holder set and, with the GPU held awake by that
+/// work, never produces the suspend/resume edge that clears the latch — so
+/// without a bound the parked profile would never re-materialize for the
+/// whole workload. A GPU that read `active` for this entire window is
+/// demonstrably awake, so the one re-probe cannot wake anything.
+const LATCH_REPROBE_TICKS: u32 = 300;
+
 struct IdleLatch {
     gpu_index: Option<u32>,
     holders: Vec<GpuClientProcess>,
+    /// Consecutive latch hits; at [`LATCH_REPROBE_TICKS`] the latch expires
+    /// into one fresh probe.
+    held_ticks: u32,
 }
 
 trait ContextProvider {
@@ -93,13 +107,18 @@ impl ClientDetector {
         }
 
         let holders = nvidia_device_node_holders_in(&self.proc_root, self.self_pid);
-        if input.phase == ClientPhase::Deferred
-            && input.fine_grained
-            && self.idle_latch.as_ref().is_some_and(|latch| {
-                latch.gpu_index == input.gpu_index && latch.holders == holders
-            })
-        {
-            return ClientVerdict::Pending;
+        if input.phase == ClientPhase::Deferred && input.fine_grained {
+            if let Some(latch) = self.idle_latch.as_mut() {
+                if latch.gpu_index == input.gpu_index && latch.holders == holders {
+                    latch.held_ticks = latch.held_ticks.saturating_add(1);
+                    if latch.held_ticks < LATCH_REPROBE_TICKS {
+                        return ClientVerdict::Pending;
+                    }
+                    // Bounded re-arm: the GPU stayed awake for the whole
+                    // window, so probe once — a latched holder may have
+                    // started real work that must re-materialize the profile.
+                }
+            }
         }
         self.clear_idle_latch();
 
@@ -170,7 +189,11 @@ impl ClientDetector {
     }
 
     fn latch_idle(&mut self, gpu_index: Option<u32>, holders: Vec<GpuClientProcess>) {
-        self.idle_latch = Some(IdleLatch { gpu_index, holders });
+        self.idle_latch = Some(IdleLatch {
+            gpu_index,
+            holders,
+            held_ticks: 0,
+        });
     }
 
     fn clear_idle_latch(&mut self) {
@@ -474,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn unchanged_holder_set_never_reprobes_without_an_external_event() {
+    fn unchanged_holder_set_does_not_reprobe_within_the_bounded_window() {
         let root = tempfile::tempdir().unwrap();
         write_identity(root.path(), 880, "nvidia-powerd", 0);
         let calls = Rc::new(RefCell::new(0));
@@ -494,11 +517,84 @@ mod tests {
 
         write_identity(root.path(), 4242, "some-game", 1000);
         contexts.borrow_mut().graphics.push(4242);
+        for _ in 0..(LATCH_REPROBE_TICKS - 1) {
+            assert_eq!(
+                detector.tick(active_tick(ClientPhase::Deferred)),
+                ClientVerdict::Pending
+            );
+        }
+        assert_eq!(*calls.borrow(), 1);
+    }
+
+    #[test]
+    fn latched_holder_that_starts_work_is_noticed_at_the_reprobe_bound() {
+        // The missed-wake gap: an already-listed fd holder starts submitting
+        // real GPU work. The holder set never changes and the busy GPU never
+        // suspends, so neither re-arm edge fires — only the bounded window
+        // may notice the new context and re-materialize the parked profile.
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 1450, "plasmashell", 1000);
+        let fd_dir = root.path().join("1450/fd");
+        fs::create_dir_all(&fd_dir).unwrap();
+        symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+        let calls = Rc::new(RefCell::new(0));
+        let contexts = Rc::new(RefCell::new(GpuContextPids::default()));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: contexts.clone(),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Idle(_)
+        ));
+
+        contexts.borrow_mut().graphics.push(1450);
+        for _ in 0..(LATCH_REPROBE_TICKS - 1) {
+            assert_eq!(
+                detector.tick(active_tick(ClientPhase::Deferred)),
+                ClientVerdict::Pending
+            );
+        }
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Busy(_)
+        ));
+        assert_eq!(*calls.borrow(), 2);
+    }
+
+    #[test]
+    fn idle_reprobe_at_the_bound_relatches_for_another_window() {
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 880, "nvidia-powerd", 0);
+        let calls = Rc::new(RefCell::new(0));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: Rc::new(RefCell::new(GpuContextPids::default())),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Idle(_)
+        ));
+        for _ in 0..(LATCH_REPROBE_TICKS - 1) {
+            assert_eq!(
+                detector.tick(active_tick(ClientPhase::Deferred)),
+                ClientVerdict::Pending
+            );
+        }
+        // Bound reached: one probe, still idle, and the fresh latch holds the
+        // next window without probing.
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Idle(_)
+        ));
+        assert_eq!(*calls.borrow(), 2);
         assert_eq!(
             detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Pending
         );
-        assert_eq!(*calls.borrow(), 1);
+        assert_eq!(*calls.borrow(), 2);
     }
 
     #[test]

--- a/burnerd/src/rtd3/clients.rs
+++ b/burnerd/src/rtd3/clients.rs
@@ -1,0 +1,594 @@
+//! Mode-aware GPU-client detection for the RTD3 watcher.
+//!
+//! The module hides both the client-evidence rules and the cadence of NVIDIA
+//! queries. Fine-grained probes are short-lived and followed by a quiet window
+//! in deferred mode so the watcher cannot keep a GPU awake by observing it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::gpu::{self, GpuContextPids};
+use crate::logging;
+
+use super::detect::RuntimePmStatus;
+use super::{GpuClientObservation, GpuClientProcess, GpuClientSource};
+
+const WATCH_TICK: Duration = Duration::from_secs(1);
+const UNKNOWN_AUTOSUSPEND_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClientPhase {
+    Attached,
+    Deferred,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ClientTick {
+    pub phase: ClientPhase,
+    pub gpu_index: Option<u32>,
+    pub fine_grained: bool,
+    pub runtime_status: Option<RuntimePmStatus>,
+    pub autosuspend_delay: Option<Duration>,
+    pub now: Instant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ClientVerdict {
+    Busy(GpuClientObservation),
+    Idle(GpuClientObservation),
+    /// No NVIDIA observation is safe or due. This never authorizes a start or
+    /// advances a park countdown.
+    Pending,
+}
+
+trait ContextProvider {
+    fn context_pids(
+        &self,
+        gpu_index: u32,
+    ) -> Result<GpuContextPids, gpu::context::ContextProbeError>;
+}
+
+struct EphemeralContextProvider;
+
+impl ContextProvider for EphemeralContextProvider {
+    fn context_pids(
+        &self,
+        gpu_index: u32,
+    ) -> Result<GpuContextPids, gpu::context::ContextProbeError> {
+        gpu::context::context_pids_ephemeral(gpu_index)
+    }
+}
+
+pub(crate) struct ClientDetector {
+    proc_root: PathBuf,
+    self_pid: u32,
+    provider: Box<dyn ContextProvider>,
+    quiet_until: Option<Instant>,
+    quiet_gpu_index: Option<Option<u32>>,
+    quiet_holders: Vec<GpuClientProcess>,
+}
+
+impl ClientDetector {
+    pub(crate) fn system() -> Self {
+        Self {
+            proc_root: client_proc_root(),
+            self_pid: std::process::id(),
+            provider: Box::new(EphemeralContextProvider),
+            quiet_until: None,
+            quiet_gpu_index: None,
+            quiet_holders: Vec::new(),
+        }
+    }
+
+    pub(crate) fn tick(&mut self, input: ClientTick) -> ClientVerdict {
+        // A running profile engine already owns and wakes the GPU even if the
+        // cached sysfs sample still says `suspended`. Only a deferred runtime
+        // relies on runtime_status to prove a query is safe.
+        if input.phase == ClientPhase::Deferred
+            && input.runtime_status != Some(RuntimePmStatus::Active)
+        {
+            self.clear_quiet();
+            return ClientVerdict::Pending;
+        }
+
+        let holders = nvidia_device_node_holders_in(&self.proc_root, self.self_pid);
+        if input.phase == ClientPhase::Deferred
+            && input.fine_grained
+            && self
+                .quiet_until
+                .is_some_and(|until| input.now < until)
+            && self.quiet_gpu_index == Some(input.gpu_index)
+            && holders == self.quiet_holders
+        {
+            return ClientVerdict::Pending;
+        }
+        self.clear_quiet();
+
+        let observation = match self.observe(input.gpu_index, input.fine_grained, holders.clone()) {
+            Ok(observation) => observation,
+            Err(error) => {
+                log_context_shutdown_failure(&error);
+                if input.phase == ClientPhase::Deferred && input.fine_grained {
+                    self.arm_quiet(input, holders);
+                }
+                return ClientVerdict::Pending;
+            }
+        };
+        if observation.in_use() {
+            return ClientVerdict::Busy(observation);
+        }
+
+        if input.phase == ClientPhase::Deferred && input.fine_grained {
+            self.arm_quiet(input, observation.device_node_holders.clone());
+        }
+        ClientVerdict::Idle(observation)
+    }
+
+    fn observe(
+        &self,
+        gpu_index: Option<u32>,
+        fine_grained: bool,
+        device_node_holders: Vec<GpuClientProcess>,
+    ) -> Result<GpuClientObservation, gpu::context::ContextProbeError> {
+        let mut observation = GpuClientObservation {
+            source: GpuClientSource::DeviceNodes,
+            graphics: Vec::new(),
+            compute: Vec::new(),
+            device_node_holders,
+            ignored_clients: Vec::new(),
+        };
+        if !fine_grained {
+            return Ok(observation);
+        }
+        let Some(index) = gpu_index else {
+            return Ok(observation);
+        };
+        match self.provider.context_pids(index) {
+            Ok(contexts) => {
+                observation.source = GpuClientSource::NvmlContexts;
+                let (graphics, compute, ignored) = classified_context_processes(
+                    &self.proc_root,
+                    &contexts.graphics,
+                    &contexts.compute,
+                    self.self_pid,
+                );
+                observation.graphics = graphics;
+                observation.compute = compute;
+                observation.ignored_clients = ignored;
+            }
+            Err(gpu::context::ContextProbeError::Query(error)) => {
+                log_context_query_fallback(&error);
+                observation.ignored_clients = ignored_powerd_processes(
+                    &self.proc_root,
+                    &observation.device_node_holders,
+                );
+            }
+            Err(error @ gpu::context::ContextProbeError::Shutdown { .. }) => {
+                return Err(error);
+            }
+        }
+        Ok(observation)
+    }
+
+    fn arm_quiet(&mut self, input: ClientTick, holders: Vec<GpuClientProcess>) {
+        let delay = input
+            .autosuspend_delay
+            .unwrap_or(UNKNOWN_AUTOSUSPEND_DELAY)
+            .saturating_add(WATCH_TICK);
+        self.quiet_until = input.now.checked_add(delay);
+        self.quiet_gpu_index = Some(input.gpu_index);
+        self.quiet_holders = holders;
+    }
+
+    fn clear_quiet(&mut self) {
+        self.quiet_until = None;
+        self.quiet_gpu_index = None;
+        self.quiet_holders.clear();
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.clear_quiet();
+    }
+
+    #[cfg(test)]
+    fn with_provider(
+        proc_root: PathBuf,
+        self_pid: u32,
+        provider: impl ContextProvider + 'static,
+    ) -> Self {
+        Self {
+            proc_root,
+            self_pid,
+            provider: Box::new(provider),
+            quiet_until: None,
+            quiet_gpu_index: None,
+            quiet_holders: Vec::new(),
+        }
+    }
+}
+
+/// The proc tree the client scan and name lookups read. Test seam (never set
+/// in production): `PENGUIN_BURNERD_TEST_CLIENT_PROC` points at a fake proc
+/// tree so integration tests can stage GPU clients deterministically.
+fn client_proc_root() -> PathBuf {
+    std::env::var_os("PENGUIN_BURNERD_TEST_CLIENT_PROC")
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| PathBuf::from("/proc"), PathBuf::from)
+}
+
+fn classified_context_processes(
+    proc_root: &Path,
+    graphics_pids: &[u32],
+    compute_pids: &[u32],
+    self_pid: u32,
+) -> (
+    Vec<GpuClientProcess>,
+    Vec<GpuClientProcess>,
+    Vec<GpuClientProcess>,
+) {
+    let mut unique_pids: Vec<u32> = graphics_pids
+        .iter()
+        .chain(compute_pids)
+        .copied()
+        .filter(|pid| *pid != self_pid)
+        .collect();
+    unique_pids.sort_unstable();
+    unique_pids.dedup();
+
+    let mut counted = Vec::new();
+    let mut ignored = Vec::new();
+    for pid in unique_pids {
+        let name = process_name(proc_root, pid);
+        let process = GpuClientProcess { pid, name };
+        if is_root_nvidia_powerd(proc_root, &process) {
+            ignored.push(process);
+        } else {
+            counted.push(process);
+        }
+    }
+    let graphics = counted
+        .iter()
+        .filter(|process| graphics_pids.contains(&process.pid))
+        .cloned()
+        .collect();
+    let compute = counted
+        .iter()
+        .filter(|process| compute_pids.contains(&process.pid))
+        .cloned()
+        .collect();
+    (graphics, compute, ignored)
+}
+
+fn process_name(proc_root: &Path, pid: u32) -> Option<String> {
+    let comm = fs::read_to_string(proc_root.join(pid.to_string()).join("comm")).ok()?;
+    let name = comm.strip_suffix('\n').unwrap_or(&comm);
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+fn process_effective_uid(proc_root: &Path, pid: u32) -> Option<u32> {
+    let status = fs::read_to_string(proc_root.join(pid.to_string()).join("status")).ok()?;
+    let mut records = status.lines().filter_map(|line| line.strip_prefix("Uid:"));
+    let record = records.next()?;
+    if records.next().is_some() {
+        return None;
+    }
+    let mut fields = record.split_whitespace();
+    let _real: u32 = fields.next()?.parse().ok()?;
+    let effective: u32 = fields.next()?.parse().ok()?;
+    let _saved: u32 = fields.next()?.parse().ok()?;
+    let _filesystem: u32 = fields.next()?.parse().ok()?;
+    if fields.next().is_some() {
+        return None;
+    }
+    Some(effective)
+}
+
+fn is_root_nvidia_powerd(proc_root: &Path, process: &GpuClientProcess) -> bool {
+    process.name.as_deref() == Some("nvidia-powerd")
+        && process_effective_uid(proc_root, process.pid) == Some(0)
+}
+
+fn ignored_powerd_processes(
+    proc_root: &Path,
+    processes: &[GpuClientProcess],
+) -> Vec<GpuClientProcess> {
+    processes
+        .iter()
+        .filter(|process| is_root_nvidia_powerd(proc_root, process))
+        .cloned()
+        .collect()
+}
+
+fn is_nvidia_device_node(target: &str) -> bool {
+    target
+        .strip_prefix("/dev/nvidia")
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn nvidia_device_node_holders_in(
+    proc_root: impl AsRef<Path>,
+    self_pid: u32,
+) -> Vec<GpuClientProcess> {
+    let proc_root = proc_root.as_ref();
+    let mut holders = Vec::new();
+    let Ok(entries) = fs::read_dir(proc_root) else {
+        return holders;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let Ok(fds) = fs::read_dir(entry.path().join("fd")) else {
+            continue;
+        };
+        let holds_device_node = fds.filter_map(Result::ok).any(|fd| {
+            fs::read_link(fd.path())
+                .is_ok_and(|target| is_nvidia_device_node(&target.to_string_lossy()))
+        });
+        if holds_device_node {
+            holders.push(GpuClientProcess {
+                pid,
+                name: process_name(proc_root, pid),
+            });
+        }
+    }
+    holders.sort_unstable_by_key(|process| process.pid);
+    holders
+}
+
+fn log_context_query_fallback(error: &impl std::fmt::Display) {
+    static LOGGED: std::sync::Once = std::sync::Once::new();
+    LOGGED.call_once(|| {
+        logging::info(&format!(
+            "deep sleep: NVML context query unavailable ({error}); using the device-node scan"
+        ));
+    });
+}
+
+fn log_context_shutdown_failure(error: &impl std::fmt::Display) {
+    static LOGGED: std::sync::Once = std::sync::Once::new();
+    LOGGED.call_once(|| {
+        logging::info(&format!(
+            "deep sleep: NVIDIA context probe cleanup failed ({error}); refusing an idle decision"
+        ));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::os::unix::fs::symlink;
+    use std::rc::Rc;
+
+    struct ScriptedProvider {
+        calls: Rc<RefCell<u32>>,
+        contexts: Rc<RefCell<GpuContextPids>>,
+    }
+
+    struct ShutdownFailingProvider {
+        calls: Rc<RefCell<u32>>,
+    }
+
+    impl ContextProvider for ScriptedProvider {
+        fn context_pids(
+            &self,
+            _gpu_index: u32,
+        ) -> Result<GpuContextPids, gpu::context::ContextProbeError> {
+            *self.calls.borrow_mut() += 1;
+            Ok(self.contexts.borrow().clone())
+        }
+    }
+
+    impl ContextProvider for ShutdownFailingProvider {
+        fn context_pids(
+            &self,
+            _gpu_index: u32,
+        ) -> Result<GpuContextPids, gpu::context::ContextProbeError> {
+            *self.calls.borrow_mut() += 1;
+            Err(gpu::context::ContextProbeError::Shutdown {
+                shutdown: gpu::GpuError::other("mock nvmlShutdown failure", 0),
+                query: None,
+            })
+        }
+    }
+
+    fn active_tick(phase: ClientPhase, now: Instant) -> ClientTick {
+        ClientTick {
+            phase,
+            gpu_index: Some(0),
+            fine_grained: true,
+            runtime_status: Some(RuntimePmStatus::Active),
+            autosuspend_delay: Some(Duration::from_secs(5)),
+            now,
+        }
+    }
+
+    fn write_identity(root: &Path, pid: u32, name: &str, uid: u32) {
+        let process = root.join(pid.to_string());
+        fs::create_dir_all(&process).unwrap();
+        fs::write(process.join("comm"), format!("{name}\n")).unwrap();
+        fs::write(
+            process.join("status"),
+            format!("Name:\t{name}\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn powerd_only_enters_a_quiet_window_and_holder_change_rearms_probe() {
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 880, "nvidia-powerd", 0);
+        let calls = Rc::new(RefCell::new(0));
+        let contexts = Rc::new(RefCell::new(GpuContextPids {
+            graphics: vec![880],
+            compute: vec![880],
+        }));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: contexts.clone(),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        let now = Instant::now();
+
+        let first = detector.tick(active_tick(ClientPhase::Deferred, now));
+        assert!(matches!(first, ClientVerdict::Idle(_)));
+        assert_eq!(*calls.borrow(), 1);
+        assert_eq!(
+            detector.tick(active_tick(ClientPhase::Deferred, now + Duration::from_secs(2))),
+            ClientVerdict::Pending
+        );
+        assert_eq!(*calls.borrow(), 1);
+
+        write_identity(root.path(), 4242, "some-game", 1000);
+        let fd_dir = root.path().join("4242/fd");
+        fs::create_dir_all(&fd_dir).unwrap();
+        symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+        contexts.borrow_mut().graphics.push(4242);
+        let changed = detector.tick(active_tick(
+            ClientPhase::Deferred,
+            now + Duration::from_secs(3),
+        ));
+        assert!(matches!(changed, ClientVerdict::Busy(_)));
+        assert_eq!(*calls.borrow(), 2);
+    }
+
+    #[test]
+    fn nonactive_status_never_opens_the_context_provider() {
+        let root = tempfile::tempdir().unwrap();
+        let calls = Rc::new(RefCell::new(0));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: Rc::new(RefCell::new(GpuContextPids::default())),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        let mut input = active_tick(ClientPhase::Deferred, Instant::now());
+        input.runtime_status = Some(RuntimePmStatus::Suspended);
+        assert_eq!(detector.tick(input), ClientVerdict::Pending);
+        assert_eq!(*calls.borrow(), 0);
+    }
+
+    #[test]
+    fn shutdown_failure_is_pending_and_does_not_create_a_probe_loop() {
+        let root = tempfile::tempdir().unwrap();
+        let calls = Rc::new(RefCell::new(0));
+        let provider = ShutdownFailingProvider {
+            calls: calls.clone(),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        let now = Instant::now();
+
+        assert_eq!(
+            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            ClientVerdict::Pending
+        );
+        assert_eq!(
+            detector.tick(active_tick(
+                ClientPhase::Deferred,
+                now + Duration::from_secs(2),
+            )),
+            ClientVerdict::Pending
+        );
+        assert_eq!(*calls.borrow(), 1);
+    }
+
+    #[test]
+    fn quiet_deadline_reprobes_when_a_context_appears_without_a_new_holder() {
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 880, "nvidia-powerd", 0);
+        let calls = Rc::new(RefCell::new(0));
+        let contexts = Rc::new(RefCell::new(GpuContextPids {
+            graphics: vec![880],
+            compute: Vec::new(),
+        }));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: contexts.clone(),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        let now = Instant::now();
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            ClientVerdict::Idle(_)
+        ));
+
+        write_identity(root.path(), 4242, "some-game", 1000);
+        contexts.borrow_mut().graphics.push(4242);
+        assert!(matches!(
+            detector.tick(active_tick(
+                ClientPhase::Deferred,
+                now + Duration::from_secs(7),
+            )),
+            ClientVerdict::Busy(_)
+        ));
+        assert_eq!(*calls.borrow(), 2);
+    }
+
+    #[test]
+    fn quiet_window_does_not_cross_gpu_indices() {
+        let root = tempfile::tempdir().unwrap();
+        let calls = Rc::new(RefCell::new(0));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: Rc::new(RefCell::new(GpuContextPids::default())),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        let now = Instant::now();
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            ClientVerdict::Idle(_)
+        ));
+
+        let mut other_gpu = active_tick(ClientPhase::Deferred, now + Duration::from_secs(1));
+        other_gpu.gpu_index = Some(1);
+        assert!(matches!(detector.tick(other_gpu), ClientVerdict::Idle(_)));
+        assert_eq!(*calls.borrow(), 2);
+    }
+
+    #[test]
+    fn only_numbered_device_nodes_count_as_clients() {
+        assert!(is_nvidia_device_node("/dev/nvidia0"));
+        assert!(is_nvidia_device_node("/dev/nvidia12"));
+        assert!(!is_nvidia_device_node("/dev/nvidiactl"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-uvm"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-modeset"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-caps/nvidia-cap1"));
+        assert!(!is_nvidia_device_node("/dev/dri/renderD128"));
+    }
+
+    #[test]
+    fn collects_nvidia_fd_holders_with_names_and_skips_self() {
+        let root = tempfile::tempdir().unwrap();
+        let fd_dir = root.path().join("4242/fd");
+        fs::create_dir_all(&fd_dir).unwrap();
+        symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+        fs::write(root.path().join("4242/comm"), "some-game\n").unwrap();
+        let holders = nvidia_device_node_holders_in(root.path(), 1);
+        assert_eq!(holders.len(), 1);
+        assert_eq!(holders[0].pid, 4242);
+        assert_eq!(holders[0].name.as_deref(), Some("some-game"));
+        assert!(nvidia_device_node_holders_in(root.path(), 4242).is_empty());
+    }
+
+    #[test]
+    fn classified_context_processes_drop_self_and_ignore_only_root_powerd() {
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 880, "nvidia-powerd", 0);
+        write_identity(root.path(), 881, "nvidia-powerd", 1000);
+        write_identity(root.path(), 4242, "some-game", 1000);
+        let (graphics, compute, ignored) = classified_context_processes(
+            root.path(),
+            &[880, 881, 4242, 999],
+            &[4242, 777],
+            999,
+        );
+        assert_eq!(ignored.iter().map(|p| p.pid).collect::<Vec<_>>(), vec![880]);
+        assert_eq!(graphics.iter().map(|p| p.pid).collect::<Vec<_>>(), vec![881, 4242]);
+        assert_eq!(compute.iter().map(|p| p.pid).collect::<Vec<_>>(), vec![777, 4242]);
+    }
+}

--- a/burnerd/src/rtd3/clients.rs
+++ b/burnerd/src/rtd3/clients.rs
@@ -1,21 +1,17 @@
 //! Mode-aware GPU-client detection for the RTD3 watcher.
 //!
 //! The module hides both the client-evidence rules and the cadence of NVIDIA
-//! queries. Fine-grained probes are short-lived and followed by a quiet window
-//! in deferred mode so the watcher cannot keep a GPU awake by observing it.
+//! queries. Fine-grained idle observations are latched in deferred mode so the
+//! watcher cannot keep a GPU awake by periodically observing it.
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 
 use crate::gpu::{self, GpuContextPids};
 use crate::logging;
 
 use super::detect::RuntimePmStatus;
 use super::{GpuClientObservation, GpuClientProcess, GpuClientSource};
-
-const WATCH_TICK: Duration = Duration::from_secs(1);
-const UNKNOWN_AUTOSUSPEND_DELAY: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ClientPhase {
@@ -29,8 +25,6 @@ pub(crate) struct ClientTick {
     pub gpu_index: Option<u32>,
     pub fine_grained: bool,
     pub runtime_status: Option<RuntimePmStatus>,
-    pub autosuspend_delay: Option<Duration>,
-    pub now: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +34,11 @@ pub(crate) enum ClientVerdict {
     /// No NVIDIA observation is safe or due. This never authorizes a start or
     /// advances a park countdown.
     Pending,
+}
+
+struct IdleLatch {
+    gpu_index: Option<u32>,
+    holders: Vec<GpuClientProcess>,
 }
 
 trait ContextProvider {
@@ -64,9 +63,7 @@ pub(crate) struct ClientDetector {
     proc_root: PathBuf,
     self_pid: u32,
     provider: Box<dyn ContextProvider>,
-    quiet_until: Option<Instant>,
-    quiet_gpu_index: Option<Option<u32>>,
-    quiet_holders: Vec<GpuClientProcess>,
+    idle_latch: Option<IdleLatch>,
 }
 
 impl ClientDetector {
@@ -75,9 +72,7 @@ impl ClientDetector {
             proc_root: client_proc_root(),
             self_pid: std::process::id(),
             provider: Box::new(EphemeralContextProvider),
-            quiet_until: None,
-            quiet_gpu_index: None,
-            quiet_holders: Vec::new(),
+            idle_latch: None,
         }
     }
 
@@ -88,29 +83,32 @@ impl ClientDetector {
         if input.phase == ClientPhase::Deferred
             && input.runtime_status != Some(RuntimePmStatus::Active)
         {
-            self.clear_quiet();
+            if matches!(
+                input.runtime_status,
+                Some(RuntimePmStatus::Suspended | RuntimePmStatus::Resuming)
+            ) {
+                self.clear_idle_latch();
+            }
             return ClientVerdict::Pending;
         }
 
         let holders = nvidia_device_node_holders_in(&self.proc_root, self.self_pid);
         if input.phase == ClientPhase::Deferred
             && input.fine_grained
-            && self
-                .quiet_until
-                .is_some_and(|until| input.now < until)
-            && self.quiet_gpu_index == Some(input.gpu_index)
-            && holders == self.quiet_holders
+            && self.idle_latch.as_ref().is_some_and(|latch| {
+                latch.gpu_index == input.gpu_index && latch.holders == holders
+            })
         {
             return ClientVerdict::Pending;
         }
-        self.clear_quiet();
+        self.clear_idle_latch();
 
         let observation = match self.observe(input.gpu_index, input.fine_grained, holders.clone()) {
             Ok(observation) => observation,
             Err(error) => {
                 log_context_shutdown_failure(&error);
                 if input.phase == ClientPhase::Deferred && input.fine_grained {
-                    self.arm_quiet(input, holders);
+                    self.latch_idle(input.gpu_index, holders);
                 }
                 return ClientVerdict::Pending;
             }
@@ -120,7 +118,7 @@ impl ClientDetector {
         }
 
         if input.phase == ClientPhase::Deferred && input.fine_grained {
-            self.arm_quiet(input, observation.device_node_holders.clone());
+            self.latch_idle(input.gpu_index, observation.device_node_holders.clone());
         }
         ClientVerdict::Idle(observation)
     }
@@ -171,24 +169,16 @@ impl ClientDetector {
         Ok(observation)
     }
 
-    fn arm_quiet(&mut self, input: ClientTick, holders: Vec<GpuClientProcess>) {
-        let delay = input
-            .autosuspend_delay
-            .unwrap_or(UNKNOWN_AUTOSUSPEND_DELAY)
-            .saturating_add(WATCH_TICK);
-        self.quiet_until = input.now.checked_add(delay);
-        self.quiet_gpu_index = Some(input.gpu_index);
-        self.quiet_holders = holders;
+    fn latch_idle(&mut self, gpu_index: Option<u32>, holders: Vec<GpuClientProcess>) {
+        self.idle_latch = Some(IdleLatch { gpu_index, holders });
     }
 
-    fn clear_quiet(&mut self) {
-        self.quiet_until = None;
-        self.quiet_gpu_index = None;
-        self.quiet_holders.clear();
+    fn clear_idle_latch(&mut self) {
+        self.idle_latch = None;
     }
 
     pub(crate) fn reset(&mut self) {
-        self.clear_quiet();
+        self.clear_idle_latch();
     }
 
     #[cfg(test)]
@@ -201,9 +191,7 @@ impl ClientDetector {
             proc_root,
             self_pid,
             provider: Box::new(provider),
-            quiet_until: None,
-            quiet_gpu_index: None,
-            quiet_holders: Vec::new(),
+            idle_latch: None,
         }
     }
 }
@@ -398,14 +386,12 @@ mod tests {
         }
     }
 
-    fn active_tick(phase: ClientPhase, now: Instant) -> ClientTick {
+    fn active_tick(phase: ClientPhase) -> ClientTick {
         ClientTick {
             phase,
             gpu_index: Some(0),
             fine_grained: true,
             runtime_status: Some(RuntimePmStatus::Active),
-            autosuspend_delay: Some(Duration::from_secs(5)),
-            now,
         }
     }
 
@@ -421,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn powerd_only_enters_a_quiet_window_and_holder_change_rearms_probe() {
+    fn powerd_only_latches_idle_and_holder_change_rearms_probe() {
         let root = tempfile::tempdir().unwrap();
         write_identity(root.path(), 880, "nvidia-powerd", 0);
         let calls = Rc::new(RefCell::new(0));
@@ -434,13 +420,11 @@ mod tests {
             contexts: contexts.clone(),
         };
         let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
-        let now = Instant::now();
-
-        let first = detector.tick(active_tick(ClientPhase::Deferred, now));
+        let first = detector.tick(active_tick(ClientPhase::Deferred));
         assert!(matches!(first, ClientVerdict::Idle(_)));
         assert_eq!(*calls.borrow(), 1);
         assert_eq!(
-            detector.tick(active_tick(ClientPhase::Deferred, now + Duration::from_secs(2))),
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Pending
         );
         assert_eq!(*calls.borrow(), 1);
@@ -450,10 +434,7 @@ mod tests {
         fs::create_dir_all(&fd_dir).unwrap();
         symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
         contexts.borrow_mut().graphics.push(4242);
-        let changed = detector.tick(active_tick(
-            ClientPhase::Deferred,
-            now + Duration::from_secs(3),
-        ));
+        let changed = detector.tick(active_tick(ClientPhase::Deferred));
         assert!(matches!(changed, ClientVerdict::Busy(_)));
         assert_eq!(*calls.borrow(), 2);
     }
@@ -467,7 +448,7 @@ mod tests {
             contexts: Rc::new(RefCell::new(GpuContextPids::default())),
         };
         let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
-        let mut input = active_tick(ClientPhase::Deferred, Instant::now());
+        let mut input = active_tick(ClientPhase::Deferred);
         input.runtime_status = Some(RuntimePmStatus::Suspended);
         assert_eq!(detector.tick(input), ClientVerdict::Pending);
         assert_eq!(*calls.borrow(), 0);
@@ -481,24 +462,19 @@ mod tests {
             calls: calls.clone(),
         };
         let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
-        let now = Instant::now();
-
         assert_eq!(
-            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Pending
         );
         assert_eq!(
-            detector.tick(active_tick(
-                ClientPhase::Deferred,
-                now + Duration::from_secs(2),
-            )),
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Pending
         );
         assert_eq!(*calls.borrow(), 1);
     }
 
     #[test]
-    fn quiet_deadline_reprobes_when_a_context_appears_without_a_new_holder() {
+    fn unchanged_holder_set_never_reprobes_without_an_external_event() {
         let root = tempfile::tempdir().unwrap();
         write_identity(root.path(), 880, "nvidia-powerd", 0);
         let calls = Rc::new(RefCell::new(0));
@@ -511,26 +487,53 @@ mod tests {
             contexts: contexts.clone(),
         };
         let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
-        let now = Instant::now();
         assert!(matches!(
-            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Idle(_)
         ));
 
         write_identity(root.path(), 4242, "some-game", 1000);
         contexts.borrow_mut().graphics.push(4242);
+        assert_eq!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Pending
+        );
+        assert_eq!(*calls.borrow(), 1);
+    }
+
+    #[test]
+    fn runtime_pm_cycle_rearms_probe_without_a_new_holder() {
+        let root = tempfile::tempdir().unwrap();
+        write_identity(root.path(), 880, "nvidia-powerd", 0);
+        let calls = Rc::new(RefCell::new(0));
+        let contexts = Rc::new(RefCell::new(GpuContextPids {
+            graphics: vec![880],
+            compute: Vec::new(),
+        }));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: contexts.clone(),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
         assert!(matches!(
-            detector.tick(active_tick(
-                ClientPhase::Deferred,
-                now + Duration::from_secs(7),
-            )),
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Idle(_)
+        ));
+
+        let mut suspended = active_tick(ClientPhase::Deferred);
+        suspended.runtime_status = Some(RuntimePmStatus::Suspended);
+        assert_eq!(detector.tick(suspended), ClientVerdict::Pending);
+        write_identity(root.path(), 4242, "some-game", 1000);
+        contexts.borrow_mut().graphics.push(4242);
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Busy(_)
         ));
         assert_eq!(*calls.borrow(), 2);
     }
 
     #[test]
-    fn quiet_window_does_not_cross_gpu_indices() {
+    fn unproven_nonactive_statuses_do_not_rearm_probe() {
         let root = tempfile::tempdir().unwrap();
         let calls = Rc::new(RefCell::new(0));
         let provider = ScriptedProvider {
@@ -538,13 +541,43 @@ mod tests {
             contexts: Rc::new(RefCell::new(GpuContextPids::default())),
         };
         let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
-        let now = Instant::now();
         assert!(matches!(
-            detector.tick(active_tick(ClientPhase::Deferred, now)),
+            detector.tick(active_tick(ClientPhase::Deferred)),
             ClientVerdict::Idle(_)
         ));
 
-        let mut other_gpu = active_tick(ClientPhase::Deferred, now + Duration::from_secs(1));
+        for status in [
+            RuntimePmStatus::Suspending,
+            RuntimePmStatus::Error,
+            RuntimePmStatus::Unsupported,
+            RuntimePmStatus::Unknown,
+        ] {
+            let mut nonactive = active_tick(ClientPhase::Deferred);
+            nonactive.runtime_status = Some(status);
+            assert_eq!(detector.tick(nonactive), ClientVerdict::Pending);
+            assert_eq!(
+                detector.tick(active_tick(ClientPhase::Deferred)),
+                ClientVerdict::Pending
+            );
+        }
+        assert_eq!(*calls.borrow(), 1);
+    }
+
+    #[test]
+    fn idle_latch_does_not_cross_gpu_indices() {
+        let root = tempfile::tempdir().unwrap();
+        let calls = Rc::new(RefCell::new(0));
+        let provider = ScriptedProvider {
+            calls: calls.clone(),
+            contexts: Rc::new(RefCell::new(GpuContextPids::default())),
+        };
+        let mut detector = ClientDetector::with_provider(root.path().to_path_buf(), 999, provider);
+        assert!(matches!(
+            detector.tick(active_tick(ClientPhase::Deferred)),
+            ClientVerdict::Idle(_)
+        ));
+
+        let mut other_gpu = active_tick(ClientPhase::Deferred);
         other_gpu.gpu_index = Some(1);
         assert!(matches!(detector.tick(other_gpu), ClientVerdict::Idle(_)));
         assert_eq!(*calls.borrow(), 2);

--- a/burnerd/src/rtd3/detect.rs
+++ b/burnerd/src/rtd3/detect.rs
@@ -8,6 +8,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// `Runtime D3 status:` as reported by `/proc/driver/nvidia/gpus/<addr>/power`.
 ///
@@ -201,6 +202,20 @@ impl Rtd3Probe {
         }
     }
 
+    /// Kernel autosuspend delay for this device. Missing, negative, or
+    /// malformed values are unknown; callers choose a conservative fallback.
+    /// This is a cached sysfs read and never wakes the device.
+    pub fn autosuspend_delay(&self, addr: &str) -> Option<Duration> {
+        Self::read_trimmed(
+            &self
+                .pci_devices_root
+                .join(addr)
+                .join("power/autosuspend_delay_ms"),
+        )
+        .and_then(|text| text.parse::<u64>().ok())
+        .map(Duration::from_millis)
+    }
+
     /// Cumulative runtime-PM residency: `power/runtime_active_time` and
     /// `power/runtime_suspended_time`, milliseconds since boot
     /// (Documentation/ABI/testing/sysfs-devices-power). Cached kernel
@@ -306,6 +321,23 @@ mod tests {
         // Garbage stays None per counter, not a panic.
         fs::write(power.join("runtime_active_time"), "not-a-number\n").unwrap();
         assert_eq!(probe.runtime_pm_times(addr), (None, Some(60789)));
+    }
+
+    #[test]
+    fn autosuspend_delay_accepts_nonnegative_milliseconds_only() {
+        let (root, probe, addr) = fake_tree(None, None, Some("active"));
+        let path = root
+            .path()
+            .join("sys")
+            .join(addr)
+            .join("power/autosuspend_delay_ms");
+        assert_eq!(probe.autosuspend_delay(addr), None);
+        fs::write(&path, "5000\n").unwrap();
+        assert_eq!(probe.autosuspend_delay(addr), Some(Duration::from_secs(5)));
+        fs::write(&path, "-1\n").unwrap();
+        assert_eq!(probe.autosuspend_delay(addr), None);
+        fs::write(&path, "not-a-number\n").unwrap();
+        assert_eq!(probe.autosuspend_delay(addr), None);
     }
 
     #[test]

--- a/burnerd/src/rtd3/detect.rs
+++ b/burnerd/src/rtd3/detect.rs
@@ -202,39 +202,39 @@ impl Rtd3Probe {
     }
 }
 
-/// The startup verdict for one GPU. `Unknown` is a deliberate third state:
+/// The deep-sleep mode for one GPU. `Unknown` is a deliberate third state:
 /// "not decidable yet" (device not bound, driver power file still `?`) must
-/// keep the daemon detached rather than fall through to the classic
+/// keep the daemon detached rather than fall through to the desktop
 /// NVML-at-boot path, otherwise the boot race reintroduces the pinned-GPU bug.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DeepSleepDecision {
-    Armed { fine_grained: bool },
-    Disabled { reason: &'static str },
+pub enum DeepSleepMode {
+    Mobile { fine_grained: bool },
+    Desktop { reason: &'static str },
     Unknown { reason: &'static str },
 }
 
-pub fn assess(probe: &Rtd3Probe, addr: &str) -> DeepSleepDecision {
+pub fn assess(probe: &Rtd3Probe, addr: &str) -> DeepSleepMode {
     if !probe.device_present(addr) {
-        return DeepSleepDecision::Unknown {
+        return DeepSleepMode::Unknown {
             reason: "PCI device not visible yet",
         };
     }
     match probe.runtime_d3_config(addr) {
         config if config.enabled() => match probe.power_control(addr).as_deref() {
-            Some("auto") => DeepSleepDecision::Armed {
+            Some("auto") => DeepSleepMode::Mobile {
                 fine_grained: config == RuntimeD3Config::FineGrained,
             },
-            Some(_) => DeepSleepDecision::Disabled {
+            Some(_) => DeepSleepMode::Desktop {
                 reason: "power/control is not 'auto' (runtime PM disabled by policy)",
             },
-            None => DeepSleepDecision::Unknown {
+            None => DeepSleepMode::Unknown {
                 reason: "power/control not readable",
             },
         },
-        RuntimeD3Config::Disabled | RuntimeD3Config::NotSupported => DeepSleepDecision::Disabled {
+        RuntimeD3Config::Disabled | RuntimeD3Config::NotSupported => DeepSleepMode::Desktop {
             reason: "driver reports runtime D3 disabled or unsupported",
         },
-        _ => DeepSleepDecision::Unknown {
+        _ => DeepSleepMode::Unknown {
             reason: "driver power file missing or GPU not initialized",
         },
     }
@@ -321,34 +321,34 @@ mod tests {
     }
 
     #[test]
-    fn arms_on_fine_grained_rtd3_with_auto_control() {
+    fn selects_mobile_on_fine_grained_rtd3_with_auto_control() {
         let (_root, probe, addr) =
             fake_tree(Some("Enabled (fine-grained)"), Some("auto"), Some("suspended"));
         assert_eq!(
             assess(&probe, addr),
-            DeepSleepDecision::Armed { fine_grained: true }
+            DeepSleepMode::Mobile { fine_grained: true }
         );
         assert_eq!(probe.runtime_pm_status(addr), RuntimePmStatus::Suspended);
         assert_eq!(probe.first_nvidia_gpu_addr().as_deref(), Some(addr));
     }
 
     #[test]
-    fn disables_when_control_is_pinned_on() {
+    fn selects_desktop_when_control_is_pinned_on() {
         let (_root, probe, addr) =
             fake_tree(Some("Enabled (fine-grained)"), Some("on"), Some("active"));
         assert!(matches!(
             assess(&probe, addr),
-            DeepSleepDecision::Disabled { .. }
+            DeepSleepMode::Desktop { .. }
         ));
     }
 
     #[test]
-    fn disables_on_desktop_config() {
+    fn selects_desktop_when_rtd3_is_disabled() {
         let (_root, probe, addr) =
             fake_tree(Some("Disabled by default"), Some("auto"), Some("active"));
         assert!(matches!(
             assess(&probe, addr),
-            DeepSleepDecision::Disabled { .. }
+            DeepSleepMode::Desktop { .. }
         ));
     }
 
@@ -357,12 +357,12 @@ mod tests {
         let (_root, probe, addr) = fake_tree(None, Some("auto"), Some("active"));
         assert!(matches!(
             assess(&probe, addr),
-            DeepSleepDecision::Unknown { .. }
+            DeepSleepMode::Unknown { .. }
         ));
         let (_root, probe, addr) = fake_tree(Some("?"), Some("auto"), Some("active"));
         assert!(matches!(
             assess(&probe, addr),
-            DeepSleepDecision::Unknown { .. }
+            DeepSleepMode::Unknown { .. }
         ));
     }
 
@@ -371,7 +371,7 @@ mod tests {
         let (_root, probe, _) = fake_tree(Some("Enabled (fine-grained)"), Some("auto"), None);
         assert!(matches!(
             assess(&probe, "0000:99:00.0"),
-            DeepSleepDecision::Unknown { .. }
+            DeepSleepMode::Unknown { .. }
         ));
     }
 }

--- a/burnerd/src/rtd3/detect.rs
+++ b/burnerd/src/rtd3/detect.rs
@@ -1,0 +1,377 @@
+//! Wake-free RTD3 (runtime D3 / D3cold) detection.
+//!
+//! Every read here is a cached kernel string: PCI sysfs power attributes and
+//! the NVIDIA procfs `power` file report state without initializing or waking
+//! the GPU. That is the point — the daemon decides whether deep sleep needs
+//! protecting BEFORE it ever touches NVML, because an NVML init (or any
+//! `/dev/nvidia*` open) would itself wake the GPU and hold it in D0.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// `Runtime D3 status:` as reported by `/proc/driver/nvidia/gpus/<addr>/power`.
+///
+/// `Unknown` covers a missing file, a missing line, and the literal `?` the
+/// driver prints while the GPU has never been initialized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeD3Config {
+    FineGrained,
+    CoarseGrained,
+    Disabled,
+    NotSupported,
+    Unknown,
+}
+
+impl RuntimeD3Config {
+    pub fn enabled(self) -> bool {
+        matches!(self, Self::FineGrained | Self::CoarseGrained)
+    }
+}
+
+pub fn parse_runtime_d3_config(power_file_text: &str) -> RuntimeD3Config {
+    let Some(value) = power_file_text
+        .lines()
+        .find_map(|line| line.strip_prefix("Runtime D3 status:").map(str::trim))
+    else {
+        return RuntimeD3Config::Unknown;
+    };
+    let lower = value.to_ascii_lowercase();
+    if lower.starts_with("enabled") {
+        if lower.contains("coarse-grained") {
+            RuntimeD3Config::CoarseGrained
+        } else {
+            // "Enabled (fine-grained)"; a bare "Enabled" is treated as
+            // fine-grained because the distinction only affects reporting.
+            RuntimeD3Config::FineGrained
+        }
+    } else if lower.starts_with("disabled") {
+        RuntimeD3Config::Disabled
+    } else if lower.starts_with("not supported") {
+        RuntimeD3Config::NotSupported
+    } else {
+        RuntimeD3Config::Unknown
+    }
+}
+
+/// Kernel runtime-PM state from `<device>/power/runtime_status`
+/// (Documentation/ABI/testing/sysfs-devices-power).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimePmStatus {
+    Active,
+    Suspending,
+    Suspended,
+    Resuming,
+    Error,
+    Unsupported,
+    Unknown,
+}
+
+impl RuntimePmStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Suspending => "suspending",
+            Self::Suspended => "suspended",
+            Self::Resuming => "resuming",
+            Self::Error => "error",
+            Self::Unsupported => "unsupported",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+pub fn parse_runtime_pm_status(text: &str) -> RuntimePmStatus {
+    match text.trim() {
+        "active" => RuntimePmStatus::Active,
+        "suspending" => RuntimePmStatus::Suspending,
+        "suspended" => RuntimePmStatus::Suspended,
+        "resuming" => RuntimePmStatus::Resuming,
+        "error" => RuntimePmStatus::Error,
+        "unsupported" => RuntimePmStatus::Unsupported,
+        _ => RuntimePmStatus::Unknown,
+    }
+}
+
+/// Normalize a PCI address to the sysfs form `0000:01:00.0`.
+///
+/// NVML reports an eight-hex-digit domain (`00000000:01:00.0`); sysfs and the
+/// NVIDIA procfs tree use four. Both are accepted, as is a domain-less
+/// `01:00.0`.
+pub fn sysfs_pci_addr(raw: &str) -> Option<String> {
+    let lower = raw.trim().to_ascii_lowercase();
+    let parts: Vec<&str> = lower.split(':').collect();
+    let (domain, bus, devfn) = match parts.as_slice() {
+        [domain, bus, devfn] => (u32::from_str_radix(domain, 16).ok()?, *bus, *devfn),
+        [bus, devfn] => (0, *bus, *devfn),
+        _ => return None,
+    };
+    let (dev, func) = devfn.split_once('.')?;
+    Some(format!(
+        "{domain:04x}:{:02x}:{:02x}.{:x}",
+        u8::from_str_radix(bus, 16).ok()?,
+        u8::from_str_radix(dev, 16).ok()?,
+        u8::from_str_radix(func, 16).ok()?,
+    ))
+}
+
+/// Read-only view of the PCI sysfs tree and the NVIDIA procfs tree, with
+/// injectable roots so tests can point it at a fake filesystem.
+pub struct Rtd3Probe {
+    pci_devices_root: PathBuf,
+    nvidia_gpus_root: PathBuf,
+}
+
+const SYSFS_ROOT_ENV: &str = "PENGUIN_BURNERD_TEST_RTD3_SYSFS";
+const PROC_ROOT_ENV: &str = "PENGUIN_BURNERD_TEST_RTD3_PROC";
+
+impl Rtd3Probe {
+    /// The live system trees. Test seam (never set in production): the
+    /// `PENGUIN_BURNERD_TEST_RTD3_*` env roots swap in a fake tree so the
+    /// integration harness can simulate an RTD3 laptop on any machine.
+    pub fn system() -> Self {
+        let env_path = |name: &str, default: &str| {
+            std::env::var_os(name)
+                .filter(|v| !v.is_empty())
+                .map_or_else(|| PathBuf::from(default), PathBuf::from)
+        };
+        Self {
+            pci_devices_root: env_path(SYSFS_ROOT_ENV, "/sys/bus/pci/devices"),
+            nvidia_gpus_root: env_path(PROC_ROOT_ENV, "/proc/driver/nvidia/gpus"),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_roots(pci_devices_root: &Path, nvidia_gpus_root: &Path) -> Self {
+        Self {
+            pci_devices_root: pci_devices_root.to_path_buf(),
+            nvidia_gpus_root: nvidia_gpus_root.to_path_buf(),
+        }
+    }
+
+    fn read_trimmed(path: &Path) -> Option<String> {
+        fs::read_to_string(path)
+            .ok()
+            .map(|text| text.trim().to_string())
+    }
+
+    pub fn device_present(&self, addr: &str) -> bool {
+        self.pci_devices_root.join(addr).is_dir()
+    }
+
+    /// True when the device at `addr` is an NVIDIA display device (vendor
+    /// 0x10de, class 0x03xxxx). Guards the persisted-spec hint: an address is
+    /// only trusted if the hardware behind it is still the expected GPU.
+    pub fn is_nvidia_gpu(&self, addr: &str) -> bool {
+        let device = self.pci_devices_root.join(addr);
+        let vendor = Self::read_trimmed(&device.join("vendor"));
+        let class = Self::read_trimmed(&device.join("class"));
+        vendor.as_deref() == Some("0x10de") && class.is_some_and(|class| class.starts_with("0x03"))
+    }
+
+    /// First NVIDIA display-class device in the PCI tree, in stable name
+    /// order. Hybrid laptops have exactly one.
+    pub fn first_nvidia_gpu_addr(&self) -> Option<String> {
+        let entries = fs::read_dir(&self.pci_devices_root).ok()?;
+        let mut addrs: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .collect();
+        addrs.sort();
+        addrs.into_iter().find(|addr| self.is_nvidia_gpu(addr))
+    }
+
+    pub fn runtime_d3_config(&self, addr: &str) -> RuntimeD3Config {
+        let path = self.nvidia_gpus_root.join(addr).join("power");
+        match fs::read_to_string(path) {
+            Ok(text) => parse_runtime_d3_config(&text),
+            Err(_) => RuntimeD3Config::Unknown,
+        }
+    }
+
+    /// `power/control`: `auto` means the kernel may runtime-suspend the
+    /// device; `on` pins it awake (the state without the NVIDIA udev rules).
+    pub fn power_control(&self, addr: &str) -> Option<String> {
+        Self::read_trimmed(&self.pci_devices_root.join(addr).join("power/control"))
+    }
+
+    pub fn runtime_pm_status(&self, addr: &str) -> RuntimePmStatus {
+        match Self::read_trimmed(&self.pci_devices_root.join(addr).join("power/runtime_status")) {
+            Some(text) => parse_runtime_pm_status(&text),
+            None => RuntimePmStatus::Unknown,
+        }
+    }
+}
+
+/// The startup verdict for one GPU. `Unknown` is a deliberate third state:
+/// "not decidable yet" (device not bound, driver power file still `?`) must
+/// keep the daemon detached rather than fall through to the classic
+/// NVML-at-boot path, otherwise the boot race reintroduces the pinned-GPU bug.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeepSleepDecision {
+    Armed { fine_grained: bool },
+    Disabled { reason: &'static str },
+    Unknown { reason: &'static str },
+}
+
+pub fn assess(probe: &Rtd3Probe, addr: &str) -> DeepSleepDecision {
+    if !probe.device_present(addr) {
+        return DeepSleepDecision::Unknown {
+            reason: "PCI device not visible yet",
+        };
+    }
+    match probe.runtime_d3_config(addr) {
+        config if config.enabled() => match probe.power_control(addr).as_deref() {
+            Some("auto") => DeepSleepDecision::Armed {
+                fine_grained: config == RuntimeD3Config::FineGrained,
+            },
+            Some(_) => DeepSleepDecision::Disabled {
+                reason: "power/control is not 'auto' (runtime PM disabled by policy)",
+            },
+            None => DeepSleepDecision::Unknown {
+                reason: "power/control not readable",
+            },
+        },
+        RuntimeD3Config::Disabled | RuntimeD3Config::NotSupported => DeepSleepDecision::Disabled {
+            reason: "driver reports runtime D3 disabled or unsupported",
+        },
+        _ => DeepSleepDecision::Unknown {
+            reason: "driver power file missing or GPU not initialized",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fake_tree(
+        d3_line: Option<&str>,
+        control: Option<&str>,
+        runtime_status: Option<&str>,
+    ) -> (tempfile::TempDir, Rtd3Probe, &'static str) {
+        let addr = "0000:01:00.0";
+        let root = tempfile::tempdir().expect("tempdir");
+        let device = root.path().join("sys").join(addr);
+        let power = device.join("power");
+        fs::create_dir_all(&power).unwrap();
+        fs::write(device.join("vendor"), "0x10de\n").unwrap();
+        fs::write(device.join("class"), "0x030000\n").unwrap();
+        if let Some(control) = control {
+            fs::write(power.join("control"), format!("{control}\n")).unwrap();
+        }
+        if let Some(status) = runtime_status {
+            fs::write(power.join("runtime_status"), format!("{status}\n")).unwrap();
+        }
+        let proc_gpu = root.path().join("proc").join(addr);
+        fs::create_dir_all(&proc_gpu).unwrap();
+        if let Some(line) = d3_line {
+            fs::write(
+                proc_gpu.join("power"),
+                format!("Runtime D3 status:          {line}\nVideo Memory:               Off\n"),
+            )
+            .unwrap();
+        }
+        let probe = Rtd3Probe::with_roots(&root.path().join("sys"), &root.path().join("proc"));
+        (root, probe, addr)
+    }
+
+    #[test]
+    fn parses_runtime_d3_config_variants() {
+        assert_eq!(
+            parse_runtime_d3_config("Runtime D3 status:          Enabled (fine-grained)\n"),
+            RuntimeD3Config::FineGrained
+        );
+        assert_eq!(
+            parse_runtime_d3_config("Runtime D3 status:          Enabled (coarse-grained)\n"),
+            RuntimeD3Config::CoarseGrained
+        );
+        assert_eq!(
+            parse_runtime_d3_config("Runtime D3 status:          Disabled by default\n"),
+            RuntimeD3Config::Disabled
+        );
+        assert_eq!(
+            parse_runtime_d3_config("Runtime D3 status:          Not supported\n"),
+            RuntimeD3Config::NotSupported
+        );
+        assert_eq!(
+            parse_runtime_d3_config("Runtime D3 status:          ?\n"),
+            RuntimeD3Config::Unknown
+        );
+        assert_eq!(parse_runtime_d3_config(""), RuntimeD3Config::Unknown);
+    }
+
+    #[test]
+    fn normalizes_pci_addresses() {
+        assert_eq!(
+            sysfs_pci_addr("00000000:01:00.0").as_deref(),
+            Some("0000:01:00.0")
+        );
+        assert_eq!(
+            sysfs_pci_addr("0000:01:00.0").as_deref(),
+            Some("0000:01:00.0")
+        );
+        assert_eq!(sysfs_pci_addr("01:00.0").as_deref(), Some("0000:01:00.0"));
+        assert_eq!(
+            sysfs_pci_addr("00000000:C1:00.0").as_deref(),
+            Some("0000:c1:00.0")
+        );
+        assert_eq!(sysfs_pci_addr(""), None);
+        assert_eq!(sysfs_pci_addr("not-a-pci-addr"), None);
+    }
+
+    #[test]
+    fn arms_on_fine_grained_rtd3_with_auto_control() {
+        let (_root, probe, addr) =
+            fake_tree(Some("Enabled (fine-grained)"), Some("auto"), Some("suspended"));
+        assert_eq!(
+            assess(&probe, addr),
+            DeepSleepDecision::Armed { fine_grained: true }
+        );
+        assert_eq!(probe.runtime_pm_status(addr), RuntimePmStatus::Suspended);
+        assert_eq!(probe.first_nvidia_gpu_addr().as_deref(), Some(addr));
+    }
+
+    #[test]
+    fn disables_when_control_is_pinned_on() {
+        let (_root, probe, addr) =
+            fake_tree(Some("Enabled (fine-grained)"), Some("on"), Some("active"));
+        assert!(matches!(
+            assess(&probe, addr),
+            DeepSleepDecision::Disabled { .. }
+        ));
+    }
+
+    #[test]
+    fn disables_on_desktop_config() {
+        let (_root, probe, addr) =
+            fake_tree(Some("Disabled by default"), Some("auto"), Some("active"));
+        assert!(matches!(
+            assess(&probe, addr),
+            DeepSleepDecision::Disabled { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_when_driver_power_file_missing_or_uninitialized() {
+        let (_root, probe, addr) = fake_tree(None, Some("auto"), Some("active"));
+        assert!(matches!(
+            assess(&probe, addr),
+            DeepSleepDecision::Unknown { .. }
+        ));
+        let (_root, probe, addr) = fake_tree(Some("?"), Some("auto"), Some("active"));
+        assert!(matches!(
+            assess(&probe, addr),
+            DeepSleepDecision::Unknown { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_when_device_absent() {
+        let (_root, probe, _) = fake_tree(Some("Enabled (fine-grained)"), Some("auto"), None);
+        assert!(matches!(
+            assess(&probe, "0000:99:00.0"),
+            DeepSleepDecision::Unknown { .. }
+        ));
+    }
+}

--- a/burnerd/src/rtd3/detect.rs
+++ b/burnerd/src/rtd3/detect.rs
@@ -200,6 +200,22 @@ impl Rtd3Probe {
             None => RuntimePmStatus::Unknown,
         }
     }
+
+    /// Cumulative runtime-PM residency: `power/runtime_active_time` and
+    /// `power/runtime_suspended_time`, milliseconds since boot
+    /// (Documentation/ABI/testing/sysfs-devices-power). Cached kernel
+    /// counters — reading them never wakes the device. `None` per counter
+    /// when the file is missing or unparsable.
+    pub fn runtime_pm_times(&self, addr: &str) -> (Option<u64>, Option<u64>) {
+        let read = |file: &str| {
+            Self::read_trimmed(&self.pci_devices_root.join(addr).join("power").join(file))
+                .and_then(|text| text.parse().ok())
+        };
+        (
+            read("runtime_active_time"),
+            read("runtime_suspended_time"),
+        )
+    }
 }
 
 /// The deep-sleep mode for one GPU. `Unknown` is a deliberate third state:
@@ -274,6 +290,22 @@ mod tests {
         }
         let probe = Rtd3Probe::with_roots(&root.path().join("sys"), &root.path().join("proc"));
         (root, probe, addr)
+    }
+
+    #[test]
+    fn runtime_pm_times_read_the_kernel_counters_or_none() {
+        let (root, probe, addr) = fake_tree(None, None, Some("suspended"));
+        // Missing files (old kernels): both counters absent.
+        assert_eq!(probe.runtime_pm_times(addr), (None, None));
+
+        let power = root.path().join("sys").join(addr).join("power");
+        fs::write(power.join("runtime_active_time"), "5123\n").unwrap();
+        fs::write(power.join("runtime_suspended_time"), "60789\n").unwrap();
+        assert_eq!(probe.runtime_pm_times(addr), (Some(5123), Some(60789)));
+
+        // Garbage stays None per counter, not a panic.
+        fs::write(power.join("runtime_active_time"), "not-a-number\n").unwrap();
+        assert_eq!(probe.runtime_pm_times(addr), (None, Some(60789)));
     }
 
     #[test]

--- a/burnerd/src/rtd3/detect.rs
+++ b/burnerd/src/rtd3/detect.rs
@@ -8,7 +8,6 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 /// `Runtime D3 status:` as reported by `/proc/driver/nvidia/gpus/<addr>/power`.
 ///
@@ -202,20 +201,6 @@ impl Rtd3Probe {
         }
     }
 
-    /// Kernel autosuspend delay for this device. Missing, negative, or
-    /// malformed values are unknown; callers choose a conservative fallback.
-    /// This is a cached sysfs read and never wakes the device.
-    pub fn autosuspend_delay(&self, addr: &str) -> Option<Duration> {
-        Self::read_trimmed(
-            &self
-                .pci_devices_root
-                .join(addr)
-                .join("power/autosuspend_delay_ms"),
-        )
-        .and_then(|text| text.parse::<u64>().ok())
-        .map(Duration::from_millis)
-    }
-
     /// Cumulative runtime-PM residency: `power/runtime_active_time` and
     /// `power/runtime_suspended_time`, milliseconds since boot
     /// (Documentation/ABI/testing/sysfs-devices-power). Cached kernel
@@ -321,23 +306,6 @@ mod tests {
         // Garbage stays None per counter, not a panic.
         fs::write(power.join("runtime_active_time"), "not-a-number\n").unwrap();
         assert_eq!(probe.runtime_pm_times(addr), (None, Some(60789)));
-    }
-
-    #[test]
-    fn autosuspend_delay_accepts_nonnegative_milliseconds_only() {
-        let (root, probe, addr) = fake_tree(None, None, Some("active"));
-        let path = root
-            .path()
-            .join("sys")
-            .join(addr)
-            .join("power/autosuspend_delay_ms");
-        assert_eq!(probe.autosuspend_delay(addr), None);
-        fs::write(&path, "5000\n").unwrap();
-        assert_eq!(probe.autosuspend_delay(addr), Some(Duration::from_secs(5)));
-        fs::write(&path, "-1\n").unwrap();
-        assert_eq!(probe.autosuspend_delay(addr), None);
-        fs::write(&path, "not-a-number\n").unwrap();
-        assert_eq!(probe.autosuspend_delay(addr), None);
     }
 
     #[test]

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -61,10 +61,30 @@ pub struct DeepSleepStatus {
     /// True while an applied profile is parked: its engine released the GPU
     /// so it can suspend, and the watcher reapplies it at the next real use.
     pub parked: bool,
+    /// The daemon's own GPU holds at status time. The client sample excludes
+    /// the daemon's pid, so without this block a daemon-held NVML session
+    /// (attached engine, a polling GUI's telemetry backend) reads as "no
+    /// clients" while it pins the GPU — the misdirection that pointed
+    /// issue #30 at nvidia-powerd.
+    pub daemon: DaemonGpuHolds,
     /// The watcher's most recent client sample (mobile modes only): which
     /// processes really use the GPU, per kind, with aggregate counts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gpu_clients: Option<GpuClientsStatus>,
+}
+
+/// The daemon's own GPU holds, reported by the supervisor at status time.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct DaemonGpuHolds {
+    /// True while the in-process profile engine is attached: the daemon
+    /// itself holds NVML/NVAPI for the applied profile — the pin the park
+    /// countdown exists to remove.
+    pub engine_attached: bool,
+    /// Lazily-opened GPU RPC backends still alive (telemetry/capability
+    /// queries). A steadily nonzero value means some client keeps querying
+    /// faster than the 30s idle sweep, holding the GPU awake through the
+    /// daemon even though no external process shows in the client lists.
+    pub rpc_backends: usize,
 }
 
 /// One process in the `gpu_clients` lists.
@@ -459,8 +479,10 @@ pub fn set_autostart_deferred(deferred: bool) {
 }
 
 /// The `deep_sleep` status block; `None` until `evaluate` has run (unit tests
-/// that build a bare supervisor never see the field).
-pub fn status() -> Option<DeepSleepStatus> {
+/// that build a bare supervisor never see the field). `daemon_holds` comes
+/// from the caller because engine and RPC-backend state belong to the
+/// supervisor and gpu_rpc, not this gate.
+pub fn status(daemon_holds: DaemonGpuHolds) -> Option<DeepSleepStatus> {
     let state = gate();
     let detected_mode = state.mode.as_ref()?;
     let mobile =
@@ -498,6 +520,7 @@ pub fn status() -> Option<DeepSleepStatus> {
         autostart_deferred: state.autostart_deferred,
         suspended_observed: state.suspended_observed,
         parked: state.parked,
+        daemon: daemon_holds,
         gpu_clients: state
             .gpu_clients
             .as_ref()
@@ -548,7 +571,9 @@ mod tests {
             DeepSleepMode::Unknown { .. }
         ));
         assert_eq!(
-            status().and_then(|status| status.pci_addr).as_deref(),
+            status(DaemonGpuHolds::default())
+                .and_then(|status| status.pci_addr)
+                .as_deref(),
             Some("0000:01:00.0")
         );
         assert!(protects_deep_sleep());
@@ -585,7 +610,9 @@ mod tests {
             DeepSleepMode::Mobile { .. }
         ));
         assert_eq!(
-            status().and_then(|status| status.pci_addr).as_deref(),
+            status(DaemonGpuHolds::default())
+                .and_then(|status| status.pci_addr)
+                .as_deref(),
             Some(addr)
         );
         reset_for_test();
@@ -637,7 +664,7 @@ mod tests {
     fn status_is_absent_until_evaluated() {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         reset_for_test();
-        assert!(status().is_none());
+        assert!(status(DaemonGpuHolds::default()).is_none());
         reset_for_test();
     }
 
@@ -745,7 +772,10 @@ mod tests {
             &root.path().join("proc"),
         );
         evaluate(&probe, None);
-        assert!(status().expect("evaluated").gpu_clients.is_none());
+        assert!(status(DaemonGpuHolds::default())
+            .expect("evaluated")
+            .gpu_clients
+            .is_none());
 
         record_gpu_clients(GpuClientObservation {
             source: GpuClientSource::DeviceNodes,
@@ -754,7 +784,7 @@ mod tests {
             device_node_holders: vec![client(4242, "some-game")],
             ignored_clients: Vec::new(),
         });
-        let clients = status()
+        let clients = status(DaemonGpuHolds::default())
             .expect("evaluated")
             .gpu_clients
             .expect("sample recorded");

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -18,7 +18,9 @@
 pub mod detect;
 pub mod watch;
 
+use std::collections::HashSet;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use serde::Serialize;
 
@@ -50,6 +52,96 @@ pub struct DeepSleepStatus {
     /// True while an applied profile is parked: its engine released the GPU
     /// so it can suspend, and the watcher reapplies it at the next real use.
     pub parked: bool,
+    /// The watcher's most recent client sample (mobile modes only): which
+    /// processes really use the GPU, per kind, with aggregate counts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_clients: Option<GpuClientsStatus>,
+}
+
+/// One process in the `gpu_clients` lists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GpuClientProcess {
+    pub pid: u32,
+    /// `/proc/<pid>/comm`; `null` when the process exited before the lookup.
+    pub name: Option<String>,
+}
+
+/// Where a client sample came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuClientSource {
+    /// Live NVML graphics/compute contexts — the decisive signal under
+    /// fine-grained RTD3.
+    NvmlContexts,
+    /// `/dev/nvidia<N>` device-node fd holders — the decisive signal under
+    /// coarse-grained/unknown RTD3, and the fallback when NVML is unavailable.
+    DeviceNodes,
+}
+
+impl GpuClientSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NvmlContexts => "nvml-contexts",
+            Self::DeviceNodes => "device-nodes",
+        }
+    }
+}
+
+/// A watcher client sample: who holds live GPU contexts and who merely holds
+/// device nodes open, minus the daemon itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuClientObservation {
+    pub source: GpuClientSource,
+    pub graphics: Vec<GpuClientProcess>,
+    pub compute: Vec<GpuClientProcess>,
+    pub device_node_holders: Vec<GpuClientProcess>,
+}
+
+/// The `gpu_clients` object inside `deep_sleep`: the watcher's latest client
+/// sample, kept so someone debugging why the GPU does or does not park
+/// (issue #30) can see exactly what the daemon saw.
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuClientsStatus {
+    /// "nvml-contexts" or "device-nodes" — which signal decided park/wake.
+    pub source: String,
+    pub graphics_count: usize,
+    pub compute_count: usize,
+    pub device_node_count: usize,
+    /// Unique PIDs the park/wake decision counted (the context lists under
+    /// "nvml-contexts", the fd holders under "device-nodes"). Parking
+    /// proceeds only while this stays 0.
+    pub total_count: usize,
+    /// Seconds since the sample was taken. Grows while the GPU sleeps —
+    /// the watcher only samples an awake GPU.
+    pub age_s: f64,
+    pub graphics: Vec<GpuClientProcess>,
+    pub compute: Vec<GpuClientProcess>,
+    /// Processes holding `/dev/nvidia<N>` open. Under fine-grained RTD3 this
+    /// is informational: a holder with no live context does not keep the GPU
+    /// awake and does not block parking.
+    pub device_node_holders: Vec<GpuClientProcess>,
+}
+
+fn gpu_clients_status(observation: &GpuClientObservation, observed_at: Instant) -> GpuClientsStatus {
+    let decisive: &[&[GpuClientProcess]] = match observation.source {
+        GpuClientSource::NvmlContexts => &[&observation.graphics, &observation.compute],
+        GpuClientSource::DeviceNodes => &[&observation.device_node_holders],
+    };
+    let counted: HashSet<u32> = decisive
+        .iter()
+        .flat_map(|list| list.iter())
+        .map(|process| process.pid)
+        .collect();
+    GpuClientsStatus {
+        source: observation.source.as_str().to_string(),
+        graphics_count: observation.graphics.len(),
+        compute_count: observation.compute.len(),
+        device_node_count: observation.device_node_holders.len(),
+        total_count: counted.len(),
+        age_s: (observed_at.elapsed().as_secs_f64() * 1000.0).round() / 1000.0,
+        graphics: observation.graphics.clone(),
+        compute: observation.compute.clone(),
+        device_node_holders: observation.device_node_holders.clone(),
+    }
 }
 
 #[derive(Default)]
@@ -60,6 +152,7 @@ struct GateState {
     suspended_observed: bool,
     autostart_deferred: bool,
     parked: bool,
+    gpu_clients: Option<(GpuClientObservation, Instant)>,
 }
 
 static GATE: Mutex<GateState> = Mutex::new(GateState {
@@ -69,6 +162,7 @@ static GATE: Mutex<GateState> = Mutex::new(GateState {
     suspended_observed: false,
     autostart_deferred: false,
     parked: false,
+    gpu_clients: None,
 });
 
 fn gate() -> std::sync::MutexGuard<'static, GateState> {
@@ -208,6 +302,53 @@ pub fn set_parked(parked: bool) {
     }
 }
 
+/// Record the watcher's latest client sample for the `gpu_clients` status
+/// block. Called on every awake-GPU check, so the block always reflects the
+/// evidence behind the most recent park/wake decision.
+///
+/// A journal line is emitted only when the sample differs from the previous
+/// one: the watcher samples at 1 Hz, and the client set changes on the order
+/// of process starts and exits, so the journal reads as a sparse narrative
+/// of who took and released the GPU instead of a per-second flood.
+pub(crate) fn record_gpu_clients(observation: GpuClientObservation) {
+    let mut state = gate();
+    let changed = state
+        .gpu_clients
+        .as_ref()
+        .is_none_or(|(previous, _)| previous != &observation);
+    if changed {
+        logging::info(&describe_gpu_clients(&observation));
+    }
+    state.gpu_clients = Some((observation, Instant::now()));
+}
+
+/// One journal line naming every sampled process with its count per list,
+/// e.g. `deep sleep: gpu clients (nvml-contexts): graphics=1 [4242
+/// some-game], compute=0, device-node holders=2 [1450 plasmashell, 3117
+/// vkcube]`.
+fn describe_gpu_clients(observation: &GpuClientObservation) -> String {
+    fn list(label: &str, processes: &[GpuClientProcess]) -> String {
+        if processes.is_empty() {
+            return format!("{label}=0");
+        }
+        let entries: Vec<String> = processes
+            .iter()
+            .map(|process| match &process.name {
+                Some(name) => format!("{} {name}", process.pid),
+                None => process.pid.to_string(),
+            })
+            .collect();
+        format!("{label}={} [{}]", processes.len(), entries.join(", "))
+    }
+    format!(
+        "deep sleep: gpu clients ({}): {}, {}, {}",
+        observation.source.as_str(),
+        list("graphics", &observation.graphics),
+        list("compute", &observation.compute),
+        list("device-node holders", &observation.device_node_holders),
+    )
+}
+
 pub fn set_autostart_deferred(deferred: bool) {
     let mut state = gate();
     if state.autostart_deferred != deferred {
@@ -258,6 +399,10 @@ pub fn status() -> Option<DeepSleepStatus> {
         autostart_deferred: state.autostart_deferred,
         suspended_observed: state.suspended_observed,
         parked: state.parked,
+        gpu_clients: state
+            .gpu_clients
+            .as_ref()
+            .map(|(observation, observed_at)| gpu_clients_status(observation, *observed_at)),
     })
 }
 
@@ -394,6 +539,93 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         reset_for_test();
         assert!(status().is_none());
+        reset_for_test();
+    }
+
+    fn client(pid: u32, name: &str) -> GpuClientProcess {
+        GpuClientProcess {
+            pid,
+            name: Some(name.to_string()),
+        }
+    }
+
+    #[test]
+    fn gpu_client_stats_count_only_the_decisive_lists() {
+        let observation = GpuClientObservation {
+            source: GpuClientSource::NvmlContexts,
+            graphics: vec![client(100, "gnome-shell"), client(200, "game")],
+            compute: vec![client(200, "game"), client(300, "python3")],
+            device_node_holders: vec![client(100, "gnome-shell"), client(999, "Xorg")],
+        };
+        let stats = gpu_clients_status(&observation, Instant::now());
+        assert_eq!(stats.source, "nvml-contexts");
+        assert_eq!(stats.graphics_count, 2);
+        assert_eq!(stats.compute_count, 2);
+        assert_eq!(stats.device_node_count, 2);
+        // A PID with both context kinds counts once; under fine-grained RTD3
+        // fd holders are informational and never counted.
+        assert_eq!(stats.total_count, 3);
+
+        let observation = GpuClientObservation {
+            source: GpuClientSource::DeviceNodes,
+            graphics: Vec::new(),
+            compute: Vec::new(),
+            device_node_holders: vec![client(999, "Xorg")],
+        };
+        let stats = gpu_clients_status(&observation, Instant::now());
+        assert_eq!(stats.source, "device-nodes");
+        assert_eq!(stats.total_count, 1);
+        assert_eq!(stats.graphics_count, 0);
+        assert_eq!(stats.compute_count, 0);
+    }
+
+    #[test]
+    fn gpu_client_log_line_names_every_process_with_counts() {
+        let observation = GpuClientObservation {
+            source: GpuClientSource::NvmlContexts,
+            graphics: vec![client(4242, "some-game")],
+            compute: Vec::new(),
+            device_node_holders: vec![
+                client(1450, "plasmashell"),
+                GpuClientProcess {
+                    pid: 3117,
+                    name: None,
+                },
+            ],
+        };
+        assert_eq!(
+            describe_gpu_clients(&observation),
+            "deep sleep: gpu clients (nvml-contexts): graphics=1 [4242 some-game], \
+             compute=0, device-node holders=2 [1450 plasmashell, 3117]"
+        );
+    }
+
+    #[test]
+    fn status_reports_the_recorded_client_sample() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        let root = tempfile::tempdir().expect("tempdir");
+        let probe = detect::Rtd3Probe::with_roots(
+            &root.path().join("sys"),
+            &root.path().join("proc"),
+        );
+        evaluate(&probe, None);
+        assert!(status().expect("evaluated").gpu_clients.is_none());
+
+        record_gpu_clients(GpuClientObservation {
+            source: GpuClientSource::DeviceNodes,
+            graphics: Vec::new(),
+            compute: Vec::new(),
+            device_node_holders: vec![client(4242, "some-game")],
+        });
+        let clients = status()
+            .expect("evaluated")
+            .gpu_clients
+            .expect("sample recorded");
+        assert_eq!(clients.source, "device-nodes");
+        assert_eq!(clients.device_node_holders[0].pid, 4242);
+        assert_eq!(clients.device_node_holders[0].name.as_deref(), Some("some-game"));
+        assert!(clients.age_s >= 0.0);
         reset_for_test();
     }
 }

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -15,12 +15,13 @@
 //! Desktop mode keeps the existing always-attached behavior. Mobile mode keeps
 //! GPU handles ephemeral so an RTD3-capable dGPU can suspend.
 
+mod clients;
 pub mod detect;
 pub mod watch;
 
 use std::collections::HashSet;
 use std::sync::Mutex;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
@@ -201,6 +202,7 @@ struct GateState {
     runtime_status_since: Option<Instant>,
     runtime_active_ms: Option<u64>,
     runtime_suspended_ms: Option<u64>,
+    autosuspend_delay: Option<Duration>,
     suspended_observed: bool,
     autostart_deferred: bool,
     parked: bool,
@@ -214,6 +216,7 @@ static GATE: Mutex<GateState> = Mutex::new(GateState {
     runtime_status_since: None,
     runtime_active_ms: None,
     runtime_suspended_ms: None,
+    autosuspend_delay: None,
     suspended_observed: false,
     autostart_deferred: false,
     parked: false,
@@ -249,6 +252,9 @@ pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepM
     };
     let runtime_status = addr.as_deref().map(|addr| probe.runtime_pm_status(addr));
     let runtime_times = addr.as_deref().map(|addr| probe.runtime_pm_times(addr));
+    let autosuspend_delay = addr
+        .as_deref()
+        .and_then(|addr| probe.autosuspend_delay(addr));
     let mut state = gate();
     state.pci_addr = addr;
     if let Some(status) = runtime_status {
@@ -258,6 +264,7 @@ pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepM
         state.runtime_active_ms = active_ms;
         state.runtime_suspended_ms = suspended_ms;
     }
+    state.autosuspend_delay = autosuspend_delay;
     if state.mode.as_ref() != Some(&mode) {
         logging::info(&format!(
             "deep sleep mode: {} (gpu={})",
@@ -328,6 +335,10 @@ pub fn fine_grained_mode() -> bool {
 
 pub fn last_runtime_status() -> Option<RuntimePmStatus> {
     gate().last_runtime_status
+}
+
+pub(crate) fn autosuspend_delay() -> Option<Duration> {
+    gate().autosuspend_delay
 }
 
 fn record_runtime_status(state: &mut GateState, status: RuntimePmStatus) {

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -47,6 +47,9 @@ pub struct DeepSleepStatus {
     /// True once the GPU has been seen suspended this daemon lifetime —
     /// definitive evidence the platform can deep-sleep.
     pub suspended_observed: bool,
+    /// True while an applied profile is parked: its engine released the GPU
+    /// so it can suspend, and the watcher reapplies it at the next real use.
+    pub parked: bool,
 }
 
 #[derive(Default)]
@@ -56,6 +59,7 @@ struct GateState {
     last_runtime_status: Option<RuntimePmStatus>,
     suspended_observed: bool,
     autostart_deferred: bool,
+    parked: bool,
 }
 
 static GATE: Mutex<GateState> = Mutex::new(GateState {
@@ -64,6 +68,7 @@ static GATE: Mutex<GateState> = Mutex::new(GateState {
     last_runtime_status: None,
     suspended_observed: false,
     autostart_deferred: false,
+    parked: false,
 });
 
 fn gate() -> std::sync::MutexGuard<'static, GateState> {
@@ -177,6 +182,20 @@ pub(crate) fn note_runtime_status(status: RuntimePmStatus) {
     record_runtime_status(&mut state, status);
 }
 
+/// Record that the applied runtime was parked (engine stopped, persisted
+/// state kept) so the GPU can suspend — or that it re-materialized.
+pub fn set_parked(parked: bool) {
+    let mut state = gate();
+    if state.parked != parked {
+        state.parked = parked;
+        logging::info(if parked {
+            "deep sleep: runtime parked; the GPU may suspend until its next real use"
+        } else {
+            "deep sleep: parked runtime re-materialized"
+        });
+    }
+}
+
 pub fn set_autostart_deferred(deferred: bool) {
     let mut state = gate();
     if state.autostart_deferred != deferred {
@@ -226,6 +245,7 @@ pub fn status() -> Option<DeepSleepStatus> {
         runtime_status: state.last_runtime_status.map(|s| s.as_str().to_string()),
         autostart_deferred: state.autostart_deferred,
         suspended_observed: state.suspended_observed,
+        parked: state.parked,
     })
 }
 

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -5,15 +5,15 @@
 //! and defeats runtime suspend (issue #30). This module owns that policy:
 //!
 //! - `detect`: wake-free probes of the PCI sysfs tree and the NVIDIA procfs
-//!   `power` file, and the startup verdict (`DeepSleepDecision`).
+//!   `power` file, and the startup mode (`DeepSleepMode`).
 //! - `watch`: the startup supervisor that defers the persisted runtime while
 //!   the GPU sleeps, starts it when a real client wakes the GPU, and sweeps
 //!   idle RPC backends so a one-off telemetry query cannot pin the GPU.
-//! - the process-wide gate (this file): the cached verdict every attach point
+//! - the process-wide gate (this file): the cached mode every attach point
 //!   consults, plus the `deep_sleep` block reported by `status`.
 //!
-//! Desktops resolve to `Disabled` and keep the classic always-attached
-//! behavior byte-for-byte.
+//! Desktop mode keeps the existing always-attached behavior. Mobile mode keeps
+//! GPU handles ephemeral so an RTD3-capable dGPU can suspend.
 
 pub mod detect;
 pub mod watch;
@@ -23,17 +23,17 @@ use std::sync::Mutex;
 use serde::Serialize;
 
 use crate::logging;
-use detect::{DeepSleepDecision, RuntimePmStatus};
+use detect::{DeepSleepMode, RuntimePmStatus};
 
 /// The `deep_sleep` object in the `status` response. Field order is the wire
 /// contract (api.rs serializes structs in declaration order).
 #[derive(Debug, Clone, Serialize)]
 pub struct DeepSleepStatus {
-    /// "armed" | "disabled" | "unknown"
+    /// "mobile" | "desktop" | "unknown"
     pub state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
-    /// "fine-grained" | "coarse-grained" when armed.
+    /// "fine-grained" | "coarse-grained" in mobile mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,7 +51,7 @@ pub struct DeepSleepStatus {
 
 #[derive(Default)]
 struct GateState {
-    decision: Option<DeepSleepDecision>,
+    mode: Option<DeepSleepMode>,
     pci_addr: Option<String>,
     last_runtime_status: Option<RuntimePmStatus>,
     suspended_observed: bool,
@@ -59,7 +59,7 @@ struct GateState {
 }
 
 static GATE: Mutex<GateState> = Mutex::new(GateState {
-    decision: None,
+    mode: None,
     pci_addr: None,
     last_runtime_status: None,
     suspended_observed: false,
@@ -70,93 +70,111 @@ fn gate() -> std::sync::MutexGuard<'static, GateState> {
     GATE.lock().unwrap_or_else(|poison| poison.into_inner())
 }
 
-/// Resolve the GPU address (persisted-spec hint first, then PCI enumeration)
-/// and store the startup verdict. Wake-free; call before any NVML init.
-pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepDecision {
-    let addr = pci_hint
-        .and_then(detect::sysfs_pci_addr)
-        .filter(|addr| probe.is_nvidia_gpu(addr))
-        .or_else(|| probe.first_nvidia_gpu_addr());
-    let decision = match &addr {
+/// Resolve the GPU address (persisted-spec hint first, then PCI enumeration),
+/// record its cached runtime status, and store the startup mode. Wake-free;
+/// call before any NVML init.
+pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepMode {
+    let normalized_hint = pci_hint.and_then(detect::sysfs_pci_addr);
+    let addr = match normalized_hint {
+        Some(addr) if probe.is_nvidia_gpu(&addr) => Some(addr),
+        // A saved device may not be bound yet, or its PCI address may have
+        // changed. Prefer any visible NVIDIA GPU; preserve an absent address
+        // only when enumeration has nothing better so boot stays Unknown.
+        Some(addr) if !probe.device_present(&addr) => {
+            probe.first_nvidia_gpu_addr().or(Some(addr))
+        }
+        // A visible hint that no longer identifies an NVIDIA display device is
+        // stale; enumerate rather than trusting the saved address.
+        _ => probe.first_nvidia_gpu_addr(),
+    };
+    let mode = match &addr {
         Some(addr) => detect::assess(probe, addr),
-        None => DeepSleepDecision::Disabled {
+        None => DeepSleepMode::Unknown {
             reason: "no NVIDIA display-class PCI device visible",
         },
     };
+    let runtime_status = addr.as_deref().map(|addr| probe.runtime_pm_status(addr));
     let mut state = gate();
     state.pci_addr = addr;
-    if state.decision.as_ref() != Some(&decision) {
+    if let Some(status) = runtime_status {
+        record_runtime_status(&mut state, status);
+    }
+    if state.mode.as_ref() != Some(&mode) {
         logging::info(&format!(
-            "deep sleep gate: {} (gpu={})",
-            describe(&decision),
+            "deep sleep mode: {} (gpu={})",
+            describe(&mode),
             state.pci_addr.as_deref().unwrap_or("unknown"),
         ));
     }
-    state.decision = Some(decision.clone());
-    decision
+    state.mode = Some(mode.clone());
+    mode
 }
 
-fn describe(decision: &DeepSleepDecision) -> String {
-    match decision {
-        DeepSleepDecision::Armed { fine_grained } => format!(
-            "armed ({} RTD3)",
+fn describe(mode: &DeepSleepMode) -> String {
+    match mode {
+        DeepSleepMode::Mobile { fine_grained } => format!(
+            "mobile ({} RTD3)",
             if *fine_grained {
                 "fine-grained"
             } else {
                 "coarse-grained"
             }
         ),
-        DeepSleepDecision::Disabled { reason } => format!("disabled: {reason}"),
-        DeepSleepDecision::Unknown { reason } => format!("undecided: {reason}"),
+        DeepSleepMode::Desktop { reason } => format!("desktop: {reason}"),
+        DeepSleepMode::Unknown { reason } => format!("unknown: {reason}"),
     }
 }
 
-/// True when NVML/NVAPI handles must be treated as ephemeral. Sticky: a GPU
-/// observed suspended arms the gate even if the config files were unreadable.
-pub fn is_armed() -> bool {
+/// True when the effective mode is Mobile. Sticky: observing a suspended GPU
+/// is definitive evidence that mobile deep-sleep handling is required even if
+/// the configuration files were unreadable or later change.
+#[cfg(test)]
+pub(crate) fn is_mobile_mode() -> bool {
     let state = gate();
-    matches!(state.decision, Some(DeepSleepDecision::Armed { .. })) || state.suspended_observed
+    matches!(state.mode, Some(DeepSleepMode::Mobile { .. })) || state.suspended_observed
 }
 
-/// True when GPU persistence mode must not be enabled: while armed it blocks
-/// runtime D3, and while the verdict is still unknown it could — an engine
-/// keeps the driver initialized through its own handles anyway, so
-/// suppressing it on an undecided machine costs nothing.
+/// True when eager attachment and long-lived GPU handles are unsafe. Unknown
+/// follows conservative Mobile behavior until detection resolves.
+pub fn protects_deep_sleep() -> bool {
+    let state = gate();
+    matches!(
+        state.mode,
+        Some(DeepSleepMode::Mobile { .. }) | Some(DeepSleepMode::Unknown { .. })
+    ) || state.suspended_observed
+}
+
+/// Only a definite Desktop mode may use eager startup.
+pub fn allows_desktop_autostart() -> bool {
+    let state = gate();
+    matches!(state.mode, Some(DeepSleepMode::Desktop { .. })) && !state.suspended_observed
+}
+
+/// Persistence mode blocks runtime D3, so Mobile and Unknown suppress it.
 pub fn suppress_persistence() -> bool {
-    let state = gate();
-    match &state.decision {
-        // Armed or still undecided: suppress.
-        Some(DeepSleepDecision::Armed { .. }) | Some(DeepSleepDecision::Unknown { .. }) => true,
-        // Decided desktop, or gate never evaluated (unreachable in the
-        // daemon, which always evaluates at startup): classic behavior,
-        // unless the GPU has proven it can suspend.
-        Some(DeepSleepDecision::Disabled { .. }) | None => state.suspended_observed,
-    }
-}
-
-pub fn current_decision() -> Option<DeepSleepDecision> {
-    gate().decision.clone()
-}
-
-pub fn pci_addr() -> Option<String> {
-    gate().pci_addr.clone()
+    protects_deep_sleep()
 }
 
 pub fn last_runtime_status() -> Option<RuntimePmStatus> {
     gate().last_runtime_status
 }
 
-/// Record a watcher observation. First `suspended` sighting arms the gate for
-/// the rest of the daemon's life (hardware proof beats config parsing).
-pub fn note_runtime_status(status: RuntimePmStatus) {
-    let mut state = gate();
+fn record_runtime_status(state: &mut GateState, status: RuntimePmStatus) {
     state.last_runtime_status = Some(status);
     if status == RuntimePmStatus::Suspended && !state.suspended_observed {
         state.suspended_observed = true;
-        if !matches!(state.decision, Some(DeepSleepDecision::Armed { .. })) {
-            logging::info("deep sleep gate: GPU observed suspended; arming deep-sleep handling");
+        if !matches!(state.mode, Some(DeepSleepMode::Mobile { .. })) {
+            logging::info("deep sleep mode: GPU observed suspended; selecting Mobile handling");
         }
     }
+}
+
+/// Record a watcher observation. First `suspended` sighting selects Mobile
+/// handling for the rest of the daemon's life (hardware proof beats parsing).
+#[cfg(test)]
+pub(crate) fn note_runtime_status(status: RuntimePmStatus) {
+    let mut state = gate();
+    record_runtime_status(&mut state, status);
 }
 
 pub fn set_autostart_deferred(deferred: bool) {
@@ -175,11 +193,11 @@ pub fn set_autostart_deferred(deferred: bool) {
 /// that build a bare supervisor never see the field).
 pub fn status() -> Option<DeepSleepStatus> {
     let state = gate();
-    let decision = state.decision.as_ref()?;
-    let armed =
-        matches!(decision, DeepSleepDecision::Armed { .. }) || state.suspended_observed;
-    let (reason, mode) = match decision {
-        DeepSleepDecision::Armed { fine_grained } => (
+    let detected_mode = state.mode.as_ref()?;
+    let mobile =
+        matches!(detected_mode, DeepSleepMode::Mobile { .. }) || state.suspended_observed;
+    let (reason, mode) = match detected_mode {
+        DeepSleepMode::Mobile { fine_grained } => (
             None,
             Some(
                 if *fine_grained {
@@ -190,15 +208,15 @@ pub fn status() -> Option<DeepSleepStatus> {
                 .to_string(),
             ),
         ),
-        DeepSleepDecision::Disabled { reason } | DeepSleepDecision::Unknown { reason } => {
+        DeepSleepMode::Desktop { reason } | DeepSleepMode::Unknown { reason } => {
             (Some((*reason).to_string()), None)
         }
     };
     Some(DeepSleepStatus {
-        state: if armed {
-            "armed".to_string()
-        } else if matches!(decision, DeepSleepDecision::Disabled { .. }) {
-            "disabled".to_string()
+        state: if mobile {
+            "mobile".to_string()
+        } else if matches!(detected_mode, DeepSleepMode::Desktop { .. }) {
+            "desktop".to_string()
         } else {
             "unknown".to_string()
         },
@@ -220,21 +238,80 @@ pub(crate) fn reset_for_test() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     /// The gate is process-global; serialize the tests that mutate it.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
-    fn sticky_suspended_observation_arms_the_gate() {
+    fn sticky_suspended_observation_selects_mobile_mode() {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
         reset_for_test();
-        assert!(!is_armed());
+        assert!(!is_mobile_mode());
         note_runtime_status(RuntimePmStatus::Active);
-        assert!(!is_armed());
+        assert!(!is_mobile_mode());
         note_runtime_status(RuntimePmStatus::Suspended);
-        assert!(is_armed());
+        assert!(is_mobile_mode());
         note_runtime_status(RuntimePmStatus::Active);
-        assert!(is_armed(), "suspended observation must be sticky");
+        assert!(is_mobile_mode(), "suspended observation must be sticky");
+        reset_for_test();
+    }
+
+    #[test]
+    fn absent_persisted_hint_stays_unknown_and_is_preserved() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        let root = tempfile::tempdir().expect("tempdir");
+        let probe = detect::Rtd3Probe::with_roots(
+            &root.path().join("sys"),
+            &root.path().join("proc"),
+        );
+
+        assert!(matches!(
+            evaluate(&probe, Some("00000000:01:00.0")),
+            DeepSleepMode::Unknown { .. }
+        ));
+        assert_eq!(
+            status().and_then(|status| status.pci_addr).as_deref(),
+            Some("0000:01:00.0")
+        );
+        assert!(protects_deep_sleep());
+        assert!(!allows_desktop_autostart());
+        reset_for_test();
+    }
+
+    #[test]
+    fn visible_nvidia_gpu_replaces_an_absent_persisted_hint() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        let root = tempfile::tempdir().expect("tempdir");
+        let addr = "0000:02:00.0";
+        let device = root.path().join("sys").join(addr);
+        fs::create_dir_all(device.join("power")).unwrap();
+        fs::write(device.join("vendor"), "0x10de\n").unwrap();
+        fs::write(device.join("class"), "0x030000\n").unwrap();
+        fs::write(device.join("power/control"), "auto\n").unwrap();
+        fs::write(device.join("power/runtime_status"), "active\n").unwrap();
+        let proc_gpu = root.path().join("proc").join(addr);
+        fs::create_dir_all(&proc_gpu).unwrap();
+        fs::write(
+            proc_gpu.join("power"),
+            "Runtime D3 status:          Enabled (fine-grained)\n",
+        )
+        .unwrap();
+        let probe = detect::Rtd3Probe::with_roots(
+            &root.path().join("sys"),
+            &root.path().join("proc"),
+        );
+
+        assert!(matches!(
+            evaluate(&probe, Some("00000000:01:00.0")),
+            DeepSleepMode::Mobile { .. }
+        ));
+        assert_eq!(
+            status().and_then(|status| status.pci_addr).as_deref(),
+            Some(addr)
+        );
         reset_for_test();
     }
 

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -160,6 +160,18 @@ pub fn suppress_persistence() -> bool {
     protects_deep_sleep()
 }
 
+/// True when the driver reports fine-grained runtime D3: it holds the GPU
+/// awake per submitted work, not per open fd, so a `/dev/nvidia<N>` holder is
+/// not evidence of use and the watcher must ask NVML for live contexts
+/// instead. Deliberately NOT satisfied by the sticky suspended-observed
+/// fallback — only the parsed driver report proves fine-grained semantics.
+pub fn fine_grained_mode() -> bool {
+    matches!(
+        gate().mode,
+        Some(DeepSleepMode::Mobile { fine_grained: true })
+    )
+}
+
 pub fn last_runtime_status() -> Option<RuntimePmStatus> {
     gate().last_runtime_status
 }
@@ -332,6 +344,48 @@ mod tests {
             status().and_then(|status| status.pci_addr).as_deref(),
             Some(addr)
         );
+        reset_for_test();
+    }
+
+    #[test]
+    fn fine_grained_mode_follows_the_parsed_driver_report_only() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        let root = tempfile::tempdir().expect("tempdir");
+        let addr = "0000:01:00.0";
+        let device = root.path().join("sys").join(addr);
+        fs::create_dir_all(device.join("power")).unwrap();
+        fs::write(device.join("vendor"), "0x10de\n").unwrap();
+        fs::write(device.join("class"), "0x030000\n").unwrap();
+        fs::write(device.join("power/control"), "auto\n").unwrap();
+        fs::write(device.join("power/runtime_status"), "active\n").unwrap();
+        let proc_gpu = root.path().join("proc").join(addr);
+        fs::create_dir_all(&proc_gpu).unwrap();
+        let probe = detect::Rtd3Probe::with_roots(
+            &root.path().join("sys"),
+            &root.path().join("proc"),
+        );
+
+        fs::write(
+            proc_gpu.join("power"),
+            "Runtime D3 status:          Enabled (fine-grained)\n",
+        )
+        .unwrap();
+        evaluate(&probe, None);
+        assert!(fine_grained_mode());
+
+        fs::write(
+            proc_gpu.join("power"),
+            "Runtime D3 status:          Enabled (coarse-grained)\n",
+        )
+        .unwrap();
+        evaluate(&probe, None);
+        assert!(!fine_grained_mode());
+        // The sticky suspended observation selects Mobile handling but must
+        // NOT claim fine-grained fd semantics.
+        note_runtime_status(RuntimePmStatus::Suspended);
+        assert!(is_mobile_mode());
+        assert!(!fine_grained_mode());
         reset_for_test();
     }
 

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -21,7 +21,7 @@ pub mod watch;
 
 use std::collections::HashSet;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use serde::Serialize;
 
@@ -202,7 +202,6 @@ struct GateState {
     runtime_status_since: Option<Instant>,
     runtime_active_ms: Option<u64>,
     runtime_suspended_ms: Option<u64>,
-    autosuspend_delay: Option<Duration>,
     suspended_observed: bool,
     autostart_deferred: bool,
     parked: bool,
@@ -216,7 +215,6 @@ static GATE: Mutex<GateState> = Mutex::new(GateState {
     runtime_status_since: None,
     runtime_active_ms: None,
     runtime_suspended_ms: None,
-    autosuspend_delay: None,
     suspended_observed: false,
     autostart_deferred: false,
     parked: false,
@@ -252,9 +250,6 @@ pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepM
     };
     let runtime_status = addr.as_deref().map(|addr| probe.runtime_pm_status(addr));
     let runtime_times = addr.as_deref().map(|addr| probe.runtime_pm_times(addr));
-    let autosuspend_delay = addr
-        .as_deref()
-        .and_then(|addr| probe.autosuspend_delay(addr));
     let mut state = gate();
     state.pci_addr = addr;
     if let Some(status) = runtime_status {
@@ -264,7 +259,6 @@ pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepM
         state.runtime_active_ms = active_ms;
         state.runtime_suspended_ms = suspended_ms;
     }
-    state.autosuspend_delay = autosuspend_delay;
     if state.mode.as_ref() != Some(&mode) {
         logging::info(&format!(
             "deep sleep mode: {} (gpu={})",
@@ -335,10 +329,6 @@ pub fn fine_grained_mode() -> bool {
 
 pub fn last_runtime_status() -> Option<RuntimePmStatus> {
     gate().last_runtime_status
-}
-
-pub(crate) fn autosuspend_delay() -> Option<Duration> {
-    gate().autosuspend_delay
 }
 
 fn record_runtime_status(state: &mut GateState, status: RuntimePmStatus) {

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -118,12 +118,32 @@ pub fn is_armed() -> bool {
     matches!(state.decision, Some(DeepSleepDecision::Armed { .. })) || state.suspended_observed
 }
 
+/// True when GPU persistence mode must not be enabled: while armed it blocks
+/// runtime D3, and while the verdict is still unknown it could — an engine
+/// keeps the driver initialized through its own handles anyway, so
+/// suppressing it on an undecided machine costs nothing.
+pub fn suppress_persistence() -> bool {
+    let state = gate();
+    match &state.decision {
+        // Armed or still undecided: suppress.
+        Some(DeepSleepDecision::Armed { .. }) | Some(DeepSleepDecision::Unknown { .. }) => true,
+        // Decided desktop, or gate never evaluated (unreachable in the
+        // daemon, which always evaluates at startup): classic behavior,
+        // unless the GPU has proven it can suspend.
+        Some(DeepSleepDecision::Disabled { .. }) | None => state.suspended_observed,
+    }
+}
+
 pub fn current_decision() -> Option<DeepSleepDecision> {
     gate().decision.clone()
 }
 
 pub fn pci_addr() -> Option<String> {
     gate().pci_addr.clone()
+}
+
+pub fn last_runtime_status() -> Option<RuntimePmStatus> {
+    gate().last_runtime_status
 }
 
 /// Record a watcher observation. First `suspended` sighting arms the gate for

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -1,0 +1,228 @@
+//! Deep-sleep (RTD3/D3cold) policy for hybrid laptops.
+//!
+//! On an RTD3-capable machine the daemon must not hold NVML or NVAPI handles
+//! while the dGPU is idle: any open `/dev/nvidia*` client pins the GPU in D0
+//! and defeats runtime suspend (issue #30). This module owns that policy:
+//!
+//! - `detect`: wake-free probes of the PCI sysfs tree and the NVIDIA procfs
+//!   `power` file, and the startup verdict (`DeepSleepDecision`).
+//! - `watch`: the startup supervisor that defers the persisted runtime while
+//!   the GPU sleeps, starts it when a real client wakes the GPU, and sweeps
+//!   idle RPC backends so a one-off telemetry query cannot pin the GPU.
+//! - the process-wide gate (this file): the cached verdict every attach point
+//!   consults, plus the `deep_sleep` block reported by `status`.
+//!
+//! Desktops resolve to `Disabled` and keep the classic always-attached
+//! behavior byte-for-byte.
+
+pub mod detect;
+pub mod watch;
+
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+use crate::logging;
+use detect::{DeepSleepDecision, RuntimePmStatus};
+
+/// The `deep_sleep` object in the `status` response. Field order is the wire
+/// contract (api.rs serializes structs in declaration order).
+#[derive(Debug, Clone, Serialize)]
+pub struct DeepSleepStatus {
+    /// "armed" | "disabled" | "unknown"
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// "fine-grained" | "coarse-grained" when armed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pci_addr: Option<String>,
+    /// Last observed kernel runtime-PM state ("suspended", "active", ...).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_status: Option<String>,
+    /// True while a persisted runtime exists but its start is held back
+    /// because the GPU is asleep.
+    pub autostart_deferred: bool,
+    /// True once the GPU has been seen suspended this daemon lifetime —
+    /// definitive evidence the platform can deep-sleep.
+    pub suspended_observed: bool,
+}
+
+#[derive(Default)]
+struct GateState {
+    decision: Option<DeepSleepDecision>,
+    pci_addr: Option<String>,
+    last_runtime_status: Option<RuntimePmStatus>,
+    suspended_observed: bool,
+    autostart_deferred: bool,
+}
+
+static GATE: Mutex<GateState> = Mutex::new(GateState {
+    decision: None,
+    pci_addr: None,
+    last_runtime_status: None,
+    suspended_observed: false,
+    autostart_deferred: false,
+});
+
+fn gate() -> std::sync::MutexGuard<'static, GateState> {
+    GATE.lock().unwrap_or_else(|poison| poison.into_inner())
+}
+
+/// Resolve the GPU address (persisted-spec hint first, then PCI enumeration)
+/// and store the startup verdict. Wake-free; call before any NVML init.
+pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepDecision {
+    let addr = pci_hint
+        .and_then(detect::sysfs_pci_addr)
+        .filter(|addr| probe.is_nvidia_gpu(addr))
+        .or_else(|| probe.first_nvidia_gpu_addr());
+    let decision = match &addr {
+        Some(addr) => detect::assess(probe, addr),
+        None => DeepSleepDecision::Disabled {
+            reason: "no NVIDIA display-class PCI device visible",
+        },
+    };
+    let mut state = gate();
+    state.pci_addr = addr;
+    if state.decision.as_ref() != Some(&decision) {
+        logging::info(&format!(
+            "deep sleep gate: {} (gpu={})",
+            describe(&decision),
+            state.pci_addr.as_deref().unwrap_or("unknown"),
+        ));
+    }
+    state.decision = Some(decision.clone());
+    decision
+}
+
+fn describe(decision: &DeepSleepDecision) -> String {
+    match decision {
+        DeepSleepDecision::Armed { fine_grained } => format!(
+            "armed ({} RTD3)",
+            if *fine_grained {
+                "fine-grained"
+            } else {
+                "coarse-grained"
+            }
+        ),
+        DeepSleepDecision::Disabled { reason } => format!("disabled: {reason}"),
+        DeepSleepDecision::Unknown { reason } => format!("undecided: {reason}"),
+    }
+}
+
+/// True when NVML/NVAPI handles must be treated as ephemeral. Sticky: a GPU
+/// observed suspended arms the gate even if the config files were unreadable.
+pub fn is_armed() -> bool {
+    let state = gate();
+    matches!(state.decision, Some(DeepSleepDecision::Armed { .. })) || state.suspended_observed
+}
+
+pub fn current_decision() -> Option<DeepSleepDecision> {
+    gate().decision.clone()
+}
+
+pub fn pci_addr() -> Option<String> {
+    gate().pci_addr.clone()
+}
+
+/// Record a watcher observation. First `suspended` sighting arms the gate for
+/// the rest of the daemon's life (hardware proof beats config parsing).
+pub fn note_runtime_status(status: RuntimePmStatus) {
+    let mut state = gate();
+    state.last_runtime_status = Some(status);
+    if status == RuntimePmStatus::Suspended && !state.suspended_observed {
+        state.suspended_observed = true;
+        if !matches!(state.decision, Some(DeepSleepDecision::Armed { .. })) {
+            logging::info("deep sleep gate: GPU observed suspended; arming deep-sleep handling");
+        }
+    }
+}
+
+pub fn set_autostart_deferred(deferred: bool) {
+    let mut state = gate();
+    if state.autostart_deferred != deferred {
+        state.autostart_deferred = deferred;
+        logging::info(if deferred {
+            "deep sleep: persisted runtime deferred until the GPU is in use"
+        } else {
+            "deep sleep: runtime deferral cleared"
+        });
+    }
+}
+
+/// The `deep_sleep` status block; `None` until `evaluate` has run (unit tests
+/// that build a bare supervisor never see the field).
+pub fn status() -> Option<DeepSleepStatus> {
+    let state = gate();
+    let decision = state.decision.as_ref()?;
+    let armed =
+        matches!(decision, DeepSleepDecision::Armed { .. }) || state.suspended_observed;
+    let (reason, mode) = match decision {
+        DeepSleepDecision::Armed { fine_grained } => (
+            None,
+            Some(
+                if *fine_grained {
+                    "fine-grained"
+                } else {
+                    "coarse-grained"
+                }
+                .to_string(),
+            ),
+        ),
+        DeepSleepDecision::Disabled { reason } | DeepSleepDecision::Unknown { reason } => {
+            (Some((*reason).to_string()), None)
+        }
+    };
+    Some(DeepSleepStatus {
+        state: if armed {
+            "armed".to_string()
+        } else if matches!(decision, DeepSleepDecision::Disabled { .. }) {
+            "disabled".to_string()
+        } else {
+            "unknown".to_string()
+        },
+        reason,
+        mode,
+        pci_addr: state.pci_addr.clone(),
+        runtime_status: state.last_runtime_status.map(|s| s.as_str().to_string()),
+        autostart_deferred: state.autostart_deferred,
+        suspended_observed: state.suspended_observed,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_test() {
+    let mut state = gate();
+    *state = GateState::default();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gate is process-global; serialize the tests that mutate it.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn sticky_suspended_observation_arms_the_gate() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        assert!(!is_armed());
+        note_runtime_status(RuntimePmStatus::Active);
+        assert!(!is_armed());
+        note_runtime_status(RuntimePmStatus::Suspended);
+        assert!(is_armed());
+        note_runtime_status(RuntimePmStatus::Active);
+        assert!(is_armed(), "suspended observation must be sticky");
+        reset_for_test();
+    }
+
+    #[test]
+    fn status_is_absent_until_evaluated() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+        reset_for_test();
+        assert!(status().is_none());
+        reset_for_test();
+    }
+}

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -102,6 +102,9 @@ pub struct GpuClientObservation {
     pub graphics: Vec<GpuClientProcess>,
     pub compute: Vec<GpuClientProcess>,
     pub device_node_holders: Vec<GpuClientProcess>,
+    /// Positively identified infrastructure helpers excluded from the verdict
+    /// in fine-grained mode, retained so status and logs explain the decision.
+    pub ignored_clients: Vec<GpuClientProcess>,
 }
 
 impl GpuClientObservation {
@@ -110,15 +113,31 @@ impl GpuClientObservation {
     /// definition of "decisive" — the watcher's verdict, the status block's
     /// `total_count`, and the journal line all derive from it.
     pub(crate) fn counted_pids(&self) -> HashSet<u32> {
-        let decisive: &[&[GpuClientProcess]] = match self.source {
-            GpuClientSource::NvmlContexts => &[&self.graphics, &self.compute],
-            GpuClientSource::DeviceNodes => &[&self.device_node_holders],
-        };
-        decisive
-            .iter()
-            .flat_map(|list| list.iter())
-            .map(|process| process.pid)
-            .collect()
+        match self.source {
+            // Context lists already contain only counted clients. If a
+            // contradictory ignored entry ever survives classification,
+            // fail closed: an explicitly counted context wins.
+            GpuClientSource::NvmlContexts => self
+                .graphics
+                .iter()
+                .chain(&self.compute)
+                .map(|process| process.pid)
+                .collect(),
+            // The fallback retains every observed holder for diagnostics and
+            // subtracts only the positively identified helper PIDs.
+            GpuClientSource::DeviceNodes => {
+                let ignored: HashSet<u32> = self
+                    .ignored_clients
+                    .iter()
+                    .map(|process| process.pid)
+                    .collect();
+                self.device_node_holders
+                    .iter()
+                    .filter(|process| !ignored.contains(&process.pid))
+                    .map(|process| process.pid)
+                    .collect()
+            }
+        }
     }
 
     /// True when the decision must treat the GPU as in use.
@@ -137,6 +156,7 @@ pub struct GpuClientsStatus {
     pub graphics_count: usize,
     pub compute_count: usize,
     pub device_node_count: usize,
+    pub ignored_count: usize,
     /// Unique PIDs the park/wake decision counted (the context lists under
     /// "nvml-contexts", the fd holders under "device-nodes"). Parking
     /// proceeds only while this stays 0.
@@ -146,6 +166,9 @@ pub struct GpuClientsStatus {
     pub age_s: f64,
     pub graphics: Vec<GpuClientProcess>,
     pub compute: Vec<GpuClientProcess>,
+    /// Infrastructure helpers observed but excluded from the fine-grained
+    /// client decision.
+    pub ignored_clients: Vec<GpuClientProcess>,
     /// Processes holding `/dev/nvidia<N>` open. Under fine-grained RTD3 this
     /// is informational: a holder with no live context does not keep the GPU
     /// awake and does not block parking.
@@ -158,10 +181,12 @@ fn gpu_clients_status(observation: &GpuClientObservation, observed_at: Instant) 
         graphics_count: observation.graphics.len(),
         compute_count: observation.compute.len(),
         device_node_count: observation.device_node_holders.len(),
+        ignored_count: observation.ignored_clients.len(),
         total_count: observation.counted_pids().len(),
         age_s: (observed_at.elapsed().as_secs_f64() * 1000.0).round() / 1000.0,
         graphics: observation.graphics.clone(),
         compute: observation.compute.clone(),
+        ignored_clients: observation.ignored_clients.clone(),
         device_node_holders: observation.device_node_holders.clone(),
     }
 }
@@ -402,7 +427,7 @@ fn describe_gpu_clients(observation: &GpuClientObservation) -> String {
         format!("{label}={} [{}]", processes.len(), entries.join(", "))
     }
     format!(
-        "deep sleep: gpu clients ({}): counted={} ({}), {}, {}, {}",
+        "deep sleep: gpu clients ({}): counted={} ({}), {}, {}, {}, {}",
         observation.source.as_str(),
         observation.counted_pids().len(),
         if observation.in_use() {
@@ -412,6 +437,10 @@ fn describe_gpu_clients(observation: &GpuClientObservation) -> String {
         },
         list("graphics", &observation.graphics),
         list("compute", &observation.compute),
+        list(
+            "ignored infrastructure helpers",
+            &observation.ignored_clients,
+        ),
         list("device-node holders", &observation.device_node_holders),
     )
 }
@@ -625,6 +654,7 @@ mod tests {
             graphics: vec![client(100, "gnome-shell"), client(200, "game")],
             compute: vec![client(200, "game"), client(300, "python3")],
             device_node_holders: vec![client(100, "gnome-shell"), client(999, "Xorg")],
+            ignored_clients: Vec::new(),
         };
         let stats = gpu_clients_status(&observation, Instant::now());
         assert_eq!(stats.source, "nvml-contexts");
@@ -640,12 +670,26 @@ mod tests {
             graphics: Vec::new(),
             compute: Vec::new(),
             device_node_holders: vec![client(999, "Xorg")],
+            ignored_clients: Vec::new(),
         };
         let stats = gpu_clients_status(&observation, Instant::now());
         assert_eq!(stats.source, "device-nodes");
         assert_eq!(stats.total_count, 1);
         assert_eq!(stats.graphics_count, 0);
         assert_eq!(stats.compute_count, 0);
+    }
+
+    #[test]
+    fn counted_context_wins_over_a_contradictory_ignored_entry() {
+        let observation = GpuClientObservation {
+            source: GpuClientSource::NvmlContexts,
+            graphics: vec![client(880, "nvidia-powerd")],
+            compute: Vec::new(),
+            device_node_holders: Vec::new(),
+            ignored_clients: vec![client(880, "nvidia-powerd")],
+        };
+        assert!(observation.in_use());
+        assert_eq!(observation.counted_pids(), HashSet::from([880]));
     }
 
     #[test]
@@ -661,11 +705,13 @@ mod tests {
                     name: None,
                 },
             ],
+            ignored_clients: Vec::new(),
         };
         assert_eq!(
             describe_gpu_clients(&observation),
             "deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), \
              graphics=1 [4242 some-game], compute=0, \
+             ignored infrastructure helpers=0, \
              device-node holders=2 [1450 plasmashell, 3117]"
         );
 
@@ -677,12 +723,14 @@ mod tests {
             graphics: Vec::new(),
             compute: Vec::new(),
             device_node_holders: vec![client(1450, "plasmashell")],
+            ignored_clients: Vec::new(),
         };
         assert!(!observation.in_use());
         assert_eq!(
             describe_gpu_clients(&observation),
             "deep sleep: gpu clients (nvml-contexts): counted=0 (idle), \
-             graphics=0, compute=0, device-node holders=1 [1450 plasmashell]"
+             graphics=0, compute=0, ignored infrastructure helpers=0, \
+             device-node holders=1 [1450 plasmashell]"
         );
     }
 
@@ -703,6 +751,7 @@ mod tests {
             graphics: Vec::new(),
             compute: Vec::new(),
             device_node_holders: vec![client(4242, "some-game")],
+            ignored_clients: Vec::new(),
         });
         let clients = status()
             .expect("evaluated")

--- a/burnerd/src/rtd3/mod.rs
+++ b/burnerd/src/rtd3/mod.rs
@@ -43,6 +43,14 @@ pub struct DeepSleepStatus {
     /// Last observed kernel runtime-PM state ("suspended", "active", ...).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_status: Option<String>,
+    /// Cumulative milliseconds the GPU has spent runtime-active since boot
+    /// (kernel counter, wake-free read). With `runtime_suspended_ms` this
+    /// quantifies how much the GPU actually sleeps.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_active_ms: Option<u64>,
+    /// Cumulative milliseconds runtime-suspended since boot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_suspended_ms: Option<u64>,
     /// True while a persisted runtime exists but its start is held back
     /// because the GPU is asleep.
     pub autostart_deferred: bool,
@@ -96,6 +104,29 @@ pub struct GpuClientObservation {
     pub device_node_holders: Vec<GpuClientProcess>,
 }
 
+impl GpuClientObservation {
+    /// The unique PIDs the park/wake decision counts: the context lists under
+    /// `NvmlContexts`, the fd holders under `DeviceNodes`. The single
+    /// definition of "decisive" — the watcher's verdict, the status block's
+    /// `total_count`, and the journal line all derive from it.
+    pub(crate) fn counted_pids(&self) -> HashSet<u32> {
+        let decisive: &[&[GpuClientProcess]] = match self.source {
+            GpuClientSource::NvmlContexts => &[&self.graphics, &self.compute],
+            GpuClientSource::DeviceNodes => &[&self.device_node_holders],
+        };
+        decisive
+            .iter()
+            .flat_map(|list| list.iter())
+            .map(|process| process.pid)
+            .collect()
+    }
+
+    /// True when the decision must treat the GPU as in use.
+    pub(crate) fn in_use(&self) -> bool {
+        !self.counted_pids().is_empty()
+    }
+}
+
 /// The `gpu_clients` object inside `deep_sleep`: the watcher's latest client
 /// sample, kept so someone debugging why the GPU does or does not park
 /// (issue #30) can see exactly what the daemon saw.
@@ -122,21 +153,12 @@ pub struct GpuClientsStatus {
 }
 
 fn gpu_clients_status(observation: &GpuClientObservation, observed_at: Instant) -> GpuClientsStatus {
-    let decisive: &[&[GpuClientProcess]] = match observation.source {
-        GpuClientSource::NvmlContexts => &[&observation.graphics, &observation.compute],
-        GpuClientSource::DeviceNodes => &[&observation.device_node_holders],
-    };
-    let counted: HashSet<u32> = decisive
-        .iter()
-        .flat_map(|list| list.iter())
-        .map(|process| process.pid)
-        .collect();
     GpuClientsStatus {
         source: observation.source.as_str().to_string(),
         graphics_count: observation.graphics.len(),
         compute_count: observation.compute.len(),
         device_node_count: observation.device_node_holders.len(),
-        total_count: counted.len(),
+        total_count: observation.counted_pids().len(),
         age_s: (observed_at.elapsed().as_secs_f64() * 1000.0).round() / 1000.0,
         graphics: observation.graphics.clone(),
         compute: observation.compute.clone(),
@@ -149,6 +171,11 @@ struct GateState {
     mode: Option<DeepSleepMode>,
     pci_addr: Option<String>,
     last_runtime_status: Option<RuntimePmStatus>,
+    /// When `last_runtime_status` last changed, so each transition line can
+    /// say how long the previous state was held.
+    runtime_status_since: Option<Instant>,
+    runtime_active_ms: Option<u64>,
+    runtime_suspended_ms: Option<u64>,
     suspended_observed: bool,
     autostart_deferred: bool,
     parked: bool,
@@ -159,6 +186,9 @@ static GATE: Mutex<GateState> = Mutex::new(GateState {
     mode: None,
     pci_addr: None,
     last_runtime_status: None,
+    runtime_status_since: None,
+    runtime_active_ms: None,
+    runtime_suspended_ms: None,
     suspended_observed: false,
     autostart_deferred: false,
     parked: false,
@@ -193,10 +223,15 @@ pub fn evaluate(probe: &detect::Rtd3Probe, pci_hint: Option<&str>) -> DeepSleepM
         },
     };
     let runtime_status = addr.as_deref().map(|addr| probe.runtime_pm_status(addr));
+    let runtime_times = addr.as_deref().map(|addr| probe.runtime_pm_times(addr));
     let mut state = gate();
     state.pci_addr = addr;
     if let Some(status) = runtime_status {
         record_runtime_status(&mut state, status);
+    }
+    if let Some((active_ms, suspended_ms)) = runtime_times {
+        state.runtime_active_ms = active_ms;
+        state.runtime_suspended_ms = suspended_ms;
     }
     if state.mode.as_ref() != Some(&mode) {
         logging::info(&format!(
@@ -271,6 +306,32 @@ pub fn last_runtime_status() -> Option<RuntimePmStatus> {
 }
 
 fn record_runtime_status(state: &mut GateState, status: RuntimePmStatus) {
+    // Transition line: the kernel-side timeline of the GPU's sleep. Emitted
+    // only when the state changes (the watcher re-reads at 1 Hz), with how
+    // long the previous state was held, so the journal shows exactly when
+    // the GPU suspended, when it woke, and how long each episode lasted.
+    match state.last_runtime_status {
+        Some(previous) if previous == status => {}
+        Some(previous) => {
+            let held = state
+                .runtime_status_since
+                .map(|since| format!(" ({} for {:.1}s)", previous.as_str(), since.elapsed().as_secs_f64()))
+                .unwrap_or_default();
+            logging::info(&format!(
+                "deep sleep: runtime_status {} -> {}{held}",
+                previous.as_str(),
+                status.as_str(),
+            ));
+            state.runtime_status_since = Some(Instant::now());
+        }
+        None => {
+            logging::info(&format!(
+                "deep sleep: runtime_status {} (initial)",
+                status.as_str()
+            ));
+            state.runtime_status_since = Some(Instant::now());
+        }
+    }
     state.last_runtime_status = Some(status);
     if status == RuntimePmStatus::Suspended && !state.suspended_observed {
         state.suspended_observed = true;
@@ -322,10 +383,10 @@ pub(crate) fn record_gpu_clients(observation: GpuClientObservation) {
     state.gpu_clients = Some((observation, Instant::now()));
 }
 
-/// One journal line naming every sampled process with its count per list,
-/// e.g. `deep sleep: gpu clients (nvml-contexts): graphics=1 [4242
-/// some-game], compute=0, device-node holders=2 [1450 plasmashell, 3117
-/// vkcube]`.
+/// One journal line carrying the decision verdict plus every sampled process
+/// with its count per list, e.g. `deep sleep: gpu clients (nvml-contexts):
+/// counted=1 (GPU in use), graphics=1 [4242 some-game], compute=0,
+/// device-node holders=2 [1450 plasmashell, 3117 vkcube]`.
 fn describe_gpu_clients(observation: &GpuClientObservation) -> String {
     fn list(label: &str, processes: &[GpuClientProcess]) -> String {
         if processes.is_empty() {
@@ -341,8 +402,14 @@ fn describe_gpu_clients(observation: &GpuClientObservation) -> String {
         format!("{label}={} [{}]", processes.len(), entries.join(", "))
     }
     format!(
-        "deep sleep: gpu clients ({}): {}, {}, {}",
+        "deep sleep: gpu clients ({}): counted={} ({}), {}, {}, {}",
         observation.source.as_str(),
+        observation.counted_pids().len(),
+        if observation.in_use() {
+            "GPU in use"
+        } else {
+            "idle"
+        },
         list("graphics", &observation.graphics),
         list("compute", &observation.compute),
         list("device-node holders", &observation.device_node_holders),
@@ -396,6 +463,8 @@ pub fn status() -> Option<DeepSleepStatus> {
         mode,
         pci_addr: state.pci_addr.clone(),
         runtime_status: state.last_runtime_status.map(|s| s.as_str().to_string()),
+        runtime_active_ms: state.runtime_active_ms,
+        runtime_suspended_ms: state.runtime_suspended_ms,
         autostart_deferred: state.autostart_deferred,
         suspended_observed: state.suspended_observed,
         parked: state.parked,
@@ -595,8 +664,25 @@ mod tests {
         };
         assert_eq!(
             describe_gpu_clients(&observation),
-            "deep sleep: gpu clients (nvml-contexts): graphics=1 [4242 some-game], \
-             compute=0, device-node holders=2 [1450 plasmashell, 3117]"
+            "deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), \
+             graphics=1 [4242 some-game], compute=0, \
+             device-node holders=2 [1450 plasmashell, 3117]"
+        );
+
+        // Fine-grained with only fd holders: counted=0 reads as idle even
+        // though the holder list is not empty — the line itself explains a
+        // park that happens under a running desktop shell.
+        let observation = GpuClientObservation {
+            source: GpuClientSource::NvmlContexts,
+            graphics: Vec::new(),
+            compute: Vec::new(),
+            device_node_holders: vec![client(1450, "plasmashell")],
+        };
+        assert!(!observation.in_use());
+        assert_eq!(
+            describe_gpu_clients(&observation),
+            "deep sleep: gpu clients (nvml-contexts): counted=0 (idle), \
+             graphics=0, compute=0, device-node holders=1 [1450 plasmashell]"
         );
     }
 

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -27,24 +27,26 @@
 //! live graphics/compute contexts instead. A root-owned `nvidia-powerd`
 //! context is reported but excluded: Dynamic Boost is driver infrastructure,
 //! and a real workload alongside it still has its own counted context. The
-//! watcher falls back to the fd scan only when the context query fails (driver
-//! too old for the _v3 symbols, no backend), applying the same narrow helper
-//! exclusion in confirmed fine-grained mode.
+//! context query owns one short-lived NVML-only session and closes it before
+//! returning. An idle result starts a wake-free quiet interval so observation
+//! cannot become a self-sustaining one-second GPU hold; a changed numbered-node
+//! holder set re-arms the query for a newly arrived workload.
+//! The watcher falls back to the fd scan only when the context query fails
+//! (driver too old for the _v3 symbols, no backend), applying the same narrow
+//! helper exclusion in confirmed fine-grained mode.
 //! While protected it also drops idle RPC backends so a one-off GUI telemetry
 //! query cannot pin NVML forever.
 
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::gpu_rpc;
 use crate::logging;
 use crate::supervisor::{self, Supervisor};
 
+use super::clients::{ClientDetector, ClientPhase, ClientTick, ClientVerdict};
 use super::detect::{Rtd3Probe, RuntimePmStatus};
-use super::{GpuClientObservation, GpuClientProcess, GpuClientSource};
 
 const MOBILE_TICK: Duration = Duration::from_secs(1);
 /// Cadence in Desktop mode: re-evaluate in case the user enables runtime PM.
@@ -154,6 +156,7 @@ fn watch_loop(
     mut desktop_autostart_attempted: bool,
 ) {
     let mut tick_state = TickState::default();
+    let mut clients = ClientDetector::system();
 
     loop {
         super::evaluate(probe, hint);
@@ -165,11 +168,12 @@ fn watch_loop(
                     "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
                 ));
             }
-            mobile_tick(sup, &mut tick_state);
+            mobile_tick(sup, &mut tick_state, &mut clients);
             thread::sleep(MOBILE_TICK);
             continue;
         }
 
+        clients.reset();
         super::set_autostart_deferred(false);
         if !desktop_autostart_attempted && super::allows_desktop_autostart() {
             // Detection resolved from Unknown to Desktop after boot: make the
@@ -184,11 +188,16 @@ fn watch_loop(
 /// One Mobile/Unknown observation tick: hold the deferred runtime back until
 /// the GPU is genuinely in use, park an attached-but-idle runtime so the GPU
 /// can suspend, and never fight another GPU owner.
-fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
+fn mobile_tick(
+    sup: &Arc<Mutex<Supervisor>>,
+    state: &mut TickState,
+    clients: &mut ClientDetector,
+) {
     // A scan/verification child owns the GPU exclusively; its own
     // `/dev/nvidia*` fds and activity must never satisfy the start policy —
     // starting the engine here would race the child's raw GPU writes.
     if supervisor::active_child_kind(sup).is_some() {
+        clients.reset();
         super::set_autostart_deferred(false);
         state.reset_wake_episode();
         state.abandon_countdown("a scan/verification child took the GPU");
@@ -208,52 +217,27 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
             // GPU for the whole window, release it: the profile stays a
             // standing intent (persisted state kept) and reapplies at the
             // next real use.
-            if gpu_in_use_by_client(supervisor::profile_gpu_index(sup)) {
-                if state.idle_ticks > 0 {
-                    logging::info(&format!(
-                        "deep sleep: park countdown reset after {}s: a GPU client appeared",
-                        state.idle_ticks
-                    ));
-                }
-                state.end_countdown();
-            } else {
-                state.idle_ticks += 1;
-                if state.idle_ticks == 1 && !state.countdown_announced {
-                    state.countdown_announced = true;
-                    // Remaining time, not the window size: this tick already
-                    // counted, so the park lands threshold-1 seconds after
-                    // this line's own timestamp.
-                    logging::info(&format!(
-                        "deep sleep: no GPU clients; parking the runtime in {}s unless one appears",
-                        park_after_idle_ticks() - state.idle_ticks
-                    ));
-                }
-                if state.idle_ticks >= park_after_idle_ticks() {
-                    state.idle_ticks = 0;
-                    logging::info(
-                        "deep sleep: no GPU clients for the idle window; parking the runtime",
-                    );
-                    if supervisor::park_runtime_for_deep_sleep(sup) {
-                        state.end_countdown();
-                        // Deferral first: the moment `parked` becomes
-                        // visible, the status block must already say the
-                        // runtime will reapply. In the other order a status
-                        // read can land between the two gate writes (the
-                        // deferral check reads spec files) and see a parked
-                        // runtime that claims it will not come back.
-                        super::set_autostart_deferred(wakeable_runtime_pending());
-                        super::set_parked(true);
-                    } else if !state.park_refusal_logged {
-                        // Once per client-free stretch: without this line a
-                        // refused park (game session owns the runtime, or
-                        // the engine did not stop in time) reads as a
-                        // countdown that silently went nowhere, repeating
-                        // every window.
-                        state.park_refusal_logged = true;
-                        logging::info(
-                            "deep sleep: park refused (a game session owns the runtime or the engine did not stop); retrying every idle window",
-                        );
+            match client_verdict(
+                clients,
+                ClientPhase::Attached,
+                supervisor::profile_gpu_index(sup),
+            ) {
+                ClientVerdict::Busy(observation) => {
+                    super::record_gpu_clients(observation);
+                    if state.idle_ticks > 0 {
+                        logging::info(&format!(
+                            "deep sleep: park countdown reset after {}s: a GPU client appeared",
+                            state.idle_ticks
+                        ));
                     }
+                    state.end_countdown();
+                }
+                ClientVerdict::Idle(observation) => {
+                    super::record_gpu_clients(observation);
+                    advance_park_countdown(sup, state);
+                }
+                ClientVerdict::Pending => {
+                    state.abandon_countdown("a safe GPU-client observation is pending");
                 }
             }
         } else {
@@ -266,6 +250,7 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
     let pending = wakeable_runtime_pending();
     super::set_autostart_deferred(pending);
     if !pending {
+        clients.reset();
         state.reset_wake_episode();
         return;
     }
@@ -284,23 +269,80 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
         );
     }
     if state.active_ticks >= SUSTAINED_ACTIVE_TICKS && !state.start_attempted {
-        if gpu_in_use_by_client(supervisor::deferred_runtime_gpu_index()) {
-            logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
-            if supervisor::start_autostart_if_configured(sup) {
-                state.start_attempted = true;
-                super::set_autostart_deferred(false);
-                super::set_parked(false);
+        match client_verdict(
+            clients,
+            ClientPhase::Deferred,
+            supervisor::deferred_runtime_gpu_index(),
+        ) {
+            ClientVerdict::Busy(observation) => {
+                super::record_gpu_clients(observation);
+                logging::info(
+                    "deep sleep: GPU is in use; starting the deferred persisted runtime",
+                );
+                if supervisor::start_autostart_if_configured(sup) {
+                    state.start_attempted = true;
+                    super::set_autostart_deferred(false);
+                    super::set_parked(false);
+                }
             }
-        } else if state.woke_from_suspend && !state.transient_wake_logged {
-            // Once per genuine wake episode: the GPU came out of suspend but
-            // nothing holds a counted client, so the runtime stays deferred.
-            // This is the journal's answer to "the GPU woke up — why didn't
-            // the profile apply?": a capability probe, not use.
-            state.transient_wake_logged = true;
-            logging::info(
-                "deep sleep: GPU awake but no counted clients; keeping the runtime deferred (transient wake?)",
-            );
+            ClientVerdict::Idle(observation) => {
+                super::record_gpu_clients(observation);
+                if state.woke_from_suspend && !state.transient_wake_logged {
+                    // Once per genuine wake episode: the GPU came out of
+                    // suspend but nothing holds a counted client, so the
+                    // runtime stays deferred.
+                    state.transient_wake_logged = true;
+                    logging::info(
+                        "deep sleep: GPU awake but no counted clients; keeping the runtime deferred (transient wake?)",
+                    );
+                }
+            }
+            ClientVerdict::Pending => {}
         }
+    }
+}
+
+fn client_verdict(
+    detector: &mut ClientDetector,
+    phase: ClientPhase,
+    gpu_index: Option<u32>,
+) -> ClientVerdict {
+    detector.tick(ClientTick {
+        phase,
+        gpu_index,
+        fine_grained: super::fine_grained_mode(),
+        runtime_status: super::last_runtime_status(),
+        autosuspend_delay: super::autosuspend_delay(),
+        now: Instant::now(),
+    })
+}
+
+fn advance_park_countdown(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
+    state.idle_ticks += 1;
+    if state.idle_ticks == 1 && !state.countdown_announced {
+        state.countdown_announced = true;
+        logging::info(&format!(
+            "deep sleep: no GPU clients; parking the runtime in {}s unless one appears",
+            park_after_idle_ticks() - state.idle_ticks
+        ));
+    }
+    if state.idle_ticks < park_after_idle_ticks() {
+        return;
+    }
+
+    state.idle_ticks = 0;
+    logging::info("deep sleep: no GPU clients for the idle window; parking the runtime");
+    if supervisor::park_runtime_for_deep_sleep(sup) {
+        state.end_countdown();
+        // Deferral first: a visible parked runtime must already say it will
+        // reapply at the next real use.
+        super::set_autostart_deferred(wakeable_runtime_pending());
+        super::set_parked(true);
+    } else if !state.park_refusal_logged {
+        state.park_refusal_logged = true;
+        logging::info(
+            "deep sleep: park refused (a game session owns the runtime or the engine did not stop); retrying every idle window",
+        );
     }
 }
 
@@ -310,302 +352,4 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
 fn wakeable_runtime_pending() -> bool {
     supervisor::deferred_runtime_pending()
         && supervisor::deferred_runtime_mode().as_deref() != Some("stock")
-}
-
-/// True when another process is really using the GPU (the mode-aware client
-/// signal described in the module docs). Only called while the GPU is already
-/// awake — an attached engine (park check) or sustained `active` (wake check)
-/// — so the fine-grained NVML query never wakes a sleeping GPU; the registry
-/// backend it opens is swept by `release_idle_backends` once the checks stop.
-///
-/// Every call records the full sample (per-kind context holders AND
-/// device-node holders, with process names) as the `deep_sleep.gpu_clients`
-/// status block, so someone debugging a park that does or does not happen
-/// can see exactly the evidence the decision used.
-fn gpu_in_use_by_client(gpu_index: Option<u32>) -> bool {
-    let proc_root = client_proc_root();
-    let self_pid = std::process::id();
-    // Sampled even when the decision ignores it: a shell holding
-    // `/dev/nvidia0` open while the context lists stay empty is precisely
-    // what explains a fine-grained park to a reader of the status block.
-    let mut observation = GpuClientObservation {
-        source: GpuClientSource::DeviceNodes,
-        graphics: Vec::new(),
-        compute: Vec::new(),
-        device_node_holders: nvidia_device_node_holders_in(&proc_root, self_pid),
-        ignored_clients: Vec::new(),
-    };
-    if super::fine_grained_mode() {
-        if let Some(index) = gpu_index {
-            match gpu_rpc::context_pids(index) {
-                Ok(contexts) => {
-                    observation.source = GpuClientSource::NvmlContexts;
-                    let (graphics, compute, ignored) = classified_context_processes(
-                        &proc_root,
-                        &contexts.graphics,
-                        &contexts.compute,
-                        self_pid,
-                    );
-                    observation.graphics = graphics;
-                    observation.compute = compute;
-                    observation.ignored_clients = ignored;
-                }
-                Err(error) => {
-                    log_context_query_fallback(&error);
-                    observation.ignored_clients = ignored_powerd_processes(
-                        &proc_root,
-                        &observation.device_node_holders,
-                    );
-                }
-            }
-        }
-    }
-    // The verdict, the status block's `total_count`, and the journal line all
-    // come from the same `counted_pids` definition, so they can never
-    // disagree about who was counted.
-    let in_use = observation.in_use();
-    super::record_gpu_clients(observation);
-    in_use
-}
-
-/// The NVML-context fallback is a per-boot property (old driver, missing
-/// symbols); log it once, not at 1 Hz.
-fn log_context_query_fallback(error: &str) {
-    static LOGGED: std::sync::Once = std::sync::Once::new();
-    LOGGED.call_once(|| {
-        logging::info(&format!(
-            "deep sleep: NVML context query unavailable ({error}); using the device-node scan"
-        ));
-    });
-}
-
-/// The proc tree the client scan and name lookups read. Test seam (never set
-/// in production): `PENGUIN_BURNERD_TEST_CLIENT_PROC` points at a fake proc
-/// tree so integration tests can stage and remove GPU clients
-/// deterministically on any machine.
-fn client_proc_root() -> PathBuf {
-    std::env::var_os("PENGUIN_BURNERD_TEST_CLIENT_PROC")
-        .filter(|v| !v.is_empty())
-        .map_or_else(|| PathBuf::from("/proc"), PathBuf::from)
-}
-
-/// Resolve each unique context PID through procfs exactly once, dropping the
-/// daemon itself and partitioning the one narrowly approved fine-grained
-/// infrastructure helper from clients that decide park/wake behavior.
-fn classified_context_processes(
-    proc_root: &Path,
-    graphics_pids: &[u32],
-    compute_pids: &[u32],
-    self_pid: u32,
-) -> (
-    Vec<GpuClientProcess>,
-    Vec<GpuClientProcess>,
-    Vec<GpuClientProcess>,
-) {
-    let mut unique_pids: Vec<u32> = graphics_pids
-        .iter()
-        .chain(compute_pids)
-        .copied()
-        .filter(|pid| *pid != self_pid)
-        .collect();
-    unique_pids.sort_unstable();
-    unique_pids.dedup();
-
-    let mut counted = Vec::new();
-    let mut ignored = Vec::new();
-    for pid in unique_pids {
-        let name = process_name(proc_root, pid);
-        let process = GpuClientProcess { pid, name };
-        if is_root_nvidia_powerd(proc_root, &process) {
-            ignored.push(process);
-        } else {
-            counted.push(process);
-        }
-    }
-    let graphics = counted
-        .iter()
-        .filter(|process| graphics_pids.contains(&process.pid))
-        .cloned()
-        .collect();
-    let compute = counted
-        .iter()
-        .filter(|process| compute_pids.contains(&process.pid))
-        .cloned()
-        .collect();
-    (graphics, compute, ignored)
-}
-
-/// Process name from `<proc_root>/<pid>/comm`; `None` once the process is
-/// gone. Pure procfs read — never touches the GPU.
-fn process_name(proc_root: &Path, pid: u32) -> Option<String> {
-    let comm = fs::read_to_string(proc_root.join(pid.to_string()).join("comm")).ok()?;
-    // procfs terminates `comm` with exactly one newline. Preserve every byte
-    // of the process name itself so the infrastructure exception is an exact
-    // match rather than a whitespace-normalized one.
-    let name = comm.strip_suffix('\n').unwrap_or(&comm);
-    (!name.is_empty()).then(|| name.to_string())
-}
-
-/// Effective UID from `/proc/<pid>/status`. Missing or malformed process
-/// metadata returns `None`, so callers retain the candidate conservatively.
-fn process_effective_uid(proc_root: &Path, pid: u32) -> Option<u32> {
-    let status = fs::read_to_string(proc_root.join(pid.to_string()).join("status")).ok()?;
-    let mut records = status.lines().filter_map(|line| line.strip_prefix("Uid:"));
-    let record = records.next()?;
-    if records.next().is_some() {
-        return None;
-    }
-    let mut fields = record.split_whitespace();
-    let _real: u32 = fields.next()?.parse().ok()?;
-    let effective: u32 = fields.next()?.parse().ok()?;
-    let _saved: u32 = fields.next()?.parse().ok()?;
-    let _filesystem: u32 = fields.next()?.parse().ok()?;
-    if fields.next().is_some() {
-        return None;
-    }
-    Some(effective)
-}
-
-/// The one approved fine-grained infrastructure exception. Keep the exact
-/// name and root-identity requirements in one predicate so the NVML and
-/// device-node fallback paths cannot drift.
-fn is_root_nvidia_powerd(proc_root: &Path, process: &GpuClientProcess) -> bool {
-    process.name.as_deref() == Some("nvidia-powerd")
-        && process_effective_uid(proc_root, process.pid) == Some(0)
-}
-
-/// Positively identify the Dynamic Boost helper among an already resolved
-/// process list. Used by the fine-grained device-node fallback; coarse and
-/// unknown modes never call this exclusion.
-fn ignored_powerd_processes(
-    proc_root: &Path,
-    processes: &[GpuClientProcess],
-) -> Vec<GpuClientProcess> {
-    processes
-        .iter()
-        .filter(|process| is_root_nvidia_powerd(proc_root, process))
-        .cloned()
-        .collect()
-}
-
-/// Only the numbered render nodes count as a real GPU client. `nvidiactl`,
-/// `nvidia-uvm*`, `nvidia-modeset`, and `nvidia-caps/*` are held long-lived
-/// by monitoring/container tooling without keeping an RTD3 GPU awake.
-fn is_nvidia_device_node(target: &str) -> bool {
-    target
-        .strip_prefix("/dev/nvidia")
-        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
-}
-
-/// Every process other than the daemon holding a `/dev/nvidia<N>` fd, with
-/// names — pure procfs reads, never touches the device. Root sees every
-/// process. Sorted by PID so repeated status reads stay stable.
-fn nvidia_device_node_holders_in(
-    proc_root: impl AsRef<Path>,
-    self_pid: u32,
-) -> Vec<GpuClientProcess> {
-    let proc_root = proc_root.as_ref();
-    let mut holders = Vec::new();
-    let Ok(entries) = fs::read_dir(proc_root) else {
-        return holders;
-    };
-    for entry in entries.filter_map(Result::ok) {
-        let name = entry.file_name();
-        let Some(pid) = name.to_str().and_then(|n| n.parse::<u32>().ok()) else {
-            continue;
-        };
-        if pid == self_pid {
-            continue;
-        }
-        let Ok(fds) = fs::read_dir(entry.path().join("fd")) else {
-            continue;
-        };
-        let holds_device_node = fds.filter_map(Result::ok).any(|fd| {
-            fs::read_link(fd.path())
-                .is_ok_and(|target| is_nvidia_device_node(&target.to_string_lossy()))
-        });
-        if holds_device_node {
-            holders.push(GpuClientProcess {
-                pid,
-                name: process_name(proc_root, pid),
-            });
-        }
-    }
-    holders.sort_unstable_by_key(|process| process.pid);
-    holders
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::os::unix::fs::symlink;
-
-    #[test]
-    fn only_numbered_device_nodes_count_as_clients() {
-        assert!(is_nvidia_device_node("/dev/nvidia0"));
-        assert!(is_nvidia_device_node("/dev/nvidia12"));
-        assert!(!is_nvidia_device_node("/dev/nvidiactl"));
-        assert!(!is_nvidia_device_node("/dev/nvidia-uvm"));
-        assert!(!is_nvidia_device_node("/dev/nvidia-uvm-tools"));
-        assert!(!is_nvidia_device_node("/dev/nvidia-modeset"));
-        assert!(!is_nvidia_device_node("/dev/nvidia-caps/nvidia-cap1"));
-        assert!(!is_nvidia_device_node("/dev/nvidia"));
-        assert!(!is_nvidia_device_node("/dev/dri/renderD128"));
-    }
-
-    #[test]
-    fn collects_nvidia_fd_holders_with_names_and_skips_self() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let fd_dir = root.path().join("4242").join("fd");
-        fs::create_dir_all(&fd_dir).unwrap();
-        symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
-        fs::write(root.path().join("4242").join("comm"), "some-game\n").unwrap();
-        // A holder whose comm is unreadable still appears, without a name.
-        let anon_fd_dir = root.path().join("77").join("fd");
-        fs::create_dir_all(&anon_fd_dir).unwrap();
-        symlink("/dev/nvidia1", anon_fd_dir.join("3")).unwrap();
-        fs::create_dir_all(root.path().join("not-a-pid")).unwrap();
-
-        let holders = nvidia_device_node_holders_in(root.path(), 1);
-        assert_eq!(holders.len(), 2);
-        assert_eq!(holders[0].pid, 77);
-        assert_eq!(holders[0].name, None);
-        assert_eq!(holders[1].pid, 4242);
-        assert_eq!(holders[1].name.as_deref(), Some("some-game"));
-        // The daemon's own fds never count as a client.
-        let holders = nvidia_device_node_holders_in(root.path(), 4242);
-        assert_eq!(holders.len(), 1);
-        assert_eq!(holders[0].pid, 77);
-    }
-
-    #[test]
-    fn auxiliary_nvidia_nodes_are_not_clients() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let fd_dir = root.path().join("100").join("fd");
-        fs::create_dir_all(&fd_dir).unwrap();
-        symlink("/dev/nvidiactl", fd_dir.join("3")).unwrap();
-        symlink("/dev/nvidia-uvm", fd_dir.join("4")).unwrap();
-        symlink("/dev/dri/renderD128", fd_dir.join("5")).unwrap();
-        assert!(nvidia_device_node_holders_in(root.path(), 1).is_empty());
-    }
-
-    #[test]
-    fn classified_context_processes_resolve_comm_once_and_drop_the_daemon() {
-        let root = tempfile::tempdir().expect("tempdir");
-        fs::create_dir_all(root.path().join("123")).unwrap();
-        fs::write(root.path().join("123").join("comm"), "cuda-worker\n").unwrap();
-
-        let (graphics, compute, ignored) =
-            classified_context_processes(root.path(), &[123, 456, 999], &[123], 456);
-        assert!(ignored.is_empty());
-        assert_eq!(graphics.len(), 2);
-        assert_eq!(graphics[0].pid, 123);
-        assert_eq!(graphics[0].name.as_deref(), Some("cuda-worker"));
-        // A PID that exited between the NVML query and the lookup keeps its
-        // entry so the counts stay honest, just without a name.
-        assert_eq!(graphics[1].pid, 999);
-        assert_eq!(graphics[1].name, None);
-        // A PID present in both context kinds shares the one classification.
-        assert_eq!(compute, vec![graphics[0].clone()]);
-    }
 }

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -24,8 +24,12 @@
 //! desktop shells and monitoring agents hold the render node open for hours
 //! while the GPU sleeps — so an fd holder proves nothing, and treating it as
 //! use would starve the park policy forever. There the watcher asks NVML for
-//! live graphics/compute contexts instead, falling back to the fd scan only
-//! when that query fails (driver too old for the _v3 symbols, no backend).
+//! live graphics/compute contexts instead. A root-owned `nvidia-powerd`
+//! context is reported but excluded: Dynamic Boost is driver infrastructure,
+//! and a real workload alongside it still has its own counted context. The
+//! watcher falls back to the fd scan only when the context query fails (driver
+//! too old for the _v3 symbols, no backend), applying the same narrow helper
+//! exclusion in confirmed fine-grained mode.
 //! While protected it also drops idle RPC backends so a one-off GUI telemetry
 //! query cannot pin NVML forever.
 
@@ -329,16 +333,30 @@ fn gpu_in_use_by_client(gpu_index: Option<u32>) -> bool {
         graphics: Vec::new(),
         compute: Vec::new(),
         device_node_holders: nvidia_device_node_holders_in(&proc_root, self_pid),
+        ignored_clients: Vec::new(),
     };
     if super::fine_grained_mode() {
         if let Some(index) = gpu_index {
             match gpu_rpc::context_pids(index) {
                 Ok(contexts) => {
                     observation.source = GpuClientSource::NvmlContexts;
-                    observation.graphics = named_processes(&proc_root, &contexts.graphics, self_pid);
-                    observation.compute = named_processes(&proc_root, &contexts.compute, self_pid);
+                    let (graphics, compute, ignored) = classified_context_processes(
+                        &proc_root,
+                        &contexts.graphics,
+                        &contexts.compute,
+                        self_pid,
+                    );
+                    observation.graphics = graphics;
+                    observation.compute = compute;
+                    observation.ignored_clients = ignored;
                 }
-                Err(error) => log_context_query_fallback(&error),
+                Err(error) => {
+                    log_context_query_fallback(&error);
+                    observation.ignored_clients = ignored_powerd_processes(
+                        &proc_root,
+                        &observation.device_node_holders,
+                    );
+                }
             }
         }
     }
@@ -371,25 +389,103 @@ fn client_proc_root() -> PathBuf {
         .map_or_else(|| PathBuf::from("/proc"), PathBuf::from)
 }
 
-/// Resolve `/proc/<pid>/comm` names for context PIDs, dropping the daemon's
-/// own PID so the lists match what the park/wake decision counts.
-fn named_processes(proc_root: &Path, pids: &[u32], self_pid: u32) -> Vec<GpuClientProcess> {
-    pids.iter()
+/// Resolve each unique context PID through procfs exactly once, dropping the
+/// daemon itself and partitioning the one narrowly approved fine-grained
+/// infrastructure helper from clients that decide park/wake behavior.
+fn classified_context_processes(
+    proc_root: &Path,
+    graphics_pids: &[u32],
+    compute_pids: &[u32],
+    self_pid: u32,
+) -> (
+    Vec<GpuClientProcess>,
+    Vec<GpuClientProcess>,
+    Vec<GpuClientProcess>,
+) {
+    let mut unique_pids: Vec<u32> = graphics_pids
+        .iter()
+        .chain(compute_pids)
         .copied()
         .filter(|pid| *pid != self_pid)
-        .map(|pid| GpuClientProcess {
-            pid,
-            name: process_name(proc_root, pid),
-        })
-        .collect()
+        .collect();
+    unique_pids.sort_unstable();
+    unique_pids.dedup();
+
+    let mut counted = Vec::new();
+    let mut ignored = Vec::new();
+    for pid in unique_pids {
+        let name = process_name(proc_root, pid);
+        let process = GpuClientProcess { pid, name };
+        if is_root_nvidia_powerd(proc_root, &process) {
+            ignored.push(process);
+        } else {
+            counted.push(process);
+        }
+    }
+    let graphics = counted
+        .iter()
+        .filter(|process| graphics_pids.contains(&process.pid))
+        .cloned()
+        .collect();
+    let compute = counted
+        .iter()
+        .filter(|process| compute_pids.contains(&process.pid))
+        .cloned()
+        .collect();
+    (graphics, compute, ignored)
 }
 
 /// Process name from `<proc_root>/<pid>/comm`; `None` once the process is
 /// gone. Pure procfs read — never touches the GPU.
 fn process_name(proc_root: &Path, pid: u32) -> Option<String> {
     let comm = fs::read_to_string(proc_root.join(pid.to_string()).join("comm")).ok()?;
-    let name = comm.trim();
+    // procfs terminates `comm` with exactly one newline. Preserve every byte
+    // of the process name itself so the infrastructure exception is an exact
+    // match rather than a whitespace-normalized one.
+    let name = comm.strip_suffix('\n').unwrap_or(&comm);
     (!name.is_empty()).then(|| name.to_string())
+}
+
+/// Effective UID from `/proc/<pid>/status`. Missing or malformed process
+/// metadata returns `None`, so callers retain the candidate conservatively.
+fn process_effective_uid(proc_root: &Path, pid: u32) -> Option<u32> {
+    let status = fs::read_to_string(proc_root.join(pid.to_string()).join("status")).ok()?;
+    let mut records = status.lines().filter_map(|line| line.strip_prefix("Uid:"));
+    let record = records.next()?;
+    if records.next().is_some() {
+        return None;
+    }
+    let mut fields = record.split_whitespace();
+    let _real: u32 = fields.next()?.parse().ok()?;
+    let effective: u32 = fields.next()?.parse().ok()?;
+    let _saved: u32 = fields.next()?.parse().ok()?;
+    let _filesystem: u32 = fields.next()?.parse().ok()?;
+    if fields.next().is_some() {
+        return None;
+    }
+    Some(effective)
+}
+
+/// The one approved fine-grained infrastructure exception. Keep the exact
+/// name and root-identity requirements in one predicate so the NVML and
+/// device-node fallback paths cannot drift.
+fn is_root_nvidia_powerd(proc_root: &Path, process: &GpuClientProcess) -> bool {
+    process.name.as_deref() == Some("nvidia-powerd")
+        && process_effective_uid(proc_root, process.pid) == Some(0)
+}
+
+/// Positively identify the Dynamic Boost helper among an already resolved
+/// process list. Used by the fine-grained device-node fallback; coarse and
+/// unknown modes never call this exclusion.
+fn ignored_powerd_processes(
+    proc_root: &Path,
+    processes: &[GpuClientProcess],
+) -> Vec<GpuClientProcess> {
+    processes
+        .iter()
+        .filter(|process| is_root_nvidia_powerd(proc_root, process))
+        .cloned()
+        .collect()
 }
 
 /// Only the numbered render nodes count as a real GPU client. `nvidiactl`,
@@ -494,18 +590,22 @@ mod tests {
     }
 
     #[test]
-    fn named_processes_resolve_comm_and_drop_the_daemon() {
+    fn classified_context_processes_resolve_comm_once_and_drop_the_daemon() {
         let root = tempfile::tempdir().expect("tempdir");
         fs::create_dir_all(root.path().join("123")).unwrap();
         fs::write(root.path().join("123").join("comm"), "cuda-worker\n").unwrap();
 
-        let named = named_processes(root.path(), &[123, 456, 999], 456);
-        assert_eq!(named.len(), 2);
-        assert_eq!(named[0].pid, 123);
-        assert_eq!(named[0].name.as_deref(), Some("cuda-worker"));
+        let (graphics, compute, ignored) =
+            classified_context_processes(root.path(), &[123, 456, 999], &[123], 456);
+        assert!(ignored.is_empty());
+        assert_eq!(graphics.len(), 2);
+        assert_eq!(graphics[0].pid, 123);
+        assert_eq!(graphics[0].name.as_deref(), Some("cuda-worker"));
         // A PID that exited between the NVML query and the lookup keeps its
         // entry so the counts stay honest, just without a name.
-        assert_eq!(named[1].pid, 999);
-        assert_eq!(named[1].name, None);
+        assert_eq!(graphics[1].pid, 999);
+        assert_eq!(graphics[1].name, None);
+        // A PID present in both context kinds shares the one classification.
+        assert_eq!(compute, vec![graphics[0].clone()]);
     }
 }

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -40,6 +40,7 @@ use crate::logging;
 use crate::supervisor::{self, Supervisor};
 
 use super::detect::{Rtd3Probe, RuntimePmStatus};
+use super::{GpuClientObservation, GpuClientProcess, GpuClientSource};
 
 const MOBILE_TICK: Duration = Duration::from_secs(1);
 /// Cadence in Desktop mode: re-evaluate in case the user enables runtime PM.
@@ -167,11 +168,14 @@ fn mobile_tick(
                         "deep sleep: no GPU clients for the idle window; parking the runtime",
                     );
                     if supervisor::park_runtime_for_deep_sleep(sup) {
-                        super::set_parked(true);
-                        // The parked intent is pending again from this very
-                        // instant — a status read between ticks must not
-                        // claim otherwise.
+                        // Deferral first: the moment `parked` becomes
+                        // visible, the status block must already say the
+                        // runtime will reapply. In the other order a status
+                        // read can land between the two gate writes (the
+                        // deferral check reads spec files) and see a parked
+                        // runtime that claims it will not come back.
                         super::set_autostart_deferred(wakeable_runtime_pending());
+                        super::set_parked(true);
                     }
                 }
             }
@@ -222,19 +226,43 @@ fn wakeable_runtime_pending() -> bool {
 /// awake — an attached engine (park check) or sustained `active` (wake check)
 /// — so the fine-grained NVML query never wakes a sleeping GPU; the registry
 /// backend it opens is swept by `release_idle_backends` once the checks stop.
+///
+/// Every call records the full sample (per-kind context holders AND
+/// device-node holders, with process names) as the `deep_sleep.gpu_clients`
+/// status block, so someone debugging a park that does or does not happen
+/// can see exactly the evidence the decision used.
 fn gpu_in_use_by_client(gpu_index: Option<u32>) -> bool {
+    let proc_root = client_proc_root();
+    let self_pid = std::process::id();
+    // Sampled even when the decision ignores it: a shell holding
+    // `/dev/nvidia0` open while the context lists stay empty is precisely
+    // what explains a fine-grained park to a reader of the status block.
+    let mut observation = GpuClientObservation {
+        source: GpuClientSource::DeviceNodes,
+        graphics: Vec::new(),
+        compute: Vec::new(),
+        device_node_holders: nvidia_device_node_holders_in(&proc_root, self_pid),
+    };
     if super::fine_grained_mode() {
         if let Some(index) = gpu_index {
             match gpu_rpc::context_pids(index) {
-                Ok(pids) => {
-                    let self_pid = std::process::id();
-                    return pids.into_iter().any(|pid| pid != self_pid);
+                Ok(contexts) => {
+                    observation.source = GpuClientSource::NvmlContexts;
+                    observation.graphics = named_processes(&proc_root, &contexts.graphics, self_pid);
+                    observation.compute = named_processes(&proc_root, &contexts.compute, self_pid);
                 }
                 Err(error) => log_context_query_fallback(&error),
             }
         }
     }
-    nvidia_client_present()
+    let in_use = match observation.source {
+        GpuClientSource::NvmlContexts => {
+            !(observation.graphics.is_empty() && observation.compute.is_empty())
+        }
+        GpuClientSource::DeviceNodes => !observation.device_node_holders.is_empty(),
+    };
+    super::record_gpu_clients(observation);
+    in_use
 }
 
 /// The NVML-context fallback is a per-boot property (old driver, missing
@@ -248,16 +276,35 @@ fn log_context_query_fallback(error: &str) {
     });
 }
 
-/// True when a process other than the daemon holds a `/dev/nvidia<N>` fd —
-/// pure procfs reads, never touches the device. Root sees every process.
-/// Test seam (never set in production): `PENGUIN_BURNERD_TEST_CLIENT_PROC`
-/// points the scan at a fake proc tree so integration tests can stage and
-/// remove GPU clients deterministically on any machine.
-fn nvidia_client_present() -> bool {
-    let proc_root = std::env::var_os("PENGUIN_BURNERD_TEST_CLIENT_PROC")
+/// The proc tree the client scan and name lookups read. Test seam (never set
+/// in production): `PENGUIN_BURNERD_TEST_CLIENT_PROC` points at a fake proc
+/// tree so integration tests can stage and remove GPU clients
+/// deterministically on any machine.
+fn client_proc_root() -> PathBuf {
+    std::env::var_os("PENGUIN_BURNERD_TEST_CLIENT_PROC")
         .filter(|v| !v.is_empty())
-        .map_or_else(|| PathBuf::from("/proc"), PathBuf::from);
-    other_nvidia_client_in(proc_root, std::process::id())
+        .map_or_else(|| PathBuf::from("/proc"), PathBuf::from)
+}
+
+/// Resolve `/proc/<pid>/comm` names for context PIDs, dropping the daemon's
+/// own PID so the lists match what the park/wake decision counts.
+fn named_processes(proc_root: &Path, pids: &[u32], self_pid: u32) -> Vec<GpuClientProcess> {
+    pids.iter()
+        .copied()
+        .filter(|pid| *pid != self_pid)
+        .map(|pid| GpuClientProcess {
+            pid,
+            name: process_name(proc_root, pid),
+        })
+        .collect()
+}
+
+/// Process name from `<proc_root>/<pid>/comm`; `None` once the process is
+/// gone. Pure procfs read — never touches the GPU.
+fn process_name(proc_root: &Path, pid: u32) -> Option<String> {
+    let comm = fs::read_to_string(proc_root.join(pid.to_string()).join("comm")).ok()?;
+    let name = comm.trim();
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 /// Only the numbered render nodes count as a real GPU client. `nvidiactl`,
@@ -269,9 +316,17 @@ fn is_nvidia_device_node(target: &str) -> bool {
         .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
-fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
+/// Every process other than the daemon holding a `/dev/nvidia<N>` fd, with
+/// names — pure procfs reads, never touches the device. Root sees every
+/// process. Sorted by PID so repeated status reads stay stable.
+fn nvidia_device_node_holders_in(
+    proc_root: impl AsRef<Path>,
+    self_pid: u32,
+) -> Vec<GpuClientProcess> {
+    let proc_root = proc_root.as_ref();
+    let mut holders = Vec::new();
     let Ok(entries) = fs::read_dir(proc_root) else {
-        return false;
+        return holders;
     };
     for entry in entries.filter_map(Result::ok) {
         let name = entry.file_name();
@@ -284,15 +339,19 @@ fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
         let Ok(fds) = fs::read_dir(entry.path().join("fd")) else {
             continue;
         };
-        for fd in fds.filter_map(Result::ok) {
-            if let Ok(target) = fs::read_link(fd.path()) {
-                if is_nvidia_device_node(&target.to_string_lossy()) {
-                    return true;
-                }
-            }
+        let holds_device_node = fds.filter_map(Result::ok).any(|fd| {
+            fs::read_link(fd.path())
+                .is_ok_and(|target| is_nvidia_device_node(&target.to_string_lossy()))
+        });
+        if holds_device_node {
+            holders.push(GpuClientProcess {
+                pid,
+                name: process_name(proc_root, pid),
+            });
         }
     }
-    false
+    holders.sort_unstable_by_key(|process| process.pid);
+    holders
 }
 
 #[cfg(test)]
@@ -314,16 +373,28 @@ mod tests {
     }
 
     #[test]
-    fn detects_nvidia_fd_holders_and_skips_self() {
+    fn collects_nvidia_fd_holders_with_names_and_skips_self() {
         let root = tempfile::tempdir().expect("tempdir");
         let fd_dir = root.path().join("4242").join("fd");
         fs::create_dir_all(&fd_dir).unwrap();
         symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+        fs::write(root.path().join("4242").join("comm"), "some-game\n").unwrap();
+        // A holder whose comm is unreadable still appears, without a name.
+        let anon_fd_dir = root.path().join("77").join("fd");
+        fs::create_dir_all(&anon_fd_dir).unwrap();
+        symlink("/dev/nvidia1", anon_fd_dir.join("3")).unwrap();
         fs::create_dir_all(root.path().join("not-a-pid")).unwrap();
 
-        assert!(other_nvidia_client_in(root.path(), 1));
+        let holders = nvidia_device_node_holders_in(root.path(), 1);
+        assert_eq!(holders.len(), 2);
+        assert_eq!(holders[0].pid, 77);
+        assert_eq!(holders[0].name, None);
+        assert_eq!(holders[1].pid, 4242);
+        assert_eq!(holders[1].name.as_deref(), Some("some-game"));
         // The daemon's own fds never count as a client.
-        assert!(!other_nvidia_client_in(root.path(), 4242));
+        let holders = nvidia_device_node_holders_in(root.path(), 4242);
+        assert_eq!(holders.len(), 1);
+        assert_eq!(holders[0].pid, 77);
     }
 
     #[test]
@@ -334,6 +405,22 @@ mod tests {
         symlink("/dev/nvidiactl", fd_dir.join("3")).unwrap();
         symlink("/dev/nvidia-uvm", fd_dir.join("4")).unwrap();
         symlink("/dev/dri/renderD128", fd_dir.join("5")).unwrap();
-        assert!(!other_nvidia_client_in(root.path(), 1));
+        assert!(nvidia_device_node_holders_in(root.path(), 1).is_empty());
+    }
+
+    #[test]
+    fn named_processes_resolve_comm_and_drop_the_daemon() {
+        let root = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(root.path().join("123")).unwrap();
+        fs::write(root.path().join("123").join("comm"), "cuda-worker\n").unwrap();
+
+        let named = named_processes(root.path(), &[123, 456, 999], 456);
+        assert_eq!(named.len(), 2);
+        assert_eq!(named[0].pid, 123);
+        assert_eq!(named[0].name.as_deref(), Some("cuda-worker"));
+        // A PID that exited between the NVML query and the lookup keeps its
+        // entry so the counts stay honest, just without a name.
+        assert_eq!(named[1].pid, 999);
+        assert_eq!(named[1].name, None);
     }
 }

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -1,17 +1,24 @@
 //! Startup supervisor for the deep-sleep gate.
 //!
-//! `startup` replaces the unconditional boot-time autostart: desktops (gate
-//! `Disabled`) start the persisted runtime synchronously exactly as before;
-//! RTD3 machines defer it and hand control to a watcher thread that polls the
-//! kernel's cached `runtime_status` (a wake-free read) once per second.
+//! `startup` replaces the unconditional boot-time autostart: a machine that is
+//! decidably a desktop (gate `Disabled`) starts the persisted runtime
+//! synchronously exactly as before, and every machine then gets a watcher
+//! thread that keeps the gate's view live for the daemon's lifetime — an
+//! undecided verdict can resolve, a `disabled` verdict can flip once the user
+//! enables runtime PM, and a `suspended` sighting arms the gate for good.
 //!
-//! The watcher starts the deferred runtime only when the GPU is demonstrably
-//! in use: sustained `active` AND some other process holding a `/dev/nvidia*`
-//! file descriptor. Bare `active` is not enough — transient wakes (Vulkan/GL
-//! capability probes from arbitrary apps, boot-time driver init) last seconds
-//! and attaching on them would hold the GPU awake, recreating the bug this
-//! module exists to fix (issue #30). While armed it also drops idle RPC
-//! backends so a one-off GUI telemetry query cannot pin NVML forever.
+//! While armed, the watcher polls the kernel's cached `runtime_status` (a
+//! wake-free read) once per second and starts the deferred runtime only when
+//! the GPU is demonstrably in use: sustained `active` AND another process
+//! holding a `/dev/nvidia<N>` device-node fd. Bare `active` is not enough —
+//! transient wakes (Vulkan/GL capability probes from arbitrary apps,
+//! boot-time driver init) last seconds, and attaching on them would hold the
+//! GPU awake, recreating the bug this module exists to fix (issue #30).
+//! Auxiliary nodes (`nvidiactl`, `nvidia-uvm`, `nvidia-modeset`,
+//! `nvidia-caps/*`) are deliberately not counted: monitoring agents and
+//! container toolkits hold them long-lived without keeping a fine-grained
+//! RTD3 GPU awake. While armed it also drops idle RPC backends so a one-off
+//! GUI telemetry query cannot pin NVML forever.
 
 use std::fs;
 use std::path::Path;
@@ -25,119 +32,160 @@ use crate::supervisor::{self, Supervisor};
 
 use super::detect::{DeepSleepDecision, Rtd3Probe, RuntimePmStatus};
 
-const TICK: Duration = Duration::from_secs(1);
+const ARMED_TICK: Duration = Duration::from_secs(1);
+/// Cadence while the verdict is `Disabled`: only re-evaluation (the user may
+/// enable runtime PM at runtime) and sticky-arming observation happen here.
+const DISABLED_TICK: Duration = Duration::from_secs(60);
 /// How long an undecided gate may stay undecided before falling back to the
 /// classic path (device never appeared / driver never initialized).
 const UNDECIDED_GRACE_TICKS: u32 = 30;
-/// Consecutive `active` readings required before the wake counts as real.
+/// Consecutive `active` readings required before a wake counts as real.
 const SUSTAINED_ACTIVE_TICKS: u32 = 3;
 /// Idle TTL for lazily-opened RPC backends while the gate is armed.
 const RPC_BACKEND_IDLE_TTL: Duration = Duration::from_secs(30);
 
-/// Evaluate the gate and either run the classic synchronous autostart
-/// (desktops) or spawn the deep-sleep watcher (armed / undecided).
+/// Evaluate the gate, run the classic synchronous autostart when the machine
+/// is decidably a desktop (preserving the start-before-socket-bind ordering),
+/// and spawn the lifetime watcher in every case.
 pub fn startup(sup: &Arc<Mutex<Supervisor>>) {
     let probe = Rtd3Probe::system();
     let hint = supervisor::persisted_pci_bus_id_hint();
     let decision = super::evaluate(&probe, hint.as_deref());
 
-    if matches!(decision, DeepSleepDecision::Disabled { .. }) {
+    let classic_started = matches!(decision, DeepSleepDecision::Disabled { .. });
+    if classic_started {
         supervisor::start_autostart_if_configured(sup);
-        return;
     }
 
     let sup = sup.clone();
     thread::Builder::new()
         .name("penguin-burner-rtd3".to_string())
-        .spawn(move || watch_loop(&sup, &probe, hint.as_deref()))
+        .spawn(move || watch_loop(&sup, &probe, hint.as_deref(), classic_started))
         .expect("spawn rtd3 watcher thread");
 }
 
-fn watch_loop(sup: &Arc<Mutex<Supervisor>>, probe: &Rtd3Probe, hint: Option<&str>) {
-    // Phase 1: resolve an undecided gate. Stay detached while waiting — the
-    // whole point is that "don't know yet" must not attach NVML.
+fn watch_loop(
+    sup: &Arc<Mutex<Supervisor>>,
+    probe: &Rtd3Probe,
+    hint: Option<&str>,
+    mut classic_started: bool,
+) {
     let mut undecided_ticks = 0u32;
+    let mut active_ticks = 0u32;
+    // One start attempt per active episode: a failed `profile::start` must not
+    // retry at 1 Hz, and a dead engine retained in the profile slot must not
+    // produce log spam. Reset when the GPU leaves `active`.
+    let mut start_attempted = false;
+
     loop {
+        if let Some(addr) = super::pci_addr() {
+            super::note_runtime_status(probe.runtime_pm_status(&addr));
+        }
+
+        if super::is_armed() {
+            let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
+            if released > 0 {
+                logging::info(&format!(
+                    "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
+                ));
+            }
+            armed_tick(sup, &mut active_ticks, &mut start_attempted);
+            thread::sleep(ARMED_TICK);
+            continue;
+        }
+
         match super::current_decision() {
-            Some(DeepSleepDecision::Armed { .. }) => break,
             Some(DeepSleepDecision::Disabled { .. }) => {
-                supervisor::start_autostart_if_configured(sup);
-                return;
+                super::set_autostart_deferred(false);
+                if !classic_started {
+                    // The verdict resolved to desktop after boot (device
+                    // appeared during the undecided window): run the classic
+                    // start it would have received at boot.
+                    classic_started = true;
+                    supervisor::start_autostart_if_configured(sup);
+                }
+                thread::sleep(DISABLED_TICK);
+                super::evaluate(probe, hint);
             }
             _ => {
-                if let Some(addr) = super::pci_addr() {
-                    super::note_runtime_status(probe.runtime_pm_status(&addr));
-                    if super::is_armed() {
-                        // Sticky suspended observation resolved it for us.
-                        break;
-                    }
-                }
                 undecided_ticks += 1;
-                if undecided_ticks > UNDECIDED_GRACE_TICKS {
+                if !classic_started && undecided_ticks > UNDECIDED_GRACE_TICKS {
+                    // Could not decide (driver power file stayed `?` or the
+                    // device never appeared). Fall back to the classic start
+                    // so a saved profile is not silently dropped; persistence
+                    // mode stays suppressed while the gate is undecided, so
+                    // this cannot permanently block D3cold on a laptop that
+                    // was merely slow to initialize.
                     logging::warn(
                         "deep sleep gate stayed undecided; falling back to classic runtime start",
                     );
+                    classic_started = true;
                     supervisor::start_autostart_if_configured(sup);
-                    return;
                 }
+                thread::sleep(ARMED_TICK);
                 super::evaluate(probe, hint);
             }
         }
-        thread::sleep(TICK);
-    }
-
-    // Phase 2: armed. Defer the persisted runtime until the GPU is really in
-    // use, and keep sweeping idle RPC backends so nothing pins the GPU.
-    let mut active_ticks = 0u32;
-    loop {
-        let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
-        if released > 0 {
-            logging::info(&format!(
-                "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
-            ));
-        }
-
-        let Some(addr) = super::pci_addr() else {
-            thread::sleep(TICK);
-            continue;
-        };
-        let status = probe.runtime_pm_status(&addr);
-        super::note_runtime_status(status);
-
-        if supervisor::profile_engine_running(sup) {
-            super::set_autostart_deferred(false);
-            active_ticks = 0;
-            thread::sleep(TICK);
-            continue;
-        }
-
-        let pending = supervisor::has_persisted_runtime();
-        super::set_autostart_deferred(pending);
-        if pending {
-            active_ticks = if status == RuntimePmStatus::Active {
-                active_ticks + 1
-            } else {
-                0
-            };
-            if active_ticks >= SUSTAINED_ACTIVE_TICKS && nvidia_client_present() {
-                logging::info(
-                    "deep sleep: GPU is in use; starting the deferred persisted runtime",
-                );
-                super::set_autostart_deferred(false);
-                supervisor::start_autostart_if_configured(sup);
-                active_ticks = 0;
-            }
-        } else {
-            active_ticks = 0;
-        }
-        thread::sleep(TICK);
     }
 }
 
-/// True when a process other than the daemon holds a `/dev/nvidia*` fd —
+/// One armed observation tick: hold the deferred runtime back until the GPU
+/// is genuinely in use, and never fight another GPU owner.
+fn armed_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attempted: &mut bool) {
+    // A scan/verification child owns the GPU exclusively; its own
+    // `/dev/nvidia*` fds and activity must never satisfy the start policy —
+    // starting the engine here would race the child's raw GPU writes.
+    if supervisor::active_child_kind(sup).is_some() {
+        super::set_autostart_deferred(false);
+        *active_ticks = 0;
+        *start_attempted = false;
+        return;
+    }
+    // The profile slot (running OR retained-after-failure) means the runtime
+    // was already handled; a retained failed engine deliberately blocks
+    // restarts, so it must not count as "deferred" either.
+    if supervisor::profile_slot_occupied(sup) {
+        super::set_autostart_deferred(false);
+        *active_ticks = 0;
+        *start_attempted = false;
+        return;
+    }
+
+    let pending = supervisor::deferred_runtime_pending();
+    super::set_autostart_deferred(pending);
+    if !pending {
+        *active_ticks = 0;
+        *start_attempted = false;
+        return;
+    }
+
+    if super::last_runtime_status() == Some(RuntimePmStatus::Active) {
+        *active_ticks += 1;
+    } else {
+        *active_ticks = 0;
+        *start_attempted = false;
+    }
+    if *active_ticks >= SUSTAINED_ACTIVE_TICKS && !*start_attempted && nvidia_client_present() {
+        *start_attempted = true;
+        logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
+        super::set_autostart_deferred(false);
+        supervisor::start_autostart_if_configured(sup);
+    }
+}
+
+/// True when a process other than the daemon holds a `/dev/nvidia<N>` fd —
 /// pure procfs reads, never touches the device. Root sees every process.
 fn nvidia_client_present() -> bool {
     other_nvidia_client_in("/proc", std::process::id())
+}
+
+/// Only the numbered render nodes count as a real GPU client. `nvidiactl`,
+/// `nvidia-uvm*`, `nvidia-modeset`, and `nvidia-caps/*` are held long-lived
+/// by monitoring/container tooling without keeping an RTD3 GPU awake.
+fn is_nvidia_device_node(target: &str) -> bool {
+    target
+        .strip_prefix("/dev/nvidia")
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
 fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
@@ -157,7 +205,7 @@ fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
         };
         for fd in fds.filter_map(Result::ok) {
             if let Ok(target) = fs::read_link(fd.path()) {
-                if target.to_string_lossy().starts_with("/dev/nvidia") {
+                if is_nvidia_device_node(&target.to_string_lossy()) {
                     return true;
                 }
             }
@@ -170,6 +218,19 @@ fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
 mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
+
+    #[test]
+    fn only_numbered_device_nodes_count_as_clients() {
+        assert!(is_nvidia_device_node("/dev/nvidia0"));
+        assert!(is_nvidia_device_node("/dev/nvidia12"));
+        assert!(!is_nvidia_device_node("/dev/nvidiactl"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-uvm"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-uvm-tools"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-modeset"));
+        assert!(!is_nvidia_device_node("/dev/nvidia-caps/nvidia-cap1"));
+        assert!(!is_nvidia_device_node("/dev/nvidia"));
+        assert!(!is_nvidia_device_node("/dev/dri/renderD128"));
+    }
 
     #[test]
     fn detects_nvidia_fd_holders_and_skips_self() {
@@ -185,11 +246,13 @@ mod tests {
     }
 
     #[test]
-    fn no_client_when_fd_targets_are_unrelated() {
+    fn auxiliary_nvidia_nodes_are_not_clients() {
         let root = tempfile::tempdir().expect("tempdir");
         let fd_dir = root.path().join("100").join("fd");
         fs::create_dir_all(&fd_dir).unwrap();
-        symlink("/dev/dri/renderD128", fd_dir.join("3")).unwrap();
+        symlink("/dev/nvidiactl", fd_dir.join("3")).unwrap();
+        symlink("/dev/nvidia-uvm", fd_dir.join("4")).unwrap();
+        symlink("/dev/dri/renderD128", fd_dir.join("5")).unwrap();
         assert!(!other_nvidia_client_in(root.path(), 1));
     }
 }

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -1,23 +1,23 @@
 //! Startup supervisor for the deep-sleep gate.
 //!
-//! `startup` replaces the unconditional boot-time autostart: a machine that is
-//! decidably a desktop (gate `Disabled`) starts the persisted runtime
-//! synchronously exactly as before, and every machine then gets a watcher
-//! thread that keeps the gate's view live for the daemon's lifetime — an
-//! undecided verdict can resolve, a `disabled` verdict can flip once the user
-//! enables runtime PM, and a `suspended` sighting arms the gate for good.
+//! `startup` replaces the unconditional boot-time autostart: Desktop mode
+//! starts the persisted runtime synchronously exactly as before, and every
+//! machine then gets a watcher thread that keeps the detected mode live for
+//! the daemon's lifetime — Unknown can resolve, Desktop can flip once the user
+//! enables runtime PM, and a `suspended` sighting selects Mobile handling for
+//! good.
 //!
-//! While armed, the watcher polls the kernel's cached `runtime_status` (a
-//! wake-free read) once per second and starts the deferred runtime only when
-//! the GPU is demonstrably in use: sustained `active` AND another process
-//! holding a `/dev/nvidia<N>` device-node fd. Bare `active` is not enough —
-//! transient wakes (Vulkan/GL capability probes from arbitrary apps,
-//! boot-time driver init) last seconds, and attaching on them would hold the
-//! GPU awake, recreating the bug this module exists to fix (issue #30).
+//! In Mobile and Unknown modes, the watcher polls the kernel's cached
+//! `runtime_status` (a wake-free read) once per second and starts the deferred
+//! runtime only when the GPU is demonstrably in use: sustained `active` AND
+//! another process holding a `/dev/nvidia<N>` device-node fd. Bare `active` is
+//! not enough — transient wakes (Vulkan/GL capability probes from arbitrary
+//! apps, boot-time driver init) last seconds, and attaching on them would hold
+//! the GPU awake, recreating the bug this module exists to fix (issue #30).
 //! Auxiliary nodes (`nvidiactl`, `nvidia-uvm`, `nvidia-modeset`,
 //! `nvidia-caps/*`) are deliberately not counted: monitoring agents and
 //! container toolkits hold them long-lived without keeping a fine-grained
-//! RTD3 GPU awake. While armed it also drops idle RPC backends so a one-off
+//! RTD3 GPU awake. While protected it also drops idle RPC backends so a one-off
 //! GUI telemetry query cannot pin NVML forever.
 
 use std::fs;
@@ -30,37 +30,33 @@ use crate::gpu_rpc;
 use crate::logging;
 use crate::supervisor::{self, Supervisor};
 
-use super::detect::{DeepSleepDecision, Rtd3Probe, RuntimePmStatus};
+use super::detect::{Rtd3Probe, RuntimePmStatus};
 
-const ARMED_TICK: Duration = Duration::from_secs(1);
-/// Cadence while the verdict is `Disabled`: only re-evaluation (the user may
-/// enable runtime PM at runtime) and sticky-arming observation happen here.
-const DISABLED_TICK: Duration = Duration::from_secs(60);
-/// How long an undecided gate may stay undecided before falling back to the
-/// classic path (device never appeared / driver never initialized).
-const UNDECIDED_GRACE_TICKS: u32 = 30;
+const MOBILE_TICK: Duration = Duration::from_secs(1);
+/// Cadence in Desktop mode: re-evaluate in case the user enables runtime PM.
+const DESKTOP_TICK: Duration = Duration::from_secs(60);
 /// Consecutive `active` readings required before a wake counts as real.
 const SUSTAINED_ACTIVE_TICKS: u32 = 3;
-/// Idle TTL for lazily-opened RPC backends while the gate is armed.
+/// Idle TTL for lazily-opened RPC backends in Mobile or Unknown mode.
 const RPC_BACKEND_IDLE_TTL: Duration = Duration::from_secs(30);
 
-/// Evaluate the gate, run the classic synchronous autostart when the machine
-/// is decidably a desktop (preserving the start-before-socket-bind ordering),
-/// and spawn the lifetime watcher in every case.
+/// Evaluate the mode, run eager autostart only in definite Desktop mode
+/// (preserving the start-before-socket-bind ordering), and spawn the lifetime
+/// watcher in every case.
 pub fn startup(sup: &Arc<Mutex<Supervisor>>) {
     let probe = Rtd3Probe::system();
     let hint = supervisor::persisted_pci_bus_id_hint();
-    let decision = super::evaluate(&probe, hint.as_deref());
+    super::evaluate(&probe, hint.as_deref());
 
-    let classic_started = matches!(decision, DeepSleepDecision::Disabled { .. });
-    if classic_started {
+    let desktop_autostart_attempted = super::allows_desktop_autostart();
+    if desktop_autostart_attempted {
         supervisor::start_autostart_if_configured(sup);
     }
 
     let sup = sup.clone();
     thread::Builder::new()
         .name("penguin-burner-rtd3".to_string())
-        .spawn(move || watch_loop(&sup, &probe, hint.as_deref(), classic_started))
+        .spawn(move || watch_loop(&sup, &probe, hint.as_deref(), desktop_autostart_attempted))
         .expect("spawn rtd3 watcher thread");
 }
 
@@ -68,9 +64,8 @@ fn watch_loop(
     sup: &Arc<Mutex<Supervisor>>,
     probe: &Rtd3Probe,
     hint: Option<&str>,
-    mut classic_started: bool,
+    mut desktop_autostart_attempted: bool,
 ) {
-    let mut undecided_ticks = 0u32;
     let mut active_ticks = 0u32;
     // One start attempt per active episode: a failed `profile::start` must not
     // retry at 1 Hz, and a dead engine retained in the profile slot must not
@@ -78,60 +73,34 @@ fn watch_loop(
     let mut start_attempted = false;
 
     loop {
-        if let Some(addr) = super::pci_addr() {
-            super::note_runtime_status(probe.runtime_pm_status(&addr));
-        }
+        super::evaluate(probe, hint);
 
-        if super::is_armed() {
+        if super::protects_deep_sleep() {
             let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
             if released > 0 {
                 logging::info(&format!(
                     "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
                 ));
             }
-            armed_tick(sup, &mut active_ticks, &mut start_attempted);
-            thread::sleep(ARMED_TICK);
+            mobile_tick(sup, &mut active_ticks, &mut start_attempted);
+            thread::sleep(MOBILE_TICK);
             continue;
         }
 
-        match super::current_decision() {
-            Some(DeepSleepDecision::Disabled { .. }) => {
-                super::set_autostart_deferred(false);
-                if !classic_started {
-                    // The verdict resolved to desktop after boot (device
-                    // appeared during the undecided window): run the classic
-                    // start it would have received at boot.
-                    classic_started = true;
-                    supervisor::start_autostart_if_configured(sup);
-                }
-                thread::sleep(DISABLED_TICK);
-                super::evaluate(probe, hint);
-            }
-            _ => {
-                undecided_ticks += 1;
-                if !classic_started && undecided_ticks > UNDECIDED_GRACE_TICKS {
-                    // Could not decide (driver power file stayed `?` or the
-                    // device never appeared). Fall back to the classic start
-                    // so a saved profile is not silently dropped; persistence
-                    // mode stays suppressed while the gate is undecided, so
-                    // this cannot permanently block D3cold on a laptop that
-                    // was merely slow to initialize.
-                    logging::warn(
-                        "deep sleep gate stayed undecided; falling back to classic runtime start",
-                    );
-                    classic_started = true;
-                    supervisor::start_autostart_if_configured(sup);
-                }
-                thread::sleep(ARMED_TICK);
-                super::evaluate(probe, hint);
-            }
+        super::set_autostart_deferred(false);
+        if !desktop_autostart_attempted && super::allows_desktop_autostart() {
+            // Detection resolved from Unknown to Desktop after boot: make the
+            // one eager-start attempt Desktop mode would have received at boot.
+            desktop_autostart_attempted = true;
+            supervisor::start_autostart_if_configured(sup);
         }
+        thread::sleep(DESKTOP_TICK);
     }
 }
 
-/// One armed observation tick: hold the deferred runtime back until the GPU
-/// is genuinely in use, and never fight another GPU owner.
-fn armed_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attempted: &mut bool) {
+/// One Mobile/Unknown observation tick: hold the deferred runtime back until
+/// the GPU is genuinely in use, and never fight another GPU owner.
+fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attempted: &mut bool) {
     // A scan/verification child owns the GPU exclusively; its own
     // `/dev/nvidia*` fds and activity must never satisfy the start policy —
     // starting the engine here would race the child's raw GPU writes.
@@ -166,10 +135,11 @@ fn armed_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attemp
         *start_attempted = false;
     }
     if *active_ticks >= SUSTAINED_ACTIVE_TICKS && !*start_attempted && nvidia_client_present() {
-        *start_attempted = true;
         logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
-        super::set_autostart_deferred(false);
-        supervisor::start_autostart_if_configured(sup);
+        if supervisor::start_autostart_if_configured(sup) {
+            *start_attempted = true;
+            super::set_autostart_deferred(false);
+        }
     }
 }
 

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -9,16 +9,25 @@
 //!
 //! In Mobile and Unknown modes, the watcher polls the kernel's cached
 //! `runtime_status` (a wake-free read) once per second and starts the deferred
-//! runtime only when the GPU is demonstrably in use: sustained `active` AND
-//! another process holding a `/dev/nvidia<N>` device-node fd. Bare `active` is
-//! not enough — transient wakes (Vulkan/GL capability probes from arbitrary
-//! apps, boot-time driver init) last seconds, and attaching on them would hold
-//! the GPU awake, recreating the bug this module exists to fix (issue #30).
-//! Auxiliary nodes (`nvidiactl`, `nvidia-uvm`, `nvidia-modeset`,
-//! `nvidia-caps/*`) are deliberately not counted: monitoring agents and
-//! container toolkits hold them long-lived without keeping a fine-grained
-//! RTD3 GPU awake. While protected it also drops idle RPC backends so a one-off
-//! GUI telemetry query cannot pin NVML forever.
+//! runtime only when the GPU is demonstrably in use: sustained `active` AND a
+//! real GPU client. Bare `active` is not enough — transient wakes (Vulkan/GL
+//! capability probes from arbitrary apps, boot-time driver init) last seconds,
+//! and attaching on them would hold the GPU awake, recreating the bug this
+//! module exists to fix (issue #30).
+//!
+//! What counts as a "real GPU client" depends on the driver's runtime-D3
+//! granularity. Coarse-grained (and undecided) RTD3 keeps the GPU awake while
+//! any process holds a `/dev/nvidia<N>` device-node fd, so the fd scan is the
+//! accurate signal there; auxiliary nodes (`nvidiactl`, `nvidia-uvm`,
+//! `nvidia-modeset`, `nvidia-caps/*`) are deliberately not counted. Under
+//! fine-grained RTD3 the driver wakes per submitted work, not per open fd —
+//! desktop shells and monitoring agents hold the render node open for hours
+//! while the GPU sleeps — so an fd holder proves nothing, and treating it as
+//! use would starve the park policy forever. There the watcher asks NVML for
+//! live graphics/compute contexts instead, falling back to the fd scan only
+//! when that query fails (driver too old for the _v3 symbols, no backend).
+//! While protected it also drops idle RPC backends so a one-off GUI telemetry
+//! query cannot pin NVML forever.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -144,11 +153,11 @@ fn mobile_tick(
             super::set_parked(false);
             // Park policy: the engine's own NVML polling resets the driver's
             // idle timer forever, so an attached engine means the GPU can
-            // NEVER suspend on its own. When no other process holds a real
-            // /dev/nvidia<N> handle for the whole window, release the GPU:
-            // the profile stays a standing intent (persisted state kept) and
-            // reapplies at the next real use.
-            if nvidia_client_present() {
+            // NEVER suspend on its own. When no other process really uses the
+            // GPU for the whole window, release it: the profile stays a
+            // standing intent (persisted state kept) and reapplies at the
+            // next real use.
+            if gpu_in_use_by_client(supervisor::profile_gpu_index(sup)) {
                 *idle_ticks = 0;
             } else {
                 *idle_ticks += 1;
@@ -187,7 +196,10 @@ fn mobile_tick(
         *active_ticks = 0;
         *start_attempted = false;
     }
-    if *active_ticks >= SUSTAINED_ACTIVE_TICKS && !*start_attempted && nvidia_client_present() {
+    if *active_ticks >= SUSTAINED_ACTIVE_TICKS
+        && !*start_attempted
+        && gpu_in_use_by_client(supervisor::deferred_runtime_gpu_index())
+    {
         logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
         if supervisor::start_autostart_if_configured(sup) {
             *start_attempted = true;
@@ -203,6 +215,37 @@ fn mobile_tick(
 fn wakeable_runtime_pending() -> bool {
     supervisor::deferred_runtime_pending()
         && supervisor::deferred_runtime_mode().as_deref() != Some("stock")
+}
+
+/// True when another process is really using the GPU (the mode-aware client
+/// signal described in the module docs). Only called while the GPU is already
+/// awake — an attached engine (park check) or sustained `active` (wake check)
+/// — so the fine-grained NVML query never wakes a sleeping GPU; the registry
+/// backend it opens is swept by `release_idle_backends` once the checks stop.
+fn gpu_in_use_by_client(gpu_index: Option<u32>) -> bool {
+    if super::fine_grained_mode() {
+        if let Some(index) = gpu_index {
+            match gpu_rpc::context_pids(index) {
+                Ok(pids) => {
+                    let self_pid = std::process::id();
+                    return pids.into_iter().any(|pid| pid != self_pid);
+                }
+                Err(error) => log_context_query_fallback(&error),
+            }
+        }
+    }
+    nvidia_client_present()
+}
+
+/// The NVML-context fallback is a per-boot property (old driver, missing
+/// symbols); log it once, not at 1 Hz.
+fn log_context_query_fallback(error: &str) {
+    static LOGGED: std::sync::Once = std::sync::Once::new();
+    LOGGED.call_once(|| {
+        logging::info(&format!(
+            "deep sleep: NVML context query unavailable ({error}); using the device-node scan"
+        ));
+    });
 }
 
 /// True when a process other than the daemon holds a `/dev/nvidia<N>` fd —

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -28,9 +28,10 @@
 //! context is reported but excluded: Dynamic Boost is driver infrastructure,
 //! and a real workload alongside it still has its own counted context. The
 //! context query owns one short-lived NVML-only session and closes it before
-//! returning. An idle result latches until a changed numbered-node holder set
-//! or a runtime-PM sleep/wake cycle re-arms the query, so observation cannot
-//! become a periodic self-sustaining GPU hold.
+//! returning. An idle result latches until a changed numbered-node holder set,
+//! a runtime-PM sleep/wake cycle, or a bounded stretch of awake latched ticks
+//! re-arms the query, so observation cannot become a periodic self-sustaining
+//! GPU hold — while a latched holder that starts real work is still noticed.
 //! The watcher falls back to the fd scan only when the context query fails
 //! (driver too old for the _v3 symbols, no backend), applying the same narrow
 //! helper exclusion in confirmed fine-grained mode.
@@ -159,30 +160,61 @@ fn watch_loop(
     let mut clients = ClientDetector::system();
 
     loop {
-        super::evaluate(probe, hint);
-
-        if super::protects_deep_sleep() {
-            let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
-            if released > 0 {
-                logging::info(&format!(
-                    "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
-                ));
-            }
-            mobile_tick(sup, &mut tick_state, &mut clients);
-            thread::sleep(MOBILE_TICK);
-            continue;
-        }
-
-        clients.reset();
-        super::set_autostart_deferred(false);
-        if !desktop_autostart_attempted && super::allows_desktop_autostart() {
-            // Detection resolved from Unknown to Desktop after boot: make the
-            // one eager-start attempt Desktop mode would have received at boot.
-            desktop_autostart_attempted = true;
-            supervisor::start_autostart_if_configured(sup);
-        }
-        thread::sleep(DESKTOP_TICK);
+        // The watcher is the only thread that parks runtimes, starts deferred
+        // ones, and sweeps idle RPC backends; a single panicking tick must not
+        // silently disable all three for the daemon's remaining lifetime.
+        // Shared state stays usable across an unwind: the gate and supervisor
+        // mutexes recover from poisoning, and TickState/ClientDetector hold
+        // only counters and latches that the next tick re-derives.
+        let tick = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            watch_tick(
+                sup,
+                probe,
+                hint,
+                &mut desktop_autostart_attempted,
+                &mut tick_state,
+                &mut clients,
+            )
+        }));
+        let delay = tick.unwrap_or_else(|_panic| {
+            logging::error("deep sleep: watcher tick panicked; keeping the watcher alive");
+            MOBILE_TICK
+        });
+        thread::sleep(delay);
     }
+}
+
+/// One watcher iteration; returns how long to sleep before the next.
+fn watch_tick(
+    sup: &Arc<Mutex<Supervisor>>,
+    probe: &Rtd3Probe,
+    hint: Option<&str>,
+    desktop_autostart_attempted: &mut bool,
+    tick_state: &mut TickState,
+    clients: &mut ClientDetector,
+) -> Duration {
+    super::evaluate(probe, hint);
+
+    if super::protects_deep_sleep() {
+        let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
+        if released > 0 {
+            logging::info(&format!(
+                "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
+            ));
+        }
+        mobile_tick(sup, tick_state, clients);
+        return MOBILE_TICK;
+    }
+
+    clients.reset();
+    super::set_autostart_deferred(false);
+    if !*desktop_autostart_attempted && super::allows_desktop_autostart() {
+        // Detection resolved from Unknown to Desktop after boot: make the
+        // one eager-start attempt Desktop mode would have received at boot.
+        *desktop_autostart_attempted = true;
+        supervisor::start_autostart_if_configured(sup);
+    }
+    DESKTOP_TICK
 }
 
 /// One Mobile/Unknown observation tick: hold the deferred runtime back until

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -83,20 +83,73 @@ pub fn startup(sup: &Arc<Mutex<Supervisor>>) {
         .expect("spawn rtd3 watcher thread");
 }
 
+/// The watcher's per-tick counters: one wake episode's progress and one park
+/// countdown. Reset on the edges commented at each `mobile_tick` site.
+#[derive(Default)]
+struct TickState {
+    /// Consecutive `active` readings; a wake counts as real at
+    /// [`SUSTAINED_ACTIVE_TICKS`].
+    active_ticks: u32,
+    /// One start attempt per active episode: a failed `profile::start` must
+    /// not retry at 1 Hz, and a dead engine retained in the profile slot must
+    /// not produce log spam. Reset when the GPU leaves `active`.
+    start_attempted: bool,
+    /// The current active episode began from a `suspended` reading, so a
+    /// sustained-active-without-clients outcome really is a transient wake.
+    /// Without this gate the drain tail of every park would be mislabeled:
+    /// the GPU stays `active` for the driver's autosuspend delay after the
+    /// engine releases it, which is not a wake.
+    woke_from_suspend: bool,
+    /// One "transient wake" journal line per active episode.
+    transient_wake_logged: bool,
+    /// Consecutive client-free ticks while an engine is attached; at the park
+    /// threshold the runtime is parked so the GPU can reach D3cold.
+    idle_ticks: u32,
+    /// The countdown-start journal line has announced the current continuous
+    /// client-free stretch. Latched across a refused park (which restarts the
+    /// countdown) so the announcement cannot re-fire every window.
+    countdown_announced: bool,
+    /// A refused park has explained itself for the current client-free
+    /// stretch; further refusals stay quiet until the stretch ends.
+    park_refusal_logged: bool,
+}
+
+impl TickState {
+    /// Reset the wake-episode trackers (the park countdown is reset
+    /// separately — the two run in disjoint phases).
+    fn reset_wake_episode(&mut self) {
+        self.active_ticks = 0;
+        self.start_attempted = false;
+        self.woke_from_suspend = false;
+        self.transient_wake_logged = false;
+    }
+
+    /// End the current client-free stretch: zero the countdown and re-arm
+    /// its journal latches.
+    fn end_countdown(&mut self) {
+        self.idle_ticks = 0;
+        self.countdown_announced = false;
+        self.park_refusal_logged = false;
+    }
+
+    /// End the countdown because its preconditions vanished (not because a
+    /// client appeared). Logs only when a countdown was actually in
+    /// progress, so an announced start line is never left dangling.
+    fn abandon_countdown(&mut self, reason: &str) {
+        if self.idle_ticks > 0 {
+            logging::info(&format!("deep sleep: park countdown abandoned: {reason}"));
+        }
+        self.end_countdown();
+    }
+}
+
 fn watch_loop(
     sup: &Arc<Mutex<Supervisor>>,
     probe: &Rtd3Probe,
     hint: Option<&str>,
     mut desktop_autostart_attempted: bool,
 ) {
-    let mut active_ticks = 0u32;
-    // One start attempt per active episode: a failed `profile::start` must not
-    // retry at 1 Hz, and a dead engine retained in the profile slot must not
-    // produce log spam. Reset when the GPU leaves `active`.
-    let mut start_attempted = false;
-    // Consecutive client-free ticks while an engine is attached; at the park
-    // threshold the runtime is parked so the GPU can reach D3cold.
-    let mut idle_ticks = 0u32;
+    let mut tick_state = TickState::default();
 
     loop {
         super::evaluate(probe, hint);
@@ -108,7 +161,7 @@ fn watch_loop(
                     "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
                 ));
             }
-            mobile_tick(sup, &mut active_ticks, &mut start_attempted, &mut idle_ticks);
+            mobile_tick(sup, &mut tick_state);
             thread::sleep(MOBILE_TICK);
             continue;
         }
@@ -127,20 +180,14 @@ fn watch_loop(
 /// One Mobile/Unknown observation tick: hold the deferred runtime back until
 /// the GPU is genuinely in use, park an attached-but-idle runtime so the GPU
 /// can suspend, and never fight another GPU owner.
-fn mobile_tick(
-    sup: &Arc<Mutex<Supervisor>>,
-    active_ticks: &mut u32,
-    start_attempted: &mut bool,
-    idle_ticks: &mut u32,
-) {
+fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, state: &mut TickState) {
     // A scan/verification child owns the GPU exclusively; its own
     // `/dev/nvidia*` fds and activity must never satisfy the start policy —
     // starting the engine here would race the child's raw GPU writes.
     if supervisor::active_child_kind(sup).is_some() {
         super::set_autostart_deferred(false);
-        *active_ticks = 0;
-        *start_attempted = false;
-        *idle_ticks = 0;
+        state.reset_wake_episode();
+        state.abandon_countdown("a scan/verification child took the GPU");
         return;
     }
     // The profile slot (running OR retained-after-failure) means the runtime
@@ -148,8 +195,7 @@ fn mobile_tick(
     // restarts, so it must not count as "deferred" either.
     if supervisor::profile_slot_occupied(sup) {
         super::set_autostart_deferred(false);
-        *active_ticks = 0;
-        *start_attempted = false;
+        state.reset_wake_episode();
         if supervisor::profile_engine_running(sup) {
             super::set_parked(false);
             // Park policy: the engine's own NVML polling resets the driver's
@@ -159,15 +205,32 @@ fn mobile_tick(
             // standing intent (persisted state kept) and reapplies at the
             // next real use.
             if gpu_in_use_by_client(supervisor::profile_gpu_index(sup)) {
-                *idle_ticks = 0;
+                if state.idle_ticks > 0 {
+                    logging::info(&format!(
+                        "deep sleep: park countdown reset after {}s: a GPU client appeared",
+                        state.idle_ticks
+                    ));
+                }
+                state.end_countdown();
             } else {
-                *idle_ticks += 1;
-                if *idle_ticks >= park_after_idle_ticks() {
-                    *idle_ticks = 0;
+                state.idle_ticks += 1;
+                if state.idle_ticks == 1 && !state.countdown_announced {
+                    state.countdown_announced = true;
+                    // Remaining time, not the window size: this tick already
+                    // counted, so the park lands threshold-1 seconds after
+                    // this line's own timestamp.
+                    logging::info(&format!(
+                        "deep sleep: no GPU clients; parking the runtime in {}s unless one appears",
+                        park_after_idle_ticks() - state.idle_ticks
+                    ));
+                }
+                if state.idle_ticks >= park_after_idle_ticks() {
+                    state.idle_ticks = 0;
                     logging::info(
                         "deep sleep: no GPU clients for the idle window; parking the runtime",
                     );
                     if supervisor::park_runtime_for_deep_sleep(sup) {
+                        state.end_countdown();
                         // Deferral first: the moment `parked` becomes
                         // visible, the status block must already say the
                         // runtime will reapply. In the other order a status
@@ -176,39 +239,63 @@ fn mobile_tick(
                         // runtime that claims it will not come back.
                         super::set_autostart_deferred(wakeable_runtime_pending());
                         super::set_parked(true);
+                    } else if !state.park_refusal_logged {
+                        // Once per client-free stretch: without this line a
+                        // refused park (game session owns the runtime, or
+                        // the engine did not stop in time) reads as a
+                        // countdown that silently went nowhere, repeating
+                        // every window.
+                        state.park_refusal_logged = true;
+                        logging::info(
+                            "deep sleep: park refused (a game session owns the runtime or the engine did not stop); retrying every idle window",
+                        );
                     }
                 }
             }
         } else {
-            *idle_ticks = 0;
+            state.abandon_countdown("the runtime engine is no longer running");
         }
         return;
     }
-    *idle_ticks = 0;
+    state.abandon_countdown("the runtime is no longer attached");
 
     let pending = wakeable_runtime_pending();
     super::set_autostart_deferred(pending);
     if !pending {
-        *active_ticks = 0;
-        *start_attempted = false;
+        state.reset_wake_episode();
         return;
     }
 
     if super::last_runtime_status() == Some(RuntimePmStatus::Active) {
-        *active_ticks += 1;
+        state.active_ticks += 1;
     } else {
-        *active_ticks = 0;
-        *start_attempted = false;
+        state.reset_wake_episode();
+        // Only an episode that starts from suspension can be a wake. One that
+        // starts while the GPU reads `active` is the drain tail of whatever
+        // just released it (a park, an exiting child) — the driver holds the
+        // GPU in D0 for its autosuspend delay after the last release.
+        state.woke_from_suspend = matches!(
+            super::last_runtime_status(),
+            Some(RuntimePmStatus::Suspended | RuntimePmStatus::Resuming)
+        );
     }
-    if *active_ticks >= SUSTAINED_ACTIVE_TICKS
-        && !*start_attempted
-        && gpu_in_use_by_client(supervisor::deferred_runtime_gpu_index())
-    {
-        logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
-        if supervisor::start_autostart_if_configured(sup) {
-            *start_attempted = true;
-            super::set_autostart_deferred(false);
-            super::set_parked(false);
+    if state.active_ticks >= SUSTAINED_ACTIVE_TICKS && !state.start_attempted {
+        if gpu_in_use_by_client(supervisor::deferred_runtime_gpu_index()) {
+            logging::info("deep sleep: GPU is in use; starting the deferred persisted runtime");
+            if supervisor::start_autostart_if_configured(sup) {
+                state.start_attempted = true;
+                super::set_autostart_deferred(false);
+                super::set_parked(false);
+            }
+        } else if state.woke_from_suspend && !state.transient_wake_logged {
+            // Once per genuine wake episode: the GPU came out of suspend but
+            // nothing holds a counted client, so the runtime stays deferred.
+            // This is the journal's answer to "the GPU woke up — why didn't
+            // the profile apply?": a capability probe, not use.
+            state.transient_wake_logged = true;
+            logging::info(
+                "deep sleep: GPU awake but no counted clients; keeping the runtime deferred (transient wake?)",
+            );
         }
     }
 }
@@ -255,12 +342,10 @@ fn gpu_in_use_by_client(gpu_index: Option<u32>) -> bool {
             }
         }
     }
-    let in_use = match observation.source {
-        GpuClientSource::NvmlContexts => {
-            !(observation.graphics.is_empty() && observation.compute.is_empty())
-        }
-        GpuClientSource::DeviceNodes => !observation.device_node_holders.is_empty(),
-    };
+    // The verdict, the status block's `total_count`, and the journal line all
+    // come from the same `counted_pids` definition, so they can never
+    // disagree about who was counted.
+    let in_use = observation.in_use();
     super::record_gpu_clients(observation);
     in_use
 }

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -1,0 +1,195 @@
+//! Startup supervisor for the deep-sleep gate.
+//!
+//! `startup` replaces the unconditional boot-time autostart: desktops (gate
+//! `Disabled`) start the persisted runtime synchronously exactly as before;
+//! RTD3 machines defer it and hand control to a watcher thread that polls the
+//! kernel's cached `runtime_status` (a wake-free read) once per second.
+//!
+//! The watcher starts the deferred runtime only when the GPU is demonstrably
+//! in use: sustained `active` AND some other process holding a `/dev/nvidia*`
+//! file descriptor. Bare `active` is not enough — transient wakes (Vulkan/GL
+//! capability probes from arbitrary apps, boot-time driver init) last seconds
+//! and attaching on them would hold the GPU awake, recreating the bug this
+//! module exists to fix (issue #30). While armed it also drops idle RPC
+//! backends so a one-off GUI telemetry query cannot pin NVML forever.
+
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crate::gpu_rpc;
+use crate::logging;
+use crate::supervisor::{self, Supervisor};
+
+use super::detect::{DeepSleepDecision, Rtd3Probe, RuntimePmStatus};
+
+const TICK: Duration = Duration::from_secs(1);
+/// How long an undecided gate may stay undecided before falling back to the
+/// classic path (device never appeared / driver never initialized).
+const UNDECIDED_GRACE_TICKS: u32 = 30;
+/// Consecutive `active` readings required before the wake counts as real.
+const SUSTAINED_ACTIVE_TICKS: u32 = 3;
+/// Idle TTL for lazily-opened RPC backends while the gate is armed.
+const RPC_BACKEND_IDLE_TTL: Duration = Duration::from_secs(30);
+
+/// Evaluate the gate and either run the classic synchronous autostart
+/// (desktops) or spawn the deep-sleep watcher (armed / undecided).
+pub fn startup(sup: &Arc<Mutex<Supervisor>>) {
+    let probe = Rtd3Probe::system();
+    let hint = supervisor::persisted_pci_bus_id_hint();
+    let decision = super::evaluate(&probe, hint.as_deref());
+
+    if matches!(decision, DeepSleepDecision::Disabled { .. }) {
+        supervisor::start_autostart_if_configured(sup);
+        return;
+    }
+
+    let sup = sup.clone();
+    thread::Builder::new()
+        .name("penguin-burner-rtd3".to_string())
+        .spawn(move || watch_loop(&sup, &probe, hint.as_deref()))
+        .expect("spawn rtd3 watcher thread");
+}
+
+fn watch_loop(sup: &Arc<Mutex<Supervisor>>, probe: &Rtd3Probe, hint: Option<&str>) {
+    // Phase 1: resolve an undecided gate. Stay detached while waiting — the
+    // whole point is that "don't know yet" must not attach NVML.
+    let mut undecided_ticks = 0u32;
+    loop {
+        match super::current_decision() {
+            Some(DeepSleepDecision::Armed { .. }) => break,
+            Some(DeepSleepDecision::Disabled { .. }) => {
+                supervisor::start_autostart_if_configured(sup);
+                return;
+            }
+            _ => {
+                if let Some(addr) = super::pci_addr() {
+                    super::note_runtime_status(probe.runtime_pm_status(&addr));
+                    if super::is_armed() {
+                        // Sticky suspended observation resolved it for us.
+                        break;
+                    }
+                }
+                undecided_ticks += 1;
+                if undecided_ticks > UNDECIDED_GRACE_TICKS {
+                    logging::warn(
+                        "deep sleep gate stayed undecided; falling back to classic runtime start",
+                    );
+                    supervisor::start_autostart_if_configured(sup);
+                    return;
+                }
+                super::evaluate(probe, hint);
+            }
+        }
+        thread::sleep(TICK);
+    }
+
+    // Phase 2: armed. Defer the persisted runtime until the GPU is really in
+    // use, and keep sweeping idle RPC backends so nothing pins the GPU.
+    let mut active_ticks = 0u32;
+    loop {
+        let released = gpu_rpc::release_idle_backends(RPC_BACKEND_IDLE_TTL);
+        if released > 0 {
+            logging::info(&format!(
+                "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
+            ));
+        }
+
+        let Some(addr) = super::pci_addr() else {
+            thread::sleep(TICK);
+            continue;
+        };
+        let status = probe.runtime_pm_status(&addr);
+        super::note_runtime_status(status);
+
+        if supervisor::profile_engine_running(sup) {
+            super::set_autostart_deferred(false);
+            active_ticks = 0;
+            thread::sleep(TICK);
+            continue;
+        }
+
+        let pending = supervisor::has_persisted_runtime();
+        super::set_autostart_deferred(pending);
+        if pending {
+            active_ticks = if status == RuntimePmStatus::Active {
+                active_ticks + 1
+            } else {
+                0
+            };
+            if active_ticks >= SUSTAINED_ACTIVE_TICKS && nvidia_client_present() {
+                logging::info(
+                    "deep sleep: GPU is in use; starting the deferred persisted runtime",
+                );
+                super::set_autostart_deferred(false);
+                supervisor::start_autostart_if_configured(sup);
+                active_ticks = 0;
+            }
+        } else {
+            active_ticks = 0;
+        }
+        thread::sleep(TICK);
+    }
+}
+
+/// True when a process other than the daemon holds a `/dev/nvidia*` fd —
+/// pure procfs reads, never touches the device. Root sees every process.
+fn nvidia_client_present() -> bool {
+    other_nvidia_client_in("/proc", std::process::id())
+}
+
+fn other_nvidia_client_in(proc_root: impl AsRef<Path>, self_pid: u32) -> bool {
+    let Ok(entries) = fs::read_dir(proc_root) else {
+        return false;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|n| n.parse::<u32>().ok()) else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let Ok(fds) = fs::read_dir(entry.path().join("fd")) else {
+            continue;
+        };
+        for fd in fds.filter_map(Result::ok) {
+            if let Ok(target) = fs::read_link(fd.path()) {
+                if target.to_string_lossy().starts_with("/dev/nvidia") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn detects_nvidia_fd_holders_and_skips_self() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let fd_dir = root.path().join("4242").join("fd");
+        fs::create_dir_all(&fd_dir).unwrap();
+        symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+        fs::create_dir_all(root.path().join("not-a-pid")).unwrap();
+
+        assert!(other_nvidia_client_in(root.path(), 1));
+        // The daemon's own fds never count as a client.
+        assert!(!other_nvidia_client_in(root.path(), 4242));
+    }
+
+    #[test]
+    fn no_client_when_fd_targets_are_unrelated() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let fd_dir = root.path().join("100").join("fd");
+        fs::create_dir_all(&fd_dir).unwrap();
+        symlink("/dev/dri/renderD128", fd_dir.join("3")).unwrap();
+        assert!(!other_nvidia_client_in(root.path(), 1));
+    }
+}

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -28,9 +28,9 @@
 //! context is reported but excluded: Dynamic Boost is driver infrastructure,
 //! and a real workload alongside it still has its own counted context. The
 //! context query owns one short-lived NVML-only session and closes it before
-//! returning. An idle result starts a wake-free quiet interval so observation
-//! cannot become a self-sustaining one-second GPU hold; a changed numbered-node
-//! holder set re-arms the query for a newly arrived workload.
+//! returning. An idle result latches until a changed numbered-node holder set
+//! or a runtime-PM sleep/wake cycle re-arms the query, so observation cannot
+//! become a periodic self-sustaining GPU hold.
 //! The watcher falls back to the fd scan only when the context query fails
 //! (driver too old for the _v3 symbols, no backend), applying the same narrow
 //! helper exclusion in confirmed fine-grained mode.
@@ -39,7 +39,7 @@
 
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::gpu_rpc;
 use crate::logging;
@@ -258,6 +258,12 @@ fn mobile_tick(
     if super::last_runtime_status() == Some(RuntimePmStatus::Active) {
         state.active_ticks += 1;
     } else {
+        if matches!(
+            super::last_runtime_status(),
+            Some(RuntimePmStatus::Suspended | RuntimePmStatus::Resuming)
+        ) {
+            clients.reset();
+        }
         state.reset_wake_episode();
         // Only an episode that starts from suspension can be a wake. One that
         // starts while the GPU reads `active` is the drain tail of whatever
@@ -312,8 +318,6 @@ fn client_verdict(
         gpu_index,
         fine_grained: super::fine_grained_mode(),
         runtime_status: super::last_runtime_status(),
-        autosuspend_delay: super::autosuspend_delay(),
-        now: Instant::now(),
     })
 }
 

--- a/burnerd/src/rtd3/watch.rs
+++ b/burnerd/src/rtd3/watch.rs
@@ -21,7 +21,7 @@
 //! GUI telemetry query cannot pin NVML forever.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -39,6 +39,19 @@ const DESKTOP_TICK: Duration = Duration::from_secs(60);
 const SUSTAINED_ACTIVE_TICKS: u32 = 3;
 /// Idle TTL for lazily-opened RPC backends in Mobile or Unknown mode.
 const RPC_BACKEND_IDLE_TTL: Duration = Duration::from_secs(30);
+
+/// Client-free seconds (one Mobile tick each) before a running engine is
+/// parked so the GPU can suspend. Wide enough to ride out game restarts,
+/// launcher hand-offs, and shader-compile gaps without a park/reattach
+/// cycle. Shrunk by the integration-test timing env so the park path can be
+/// exercised in seconds.
+fn park_after_idle_ticks() -> u32 {
+    if std::env::var_os("PENGUIN_BURNERD_TEST_TIMINGS").is_some_and(|v| !v.is_empty()) {
+        2
+    } else {
+        60
+    }
+}
 
 /// Evaluate the mode, run eager autostart only in definite Desktop mode
 /// (preserving the start-before-socket-bind ordering), and spawn the lifetime
@@ -71,6 +84,9 @@ fn watch_loop(
     // retry at 1 Hz, and a dead engine retained in the profile slot must not
     // produce log spam. Reset when the GPU leaves `active`.
     let mut start_attempted = false;
+    // Consecutive client-free ticks while an engine is attached; at the park
+    // threshold the runtime is parked so the GPU can reach D3cold.
+    let mut idle_ticks = 0u32;
 
     loop {
         super::evaluate(probe, hint);
@@ -82,7 +98,7 @@ fn watch_loop(
                     "deep sleep: released {released} idle GPU backend(s) so the GPU can suspend"
                 ));
             }
-            mobile_tick(sup, &mut active_ticks, &mut start_attempted);
+            mobile_tick(sup, &mut active_ticks, &mut start_attempted, &mut idle_ticks);
             thread::sleep(MOBILE_TICK);
             continue;
         }
@@ -99,8 +115,14 @@ fn watch_loop(
 }
 
 /// One Mobile/Unknown observation tick: hold the deferred runtime back until
-/// the GPU is genuinely in use, and never fight another GPU owner.
-fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attempted: &mut bool) {
+/// the GPU is genuinely in use, park an attached-but-idle runtime so the GPU
+/// can suspend, and never fight another GPU owner.
+fn mobile_tick(
+    sup: &Arc<Mutex<Supervisor>>,
+    active_ticks: &mut u32,
+    start_attempted: &mut bool,
+    idle_ticks: &mut u32,
+) {
     // A scan/verification child owns the GPU exclusively; its own
     // `/dev/nvidia*` fds and activity must never satisfy the start policy —
     // starting the engine here would race the child's raw GPU writes.
@@ -108,6 +130,7 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attem
         super::set_autostart_deferred(false);
         *active_ticks = 0;
         *start_attempted = false;
+        *idle_ticks = 0;
         return;
     }
     // The profile slot (running OR retained-after-failure) means the runtime
@@ -117,10 +140,40 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attem
         super::set_autostart_deferred(false);
         *active_ticks = 0;
         *start_attempted = false;
+        if supervisor::profile_engine_running(sup) {
+            super::set_parked(false);
+            // Park policy: the engine's own NVML polling resets the driver's
+            // idle timer forever, so an attached engine means the GPU can
+            // NEVER suspend on its own. When no other process holds a real
+            // /dev/nvidia<N> handle for the whole window, release the GPU:
+            // the profile stays a standing intent (persisted state kept) and
+            // reapplies at the next real use.
+            if nvidia_client_present() {
+                *idle_ticks = 0;
+            } else {
+                *idle_ticks += 1;
+                if *idle_ticks >= park_after_idle_ticks() {
+                    *idle_ticks = 0;
+                    logging::info(
+                        "deep sleep: no GPU clients for the idle window; parking the runtime",
+                    );
+                    if supervisor::park_runtime_for_deep_sleep(sup) {
+                        super::set_parked(true);
+                        // The parked intent is pending again from this very
+                        // instant — a status read between ticks must not
+                        // claim otherwise.
+                        super::set_autostart_deferred(wakeable_runtime_pending());
+                    }
+                }
+            }
+        } else {
+            *idle_ticks = 0;
+        }
         return;
     }
+    *idle_ticks = 0;
 
-    let pending = supervisor::deferred_runtime_pending();
+    let pending = wakeable_runtime_pending();
     super::set_autostart_deferred(pending);
     if !pending {
         *active_ticks = 0;
@@ -139,14 +192,29 @@ fn mobile_tick(sup: &Arc<Mutex<Supervisor>>, active_ticks: &mut u32, start_attem
         if supervisor::start_autostart_if_configured(sup) {
             *start_attempted = true;
             super::set_autostart_deferred(false);
+            super::set_parked(false);
         }
     }
 }
 
+/// A runtime is pending AND worth waking for. A pending stock runtime
+/// enforces nothing: attaching an engine for it would only pin the GPU, so
+/// it neither counts as deferred nor wakes.
+fn wakeable_runtime_pending() -> bool {
+    supervisor::deferred_runtime_pending()
+        && supervisor::deferred_runtime_mode().as_deref() != Some("stock")
+}
+
 /// True when a process other than the daemon holds a `/dev/nvidia<N>` fd —
 /// pure procfs reads, never touches the device. Root sees every process.
+/// Test seam (never set in production): `PENGUIN_BURNERD_TEST_CLIENT_PROC`
+/// points the scan at a fake proc tree so integration tests can stage and
+/// remove GPU clients deterministically on any machine.
 fn nvidia_client_present() -> bool {
-    other_nvidia_client_in("/proc", std::process::id())
+    let proc_root = std::env::var_os("PENGUIN_BURNERD_TEST_CLIENT_PROC")
+        .filter(|v| !v.is_empty())
+        .map_or_else(|| PathBuf::from("/proc"), PathBuf::from);
+    other_nvidia_client_in(proc_root, std::process::id())
 }
 
 /// Only the numbered render nodes count as a real GPU client. `nvidiactl`,

--- a/burnerd/src/scan.rs
+++ b/burnerd/src/scan.rs
@@ -208,8 +208,9 @@ fn run_child(
         ChildStart::SpawnFailed(err) => {
             // `begin_child` already stopped the active profile before spawn.
             // A permission/path failure must not leave the user's standing
-            // runtime silently disabled.
-            supervisor::start_autostart_if_configured(sup);
+            // runtime silently disabled (deep-sleep armed: the watcher owns
+            // the restart so a sleeping GPU is not force-attached).
+            supervisor::resume_autostart_after_child(sup);
             write_json_line(
                 writer,
                 &StreamError::new(format!("failed to launch {}: {err}", launch_label(kind))),

--- a/burnerd/src/scan.rs
+++ b/burnerd/src/scan.rs
@@ -208,7 +208,7 @@ fn run_child(
         ChildStart::SpawnFailed(err) => {
             // `begin_child` already stopped the active profile before spawn.
             // A permission/path failure must not leave the user's standing
-            // runtime silently disabled (deep-sleep armed: the watcher owns
+            // runtime silently disabled (Mobile/Unknown: the watcher owns
             // the restart so a sleeping GPU is not force-attached).
             supervisor::resume_autostart_after_child(sup);
             write_json_line(

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -661,7 +661,13 @@ pub fn status(sup: &Mutex<Supervisor>) -> StatusResult {
     let supervisor = guard(sup);
     let game_runtime = supervisor.game_runtime_status();
     let energy_savings = energy_savings_status();
-    let deep_sleep = crate::rtd3::status();
+    let deep_sleep = crate::rtd3::status(crate::rtd3::DaemonGpuHolds {
+        engine_attached: supervisor
+            .profile
+            .as_ref()
+            .is_some_and(|job| job.engine.returncode().is_none()),
+        rpc_backends: crate::gpu_rpc::open_backend_count(),
+    });
 
     if let Some(job) = &supervisor.child {
         let returncode = job.proc.poll();

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -540,6 +540,50 @@ pub fn deferred_runtime_pending() -> bool {
     )
 }
 
+/// Mode name of the runtime spec the deep-sleep watcher would start, using
+/// the same active-then-boot precedence (and boot-consumption rule) as
+/// `deferred_runtime_pending`. `None` when nothing is pending.
+pub fn deferred_runtime_mode() -> Option<String> {
+    if let Ok(Some(spec)) = load_runtime_spec(&active_state_file_path()) {
+        return Some(spec.mode_name().to_string());
+    }
+    if !BOOT_RUNTIME_CONSUMED.load(Ordering::SeqCst) {
+        if let Ok(Some(spec)) = load_runtime_spec(&boot_state_file_path()) {
+            return Some(spec.mode_name().to_string());
+        }
+    }
+    None
+}
+
+/// Deep-sleep park: stop the running engine while deliberately KEEPING the
+/// persisted runtime state and the boot intent — the profile stays a standing
+/// intent that the rtd3 watcher re-materializes at the GPU's next real use.
+/// The engine's cleanup restores fans to hardware auto and releases the clock
+/// lock; the remaining applied state evaporates with D3cold anyway. Refuses
+/// while a game session owns the runtime lifecycle or the engine wedges.
+pub fn park_runtime_for_deep_sleep(sup: &Mutex<Supervisor>) -> bool {
+    let mut supervisor = guard(sup);
+    if !supervisor.game_runtime.watches.is_empty() {
+        return false;
+    }
+    let stop_timeout = supervisor.stop_timeout;
+    match supervisor.profile.as_mut() {
+        Some(job) if job.engine.is_running() => match job.engine.stop(stop_timeout) {
+            StopOutcome::Stopped => {
+                supervisor.profile = None;
+                true
+            }
+            StopOutcome::TimedOut => {
+                logging::error(
+                    "deep sleep park: engine did not stop within timeout; staying attached",
+                );
+                false
+            }
+        },
+        _ => false,
+    }
+}
+
 /// True while the profile slot is occupied at all — running, or retained
 /// after a failure/wedge (which deliberately blocks further starts).
 pub fn profile_slot_occupied(sup: &Mutex<Supervisor>) -> bool {
@@ -989,8 +1033,10 @@ pub fn apply_runtime_spec(
 
 pub fn stop_runtime_profile(sup: &Mutex<Supervisor>) -> Result<StopResult, String> {
     // An explicit stop settles this session's runtime intent: the boot spec
-    // must not be resurrected by the deep-sleep watcher afterwards.
+    // must not be resurrected by the deep-sleep watcher afterwards, and a
+    // parked runtime is dissolved rather than left claiming otherwise.
     BOOT_RUNTIME_CONSUMED.store(true, Ordering::SeqCst);
+    crate::rtd3::set_parked(false);
     let mut supervisor = guard(sup);
     let stop_timeout = supervisor.stop_timeout;
     match supervisor.profile.as_mut() {

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -590,6 +590,30 @@ pub fn profile_slot_occupied(sup: &Mutex<Supervisor>) -> bool {
     guard(sup).profile.is_some()
 }
 
+/// GPU index of the runtime in the profile slot, for the deep-sleep park
+/// policy's client check.
+pub fn profile_gpu_index(sup: &Mutex<Supervisor>) -> Option<u32> {
+    guard(sup)
+        .profile
+        .as_ref()
+        .map(|job| job.spec.gpu.index_at_resolution)
+}
+
+/// GPU index of the runtime spec the deep-sleep watcher would start, using
+/// the same active-then-boot precedence (and boot-consumption rule) as
+/// `deferred_runtime_pending`. `None` when nothing is pending.
+pub fn deferred_runtime_gpu_index() -> Option<u32> {
+    if let Ok(Some(spec)) = load_runtime_spec(&active_state_file_path()) {
+        return Some(spec.gpu.index_at_resolution);
+    }
+    if !BOOT_RUNTIME_CONSUMED.load(Ordering::SeqCst) {
+        if let Ok(Some(spec)) = load_runtime_spec(&boot_state_file_path()) {
+            return Some(spec.gpu.index_at_resolution);
+        }
+    }
+    None
+}
+
 /// Post-child runtime recovery: Desktop mode restarts immediately; Mobile and
 /// Unknown leave the start to the watcher so a scan exit cannot force-attach a
 /// GPU that is about to idle.

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -506,9 +506,9 @@ fn load_runtime_spec(path: &PathBuf) -> Result<Option<RuntimeSpec>, String> {
     Ok(Some(spec))
 }
 
-/// PCI bus id from the persisted runtime specs, for the deep-sleep gate to
+/// PCI bus id from the persisted runtime specs, for the deep-sleep mode to
 /// locate the GPU in sysfs before any NVML init. Empty on legacy specs saved
-/// before the field existed; the gate then falls back to PCI enumeration.
+/// before the field existed; detection then falls back to PCI enumeration.
 pub fn persisted_pci_bus_id_hint() -> Option<String> {
     for path in [active_state_file_path(), boot_state_file_path()] {
         if let Ok(Some(spec)) = load_runtime_spec(&path) {
@@ -546,11 +546,11 @@ pub fn profile_slot_occupied(sup: &Mutex<Supervisor>) -> bool {
     guard(sup).profile.is_some()
 }
 
-/// Post-child runtime recovery: on desktops this is the classic immediate
-/// restart; while the deep-sleep gate is armed the watcher owns runtime
-/// starts (a scan's exit must not force-attach a GPU that is about to idle).
+/// Post-child runtime recovery: Desktop mode restarts immediately; Mobile and
+/// Unknown leave the start to the watcher so a scan exit cannot force-attach a
+/// GPU that is about to idle.
 pub fn resume_autostart_after_child(sup: &Arc<Mutex<Supervisor>>) {
-    if crate::rtd3::is_armed() {
+    if !crate::rtd3::allows_desktop_autostart() {
         logging::info("deep sleep: leaving post-child runtime start to the watcher");
         return;
     }
@@ -1148,10 +1148,15 @@ pub fn boot_runtime_spec_summary() -> Result<Value, String> {
 /// start its stock fallback instead of trying an older spec that may identify a
 /// different GPU. Persisting the stock fallback shadows the broken intent only
 /// for the current boot; the explicit boot spec is retried after reboot.
-pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) {
+///
+/// Atomically start persisted runtime intent only when neither an engine nor a
+/// scan/verification child owns the GPU. Returns true once a valid spec was
+/// attempted (success or handled failure), and false when idle prerequisites
+/// or persisted intent were absent.
+pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) -> bool {
     let mut supervisor = guard(sup);
-    if supervisor.profile.is_some() {
-        return;
+    if supervisor.profile.is_some() || supervisor.child_running_kind().is_some() {
+        return false;
     }
 
     let candidates = [
@@ -1186,7 +1191,7 @@ pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) {
                 }
                 drop(supervisor);
                 persist_active_runtime(&spec);
-                return;
+                return true;
             }
             Err(error) => {
                 let (message, failed_engine) = error.into_parts();
@@ -1196,11 +1201,11 @@ pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) {
                 ));
                 if let Some(engine) = failed_engine {
                     supervisor.profile = Some(ProfileJob { engine, spec });
-                    return;
+                    return true;
                 }
 
                 if spec.mode_name() == "stock" {
-                    return;
+                    return true;
                 }
                 let stock = spec.stock_fallback();
                 match profile::start(stock.clone()) {
@@ -1233,10 +1238,11 @@ pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) {
                         }
                     }
                 }
-                return;
+                return true;
             }
         }
     }
+    false
 }
 
 /// Shutdown cleanup: stop the in-process engine (A3 releases fans + clock lock).
@@ -1396,9 +1402,9 @@ mod tests {
     }
 
     /// After a wedged engine finally exits, the dead job must NOT linger in the
-    /// slot — otherwise `start_autostart_if_configured` (early-returns while
-    /// `profile.is_some()`) never re-applies the persisted profile after a scan.
-    /// `stop_engine_for_child` frees the exited slot on the next start.
+    /// slot — otherwise `start_autostart_if_configured` (which refuses an
+    /// occupied profile slot) never re-applies the persisted profile after a
+    /// scan. `stop_engine_for_child` frees the exited slot on the next start.
     #[test]
     fn stop_engine_for_child_frees_an_already_exited_job() {
         let sup = wedged_supervisor(Duration::from_millis(100), Duration::from_millis(50));
@@ -1448,6 +1454,36 @@ mod tests {
             .unwrap();
         assert_eq!(loaded.gpu.uuid, "GPU-round-trip");
         assert_eq!(loaded.mode_name(), "stock");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn autostart_atomically_refuses_a_running_child() {
+        use std::process::Command;
+
+        let _lock = STATE_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = env::temp_dir().join(format!("pb-state-child-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("active-runtime.json");
+        let _state_guard = StateEnvGuard::new(&path);
+        let _inert_guard = StateEnvGuard::named("PENGUIN_BURNERD_TEST_INERT_ENGINE", "1");
+        persist_runtime_spec(&path, &RuntimeSpec::test_stock("GPU-child-gate")).unwrap();
+
+        let child = Command::new("sleep").arg("10").spawn().expect("spawn sleep");
+        let job = Arc::new(ChildJob {
+            proc: ChildProc::new(child).expect("shared child"),
+            argv: vec!["sleep".to_string(), "10".to_string()],
+            generation: 1,
+            kind: ChildKind::Scan,
+        });
+        let supervisor = Arc::new(Mutex::new(Supervisor::new()));
+        guard(&supervisor).child = Some(job.clone());
+
+        assert!(!start_autostart_if_configured(&supervisor));
+        assert!(guard(&supervisor).profile.is_none());
+
+        job.proc.signal(libc::SIGKILL);
+        job.proc.wait();
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -505,6 +505,28 @@ fn load_runtime_spec(path: &PathBuf) -> Result<Option<RuntimeSpec>, String> {
     Ok(Some(spec))
 }
 
+/// PCI bus id from the persisted runtime specs, for the deep-sleep gate to
+/// locate the GPU in sysfs before any NVML init. Empty on legacy specs saved
+/// before the field existed; the gate then falls back to PCI enumeration.
+pub fn persisted_pci_bus_id_hint() -> Option<String> {
+    for path in [active_state_file_path(), boot_state_file_path()] {
+        if let Ok(Some(spec)) = load_runtime_spec(&path) {
+            if !spec.gpu.pci_bus_id.is_empty() {
+                return Some(spec.gpu.pci_bus_id);
+            }
+        }
+    }
+    None
+}
+
+/// True when a persisted runtime exists that `start_autostart_if_configured`
+/// would start — what the deep-sleep watcher holds back while the GPU sleeps.
+pub fn has_persisted_runtime() -> bool {
+    [active_state_file_path(), boot_state_file_path()]
+        .iter()
+        .any(|path| matches!(load_runtime_spec(path), Ok(Some(_))))
+}
+
 fn persist_active_runtime(spec: &RuntimeSpec) {
     if let Err(error) = persist_runtime_spec(&active_state_file_path(), spec) {
         logging::error(&error);
@@ -541,6 +563,7 @@ pub fn status(sup: &Mutex<Supervisor>) -> StatusResult {
     let supervisor = guard(sup);
     let game_runtime = supervisor.game_runtime_status();
     let energy_savings = energy_savings_status();
+    let deep_sleep = crate::rtd3::status();
 
     if let Some(job) = &supervisor.child {
         let returncode = job.proc.poll();
@@ -575,7 +598,8 @@ pub fn status(sup: &Mutex<Supervisor>) -> StatusResult {
             }),
         )
         .with_game_runtime(game_runtime)
-        .with_energy_savings(energy_savings);
+        .with_energy_savings(energy_savings)
+        .with_deep_sleep(deep_sleep);
     }
 
     if let Some(job) = &supervisor.profile {
@@ -600,12 +624,14 @@ pub fn status(sup: &Mutex<Supervisor>) -> StatusResult {
             }),
         )
         .with_game_runtime(game_runtime)
-        .with_energy_savings(energy_savings);
+        .with_energy_savings(energy_savings)
+        .with_deep_sleep(deep_sleep);
     }
 
     StatusResult::new("idle", None)
         .with_game_runtime(game_runtime)
         .with_energy_savings(energy_savings)
+        .with_deep_sleep(deep_sleep)
 }
 
 pub fn stop_auto_uv_scan(sup: &Mutex<Supervisor>) -> StopResult {

--- a/burnerd/src/supervisor.rs
+++ b/burnerd/src/supervisor.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::PathBuf;
 use std::process::{Child, ExitStatus};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -519,12 +520,41 @@ pub fn persisted_pci_bus_id_hint() -> Option<String> {
     None
 }
 
-/// True when a persisted runtime exists that `start_autostart_if_configured`
-/// would start — what the deep-sleep watcher holds back while the GPU sleeps.
-pub fn has_persisted_runtime() -> bool {
-    [active_state_file_path(), boot_state_file_path()]
-        .iter()
-        .any(|path| matches!(load_runtime_spec(path), Ok(Some(_))))
+/// Set once this session's boot intent has been acted on (an autostart ran,
+/// or the user explicitly stopped the runtime). The boot spec must apply at
+/// most once per daemon lifetime — the deep-sleep watcher must not resurrect
+/// a runtime the user stopped just because the boot file still exists.
+static BOOT_RUNTIME_CONSUMED: AtomicBool = AtomicBool::new(false);
+
+fn deferred_pending_from(active_exists: bool, boot_exists: bool, boot_consumed: bool) -> bool {
+    active_exists || (boot_exists && !boot_consumed)
+}
+
+/// True when a persisted runtime exists that the deep-sleep watcher should
+/// hold back while the GPU sleeps and start when it is really in use.
+pub fn deferred_runtime_pending() -> bool {
+    deferred_pending_from(
+        matches!(load_runtime_spec(&active_state_file_path()), Ok(Some(_))),
+        matches!(load_runtime_spec(&boot_state_file_path()), Ok(Some(_))),
+        BOOT_RUNTIME_CONSUMED.load(Ordering::SeqCst),
+    )
+}
+
+/// True while the profile slot is occupied at all — running, or retained
+/// after a failure/wedge (which deliberately blocks further starts).
+pub fn profile_slot_occupied(sup: &Mutex<Supervisor>) -> bool {
+    guard(sup).profile.is_some()
+}
+
+/// Post-child runtime recovery: on desktops this is the classic immediate
+/// restart; while the deep-sleep gate is armed the watcher owns runtime
+/// starts (a scan's exit must not force-attach a GPU that is about to idle).
+pub fn resume_autostart_after_child(sup: &Arc<Mutex<Supervisor>>) {
+    if crate::rtd3::is_armed() {
+        logging::info("deep sleep: leaving post-child runtime start to the watcher");
+        return;
+    }
+    start_autostart_if_configured(sup);
 }
 
 fn persist_active_runtime(spec: &RuntimeSpec) {
@@ -958,6 +988,9 @@ pub fn apply_runtime_spec(
 }
 
 pub fn stop_runtime_profile(sup: &Mutex<Supervisor>) -> Result<StopResult, String> {
+    // An explicit stop settles this session's runtime intent: the boot spec
+    // must not be resurrected by the deep-sleep watcher afterwards.
+    BOOT_RUNTIME_CONSUMED.store(true, Ordering::SeqCst);
     let mut supervisor = guard(sup);
     let stop_timeout = supervisor.stop_timeout;
     match supervisor.profile.as_mut() {
@@ -1065,7 +1098,7 @@ pub fn finish_child(sup: &Arc<Mutex<Supervisor>>, job: &Arc<ChildJob>) {
         }
     };
     if restart {
-        start_autostart_if_configured(sup);
+        resume_autostart_after_child(sup);
     }
 }
 
@@ -1134,6 +1167,7 @@ pub fn start_autostart_if_configured(sup: &Arc<Mutex<Supervisor>>) {
                 continue;
             }
         };
+        BOOT_RUNTIME_CONSUMED.store(true, Ordering::SeqCst);
         match profile::start(spec.clone()) {
             Ok(engine) => {
                 logging::info(&format!(
@@ -1226,6 +1260,17 @@ mod tests {
 
     // `STATE_FILE_ENV` is process-global; serialize the tests that mutate it.
     static STATE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn deferred_pending_honors_boot_consumption() {
+        // The active-session spec always re-arms the watcher.
+        assert!(deferred_pending_from(true, false, false));
+        assert!(deferred_pending_from(true, true, true));
+        // The boot spec arms it at most once per daemon lifetime.
+        assert!(deferred_pending_from(false, true, false));
+        assert!(!deferred_pending_from(false, true, true));
+        assert!(!deferred_pending_from(false, false, false));
+    }
 
     struct StateEnvGuard {
         name: &'static str,

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -85,7 +85,11 @@ impl Daemon {
             .env_remove("PENGUIN_BURNER_DAEMON_ALLOWED_UID")
             .env_remove("NOTIFY_SOCKET")
             .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            // The daemon logs to stderr (journald's view); capture it so
+            // tests can assert the journal narrative the docs promise.
+            .stderr(Stdio::from(
+                std::fs::File::create(dir.join("daemon.stderr.log")).unwrap(),
+            ));
         for (key, value) in extra_env {
             command.env(key, value);
         }
@@ -129,6 +133,12 @@ impl Daemon {
         let mut reader = BufReader::new(stream);
         let line = read_line(&mut reader).expect("a response line");
         serde_json::from_str(&line).expect("valid JSON response")
+    }
+
+    /// Everything the daemon has logged so far (its stderr — what journald
+    /// would show).
+    fn stderr_log(&self) -> String {
+        std::fs::read_to_string(self.dir.join("daemon.stderr.log")).unwrap_or_default()
     }
 
     fn stop_request_file(&self) -> PathBuf {
@@ -1252,6 +1262,10 @@ fn write_rtd3_tree(
         format!("{runtime_status}\n"),
     )
     .unwrap();
+    // Cumulative runtime-PM residency counters (ms), surfaced in the status
+    // block so testers can quantify how much the GPU really sleeps.
+    std::fs::write(power.join("runtime_active_time"), "5123\n").unwrap();
+    std::fs::write(power.join("runtime_suspended_time"), "60789\n").unwrap();
     let proc_gpu = proc_root.join(addr);
     std::fs::create_dir_all(&proc_gpu).unwrap();
     std::fs::write(
@@ -1302,6 +1316,9 @@ fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
         if deep_sleep["autostart_deferred"] == Value::Bool(true) {
             assert_eq!(deep_sleep["runtime_status"], "suspended", "{status}");
             assert_eq!(deep_sleep["suspended_observed"], Value::Bool(true), "{status}");
+            // The kernel residency counters pass through from the fake sysfs.
+            assert_eq!(deep_sleep["runtime_active_ms"], 5123, "{status}");
+            assert_eq!(deep_sleep["runtime_suspended_ms"], 60789, "{status}");
             deferred = true;
             break;
         }
@@ -1624,6 +1641,32 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
         std::thread::sleep(Duration::from_millis(50));
     }
     assert!(stats_seen, "gpu_clients never reported the per-kind stats");
+
+    // The journal narrative the docs promise, end to end: countdown start
+    // (remaining time, threshold-1 under the 2-tick test window), park,
+    // kernel transition, the wake sample with the counted verdict, and the
+    // re-materialization. Substring checks: other lines may interleave.
+    let log = daemon.stderr_log();
+    for expected in [
+        "deep sleep: runtime_status suspended (initial)",
+        "deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, device-node holders=0",
+        "deep sleep: no GPU clients; parking the runtime in 1s unless one appears",
+        "deep sleep: no GPU clients for the idle window; parking the runtime",
+        "deep sleep: runtime parked; the GPU may suspend until its next real use",
+        "deep sleep: runtime_status suspended -> active (suspended for ",
+        "deep sleep: gpu clients (nvml-contexts): counted=2 (GPU in use), graphics=1 [4242 some-game], compute=1 [555 cuda-worker], device-node holders=0",
+        "deep sleep: GPU is in use; starting the deferred persisted runtime",
+        "deep sleep: runtime deferral cleared",
+        "deep sleep: parked runtime re-materialized",
+    ] {
+        assert!(log.contains(expected), "journal missing {expected:?}:\n{log}");
+    }
+    // The park drain must NOT be mislabeled as a wake: the GPU never came
+    // out of suspend without a client in this scenario.
+    assert!(
+        !log.contains("transient wake"),
+        "park drain was mislabeled as a transient wake:\n{log}"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -64,6 +64,11 @@ impl Daemon {
         let boot_state_file = dir.join("boot-state.json");
         let stub = dir.join("scan_stub.py");
         std::fs::write(&stub, STUB).unwrap();
+        // Generic daemon tests exercise the established always-attached path.
+        // Declare that fake machine as Desktop explicitly; no visible GPU now
+        // correctly resolves to Unknown and must stay detached.
+        let (default_rtd3_sys, default_rtd3_proc) =
+            write_rtd3_tree(&dir, "Disabled by default", "auto", "active");
 
         let mut command = Command::new(env!("CARGO_BIN_EXE_penguin-burnerd"));
         command
@@ -75,6 +80,8 @@ impl Daemon {
             .env("PENGUIN_BURNERD_TEST_BOOT_STATE_FILE", &boot_state_file)
             .env("PENGUIN_BURNERD_TEST_INERT_ENGINE", "1")
             .env("PENGUIN_BURNERD_TEST_TIMINGS", "1")
+            .env("PENGUIN_BURNERD_TEST_RTD3_SYSFS", default_rtd3_sys)
+            .env("PENGUIN_BURNERD_TEST_RTD3_PROC", default_rtd3_proc)
             .env_remove("PENGUIN_BURNER_DAEMON_ALLOWED_UID")
             .env_remove("NOTIFY_SOCKET")
             .stdout(Stdio::null())
@@ -1271,12 +1278,12 @@ fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
         ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
     ]);
 
-    // The gate is evaluated synchronously before the socket binds: armed, and
+    // The mode is evaluated synchronously before the socket binds: Mobile, and
     // the persisted runtime must NOT be running while the GPU sleeps.
     let status = daemon.request(r#"{"method":"status"}"#);
     let result = &status["result"];
     assert_eq!(result["state"], "idle", "{status}");
-    assert_eq!(result["deep_sleep"]["state"], "armed", "{status}");
+    assert_eq!(result["deep_sleep"]["state"], "mobile", "{status}");
     assert_eq!(result["deep_sleep"]["mode"], "fine-grained", "{status}");
     assert_eq!(result["deep_sleep"]["pci_addr"], "0000:01:00.0", "{status}");
 
@@ -1302,7 +1309,7 @@ fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
 }
 
 #[test]
-fn deep_sleep_disabled_on_desktop_runs_autostart_immediately() {
+fn deep_sleep_desktop_mode_runs_autostart_immediately() {
     let n = COUNTER.fetch_add(1, Ordering::SeqCst);
     let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
     let _ = std::fs::remove_dir_all(&dir);
@@ -1317,14 +1324,41 @@ fn deep_sleep_disabled_on_desktop_runs_autostart_immediately() {
         ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
     ]);
 
-    // Desktop verdict: the classic synchronous autostart path, byte-for-byte.
+    // Desktop mode preserves synchronous eager autostart.
     let status = daemon.request(r#"{"method":"status"}"#);
     let result = &status["result"];
     assert_eq!(result["state"], "runtime_profile_running", "{status}");
-    assert_eq!(result["deep_sleep"]["state"], "disabled", "{status}");
+    assert_eq!(result["deep_sleep"]["state"], "desktop", "{status}");
     assert_eq!(
         result["deep_sleep"]["autostart_deferred"],
         Value::Bool(false),
+        "{status}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn suspended_observation_selects_mobile_before_desktop_autostart() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Disabled by default", "auto", "suspended");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+    ]);
+
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["state"], "idle", "{status}");
+    assert_eq!(status["result"]["deep_sleep"]["state"], "mobile", "{status}");
+    assert_eq!(
+        status["result"]["deep_sleep"]["suspended_observed"],
+        Value::Bool(true),
         "{status}"
     );
     let _ = std::fs::remove_dir_all(&dir);
@@ -1347,7 +1381,7 @@ fn deep_sleep_scan_completion_does_not_force_start_the_deferred_runtime() {
         ("SCAN_STUB_EXIT_AFTER_LINES", "1"),
     ]);
 
-    // Armed and deferred at boot; a completed scan must hand the restart to
+    // Mobile and deferred at boot; a completed scan must hand the restart to
     // the watcher (which sees a suspended GPU) instead of force-starting the
     // runtime and pinning the GPU — the desktop finish_child behavior.
     finish_successful_scan(&daemon);
@@ -1367,5 +1401,96 @@ fn deep_sleep_scan_completion_does_not_force_start_the_deferred_runtime() {
         std::thread::sleep(Duration::from_millis(50));
     }
     assert!(deferred, "deferral did not resume after the scan");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_unknown_scan_completion_stays_deferred() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "?", "auto", "active");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("SCAN_STUB_EXIT_AFTER_LINES", "1"),
+    ]);
+
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["deep_sleep"]["state"], "unknown", "{status}");
+    finish_successful_scan(&daemon);
+
+    // Unknown follows conservative Mobile behavior: child completion must not
+    // invoke the eager Desktop autostart path.
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["state"], "idle", "{status}");
+    assert_eq!(status["result"]["deep_sleep"]["state"], "unknown", "{status}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_unknown_resolves_to_desktop_and_autostarts() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "?", "auto", "active");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+    ]);
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["deep_sleep"]["state"], "unknown", "{status}");
+
+    std::fs::write(
+        proc_root.join("0000:01:00.0").join("power"),
+        "Runtime D3 status:          Disabled by default\n",
+    )
+    .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["state"] == "runtime_profile_running" {
+            assert_eq!(status["result"]["deep_sleep"]["state"], "desktop", "{status}");
+            break;
+        }
+        assert!(Instant::now() < deadline, "Unknown never resolved: {status}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn mobile_mode_rejects_persistence_enable_rpc() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_MOCK_GPU", "1"),
+    ]);
+
+    let response =
+        daemon.request(r#"{"method":"gpu_enable_persistence_mode","gpu_index":0}"#);
+    assert_eq!(response["ok"], Value::Bool(false), "{response}");
+    assert!(
+        response["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("Mobile or Unknown")),
+        "{response}"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1329,3 +1329,43 @@ fn deep_sleep_disabled_on_desktop_runs_autostart_immediately() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn deep_sleep_scan_completion_does_not_force_start_the_deferred_runtime() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("SCAN_STUB_EXIT_AFTER_LINES", "1"),
+    ]);
+
+    // Armed and deferred at boot; a completed scan must hand the restart to
+    // the watcher (which sees a suspended GPU) instead of force-starting the
+    // runtime and pinning the GPU — the desktop finish_child behavior.
+    finish_successful_scan(&daemon);
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["state"], "idle", "{status}");
+
+    // The deferral resumes: still pending, never started.
+    let mut deferred = false;
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let result = &status["result"];
+        if result["deep_sleep"]["autostart_deferred"] == Value::Bool(true) {
+            assert_eq!(result["state"], "idle", "{status}");
+            deferred = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(deferred, "deferral did not resume after the scan");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1556,6 +1556,13 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
                 Value::Bool(true),
                 "{status}"
             );
+            // The client sample behind the park decision: no contexts, no
+            // holders — nothing counted.
+            let clients = &result["deep_sleep"]["gpu_clients"];
+            assert_eq!(clients["source"], "nvml-contexts", "{status}");
+            assert_eq!(clients["total_count"], 0, "{status}");
+            assert_eq!(clients["graphics_count"], 0, "{status}");
+            assert_eq!(clients["compute_count"], 0, "{status}");
             parked = true;
             break;
         }
@@ -1567,14 +1574,19 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
         "parking must keep the persisted runtime state"
     );
 
-    // Simulate real use: GPU active + a process with a live GPU context. The
-    // watcher must re-materialize the parked profile.
+    // Simulate real use: GPU active + processes with live GPU contexts (one
+    // graphics, one compute; comm files supply the names the status block
+    // reports). The watcher must re-materialize the parked profile.
     std::fs::write(
         sys.join("0000:01:00.0/power/runtime_status"),
         "active\n",
     )
     .unwrap();
-    std::fs::write(&contexts, "4242\n").unwrap();
+    std::fs::create_dir_all(clients.join("4242")).unwrap();
+    std::fs::write(clients.join("4242/comm"), "some-game\n").unwrap();
+    std::fs::create_dir_all(clients.join("555")).unwrap();
+    std::fs::write(clients.join("555/comm"), "cuda-worker\n").unwrap();
+    std::fs::write(&contexts, "graphics 4242\ncompute 555\n").unwrap();
 
     let mut reattached = false;
     for _ in 0..200 {
@@ -1592,6 +1604,26 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
         std::thread::sleep(Duration::from_millis(50));
     }
     assert!(reattached, "parked runtime was never re-materialized on use");
+
+    // The per-kind stats name the processes that woke the runtime.
+    let mut stats_seen = false;
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+        if clients["total_count"] == 2 {
+            assert_eq!(clients["source"], "nvml-contexts", "{status}");
+            assert_eq!(clients["graphics_count"], 1, "{status}");
+            assert_eq!(clients["compute_count"], 1, "{status}");
+            assert_eq!(clients["graphics"][0]["pid"], 4242, "{status}");
+            assert_eq!(clients["graphics"][0]["name"], "some-game", "{status}");
+            assert_eq!(clients["compute"][0]["pid"], 555, "{status}");
+            assert_eq!(clients["compute"][0]["name"], "cuda-worker", "{status}");
+            stats_seen = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(stats_seen, "gpu_clients never reported the per-kind stats");
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -1674,6 +1706,7 @@ fn deep_sleep_fine_grained_ignores_idle_device_node_holders() {
     let fd_dir = clients.join("4242").join("fd");
     std::fs::create_dir_all(&fd_dir).unwrap();
     std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+    std::fs::write(clients.join("4242/comm"), "plasmashell\n").unwrap();
     let contexts = dir.join("context-pids");
 
     let daemon = Daemon::start(&[
@@ -1698,6 +1731,17 @@ fn deep_sleep_fine_grained_ignores_idle_device_node_holders() {
     for _ in 0..200 {
         let status = daemon.request(r#"{"method":"status"}"#);
         if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            // The sample shows the holder as informational, not counted:
+            // exactly the evidence that explains this park to a debugger.
+            let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+            assert_eq!(clients["source"], "nvml-contexts", "{status}");
+            assert_eq!(clients["total_count"], 0, "{status}");
+            assert_eq!(clients["device_node_count"], 1, "{status}");
+            assert_eq!(clients["device_node_holders"][0]["pid"], 4242, "{status}");
+            assert_eq!(
+                clients["device_node_holders"][0]["name"], "plasmashell",
+                "{status}"
+            );
             parked = true;
             break;
         }
@@ -1771,6 +1815,12 @@ fn deep_sleep_coarse_grained_device_holder_blocks_park() {
         Value::Bool(false),
         "{status}"
     );
+    // Coarse-grained: the device-node scan decides, so the holder is counted.
+    let stats = &status["result"]["deep_sleep"]["gpu_clients"];
+    assert_eq!(stats["source"], "device-nodes", "{status}");
+    assert_eq!(stats["device_node_count"], 1, "{status}");
+    assert_eq!(stats["total_count"], 1, "{status}");
+    assert_eq!(stats["device_node_holders"][0]["pid"], 4242, "{status}");
 
     // The holder exits: the park policy releases the runtime.
     std::fs::remove_dir_all(clients.join("4242")).unwrap();
@@ -1819,6 +1869,11 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
     for _ in 0..200 {
         let status = daemon.request(r#"{"method":"status"}"#);
         if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            // The stats disclose that the decision fell back to the fd scan.
+            assert_eq!(
+                status["result"]["deep_sleep"]["gpu_clients"]["source"], "device-nodes",
+                "{status}"
+            );
             parked = true;
             break;
         }

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1269,7 +1269,14 @@ fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let state_file = dir.join("state.json");
-    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    // A static spec: deferral only applies to a runtime the watcher would
+    // re-attach (a pending stock runtime enforces nothing and deliberately
+    // never defers nor wakes).
+    std::fs::write(
+        &state_file,
+        test_static_runtime_spec("deferred-profile").to_string(),
+    )
+    .unwrap();
     let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
 
     let daemon = Daemon::start(&[
@@ -1371,7 +1378,14 @@ fn deep_sleep_scan_completion_does_not_force_start_the_deferred_runtime() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let state_file = dir.join("state.json");
-    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    // A static spec: deferral only applies to a runtime the watcher would
+    // re-attach (a pending stock runtime enforces nothing and deliberately
+    // never defers nor wakes).
+    std::fs::write(
+        &state_file,
+        test_static_runtime_spec("deferred-profile").to_string(),
+    )
+    .unwrap();
     let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
 
     let daemon = Daemon::start(&[
@@ -1492,5 +1506,143 @@ fn mobile_mode_rejects_persistence_enable_rpc() {
             .is_some_and(|error| error.contains("Mobile or Unknown")),
         "{response}"
     );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+    // Fake client-scan proc tree, initially empty: no GPU clients anywhere.
+    let clients = dir.join("clients");
+    std::fs::create_dir_all(&clients).unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+    ]);
+
+    // Explicit apply attaches the engine (a user action may wake the GPU).
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("parked-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["state"], "runtime_profile_running", "{status}");
+
+    // No clients for the (test-shrunk) idle window: the watcher parks the
+    // runtime — engine gone, persisted state kept, profile pending again.
+    let mut parked = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let result = &status["result"];
+        if result["deep_sleep"]["parked"] == Value::Bool(true) {
+            assert_eq!(result["state"], "idle", "{status}");
+            assert_eq!(
+                result["deep_sleep"]["autostart_deferred"],
+                Value::Bool(true),
+                "{status}"
+            );
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "runtime was never parked");
+    assert!(
+        daemon.state_file.exists(),
+        "parking must keep the persisted runtime state"
+    );
+
+    // Simulate real use: GPU active + a process holding /dev/nvidia0. The
+    // watcher must re-materialize the parked profile.
+    std::fs::write(
+        sys.join("0000:01:00.0/power/runtime_status"),
+        "active\n",
+    )
+    .unwrap();
+    let fd_dir = clients.join("4242").join("fd");
+    std::fs::create_dir_all(&fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+
+    let mut reattached = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let result = &status["result"];
+        if result["state"] == "runtime_profile_running" {
+            assert_eq!(
+                result["active_job"]["profile_id"], "parked-profile",
+                "{status}"
+            );
+            assert_eq!(result["deep_sleep"]["parked"], Value::Bool(false), "{status}");
+            reattached = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(reattached, "parked runtime was never re-materialized on use");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_never_reattaches_a_parked_stock_runtime() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+    let clients = dir.join("clients");
+    std::fs::create_dir_all(&clients).unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+    ]);
+
+    // Apply stock (the GUI's "restore defaults"): the engine attaches for the
+    // reset writes, then the park policy must release it like any runtime.
+    let start = daemon.request(&apply_runtime_request());
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    let mut parked = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "stock runtime was never parked");
+
+    // Real GPU use arrives: a stock runtime enforces nothing, so the watcher
+    // must NOT re-attach (that would only pin the GPU) and must not report
+    // the stock intent as deferred.
+    std::fs::write(
+        sys.join("0000:01:00.0/power/runtime_status"),
+        "active\n",
+    )
+    .unwrap();
+    let fd_dir = clients.join("4242").join("fd");
+    std::fs::create_dir_all(&fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let result = &status["result"];
+        assert_eq!(result["state"], "idle", "stock must never re-attach: {status}");
+        assert_eq!(
+            result["deep_sleep"]["autostart_deferred"],
+            Value::Bool(false),
+            "{status}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1519,11 +1519,19 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
     // Fake client-scan proc tree, initially empty: no GPU clients anywhere.
     let clients = dir.join("clients");
     std::fs::create_dir_all(&clients).unwrap();
+    // Fine-grained mode reads GPU contexts from NVML (the mock's staged PID
+    // file here), not the fd scan; no file yet means no contexts.
+    let contexts = dir.join("context-pids");
 
     let daemon = Daemon::start(&[
         ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
         ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
         ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
     ]);
 
     // Explicit apply attaches the engine (a user action may wake the GPU).
@@ -1559,16 +1567,14 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
         "parking must keep the persisted runtime state"
     );
 
-    // Simulate real use: GPU active + a process holding /dev/nvidia0. The
+    // Simulate real use: GPU active + a process with a live GPU context. The
     // watcher must re-materialize the parked profile.
     std::fs::write(
         sys.join("0000:01:00.0/power/runtime_status"),
         "active\n",
     )
     .unwrap();
-    let fd_dir = clients.join("4242").join("fd");
-    std::fs::create_dir_all(&fd_dir).unwrap();
-    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+    std::fs::write(&contexts, "4242\n").unwrap();
 
     let mut reattached = false;
     for _ in 0..200 {
@@ -1598,11 +1604,17 @@ fn deep_sleep_never_reattaches_a_parked_stock_runtime() {
     let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
     let clients = dir.join("clients");
     std::fs::create_dir_all(&clients).unwrap();
+    let contexts = dir.join("context-pids");
 
     let daemon = Daemon::start(&[
         ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
         ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
         ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
     ]);
 
     // Apply stock (the GUI's "restore defaults"): the engine attaches for the
@@ -1629,9 +1641,7 @@ fn deep_sleep_never_reattaches_a_parked_stock_runtime() {
         "active\n",
     )
     .unwrap();
-    let fd_dir = clients.join("4242").join("fd");
-    std::fs::create_dir_all(&fd_dir).unwrap();
-    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+    std::fs::write(&contexts, "4242\n").unwrap();
 
     for _ in 0..100 {
         let status = daemon.request(r#"{"method":"status"}"#);
@@ -1644,5 +1654,176 @@ fn deep_sleep_never_reattaches_a_parked_stock_runtime() {
         );
         std::thread::sleep(Duration::from_millis(50));
     }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The issue-#30 hardware finding: fine-grained RTD3 suspends the GPU under
+/// idly-open `/dev/nvidia<N>` fds (desktop shells, monitoring agents), so an
+/// fd holder must not starve the park policy, and after parking a bare fd
+/// holder plus an active GPU must not re-attach either — only a live NVML
+/// context is real use.
+#[test]
+fn deep_sleep_fine_grained_ignores_idle_device_node_holders() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+    // A long-lived /dev/nvidia0 holder exists the whole time.
+    let clients = dir.join("clients");
+    let fd_dir = clients.join("4242").join("fd");
+    std::fs::create_dir_all(&fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+    let contexts = dir.join("context-pids");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
+    ]);
+
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("holder-blind-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    // No NVML contexts: the fd holder alone must not block parking.
+    let mut parked = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "fd holder starved the fine-grained park policy");
+
+    // GPU goes (and stays) active with the fd holder but still no context:
+    // must not re-materialize on that alone.
+    std::fs::write(sys.join("0000:01:00.0/power/runtime_status"), "active\n").unwrap();
+    std::thread::sleep(Duration::from_secs(5));
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(
+        status["result"]["state"], "idle",
+        "an fd holder without a context re-attached the runtime: {status}"
+    );
+
+    // A real context appears: re-materialize.
+    std::fs::write(&contexts, "4242\n").unwrap();
+    let mut reattached = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["state"] == "runtime_profile_running" {
+            reattached = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(reattached, "a live context never re-materialized the runtime");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Coarse-grained RTD3 keeps the GPU awake per open fd, so there the fd scan
+/// stays the park signal: a device-node holder blocks parking, and its exit
+/// releases the runtime.
+#[test]
+fn deep_sleep_coarse_grained_device_holder_blocks_park() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (coarse-grained)", "auto", "active");
+    let clients = dir.join("clients");
+    let fd_dir = clients.join("4242").join("fd");
+    std::fs::create_dir_all(&fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+    ]);
+
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("coarse-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    // Well past the (test-shrunk) park window: the fd holder must keep the
+    // engine attached.
+    std::thread::sleep(Duration::from_secs(5));
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(
+        status["result"]["state"], "runtime_profile_running",
+        "coarse-grained park ignored the fd holder: {status}"
+    );
+    assert_eq!(
+        status["result"]["deep_sleep"]["parked"],
+        Value::Bool(false),
+        "{status}"
+    );
+
+    // The holder exits: the park policy releases the runtime.
+    std::fs::remove_dir_all(clients.join("4242")).unwrap();
+    let mut parked = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "runtime was never parked after the holder exited");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// When the NVML context query fails (driver without the _v3 process-list
+/// symbols), fine-grained mode falls back to the conservative fd scan rather
+/// than never parking (or parking under a real client).
+#[test]
+fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+    let clients = dir.join("clients");
+    std::fs::create_dir_all(&clients).unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        ("PENGUIN_BURNERD_TEST_MOCK_GPU_FAIL", "gpu_context_pids"),
+    ]);
+
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("fallback-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    // The fd scan (empty client tree) governs: the runtime still parks.
+    let mut parked = false;
+    for _ in 0..200 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "fd-scan fallback never parked the runtime");
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1220,3 +1220,112 @@ fn large_but_legal_request_line_still_parses() {
         "{response}"
     );
 }
+
+// --- deep-sleep (RTD3) gate ---------------------------------------------------
+
+/// Fake PCI sysfs + NVIDIA procfs trees for the RTD3 probe seams, at the same
+/// address `test_runtime_spec` persists so the hint path is exercised.
+fn write_rtd3_tree(
+    dir: &std::path::Path,
+    d3_line: &str,
+    control: &str,
+    runtime_status: &str,
+) -> (PathBuf, PathBuf) {
+    let addr = "0000:01:00.0";
+    let sys = dir.join("rtd3-sys");
+    let proc_root = dir.join("rtd3-proc");
+    let device = sys.join(addr);
+    let power = device.join("power");
+    std::fs::create_dir_all(&power).unwrap();
+    std::fs::write(device.join("vendor"), "0x10de\n").unwrap();
+    std::fs::write(device.join("class"), "0x030000\n").unwrap();
+    std::fs::write(power.join("control"), format!("{control}\n")).unwrap();
+    std::fs::write(
+        power.join("runtime_status"),
+        format!("{runtime_status}\n"),
+    )
+    .unwrap();
+    let proc_gpu = proc_root.join(addr);
+    std::fs::create_dir_all(&proc_gpu).unwrap();
+    std::fs::write(
+        proc_gpu.join("power"),
+        format!("Runtime D3 status:          {d3_line}\nVideo Memory:               Off\n"),
+    )
+    .unwrap();
+    (sys, proc_root)
+}
+
+#[test]
+fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+    ]);
+
+    // The gate is evaluated synchronously before the socket binds: armed, and
+    // the persisted runtime must NOT be running while the GPU sleeps.
+    let status = daemon.request(r#"{"method":"status"}"#);
+    let result = &status["result"];
+    assert_eq!(result["state"], "idle", "{status}");
+    assert_eq!(result["deep_sleep"]["state"], "armed", "{status}");
+    assert_eq!(result["deep_sleep"]["mode"], "fine-grained", "{status}");
+    assert_eq!(result["deep_sleep"]["pci_addr"], "0000:01:00.0", "{status}");
+
+    // The watcher marks the deferral within its first ticks.
+    let mut deferred = false;
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let deep_sleep = &status["result"]["deep_sleep"];
+        if deep_sleep["autostart_deferred"] == Value::Bool(true) {
+            assert_eq!(deep_sleep["runtime_status"], "suspended", "{status}");
+            assert_eq!(deep_sleep["suspended_observed"], Value::Bool(true), "{status}");
+            deferred = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(deferred, "autostart was never marked deferred");
+
+    // Still no engine: the sleeping GPU was never attached.
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(status["result"]["state"], "idle", "{status}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_disabled_on_desktop_runs_autostart_immediately() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(&state_file, test_runtime_spec().to_string()).unwrap();
+    let (sys, proc_root) = write_rtd3_tree(&dir, "Disabled by default", "auto", "active");
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+    ]);
+
+    // Desktop verdict: the classic synchronous autostart path, byte-for-byte.
+    let status = daemon.request(r#"{"method":"status"}"#);
+    let result = &status["result"];
+    assert_eq!(result["state"], "runtime_profile_running", "{status}");
+    assert_eq!(result["deep_sleep"]["state"], "disabled", "{status}");
+    assert_eq!(
+        result["deep_sleep"]["autostart_deferred"],
+        Value::Bool(false),
+        "{status}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -349,6 +349,7 @@ fn status_is_idle_when_nothing_running() {
     assert_eq!(result["state"], "idle");
     assert_eq!(result["active_job"], Value::Null);
     assert!(result["version"].is_string());
+    assert!(result["build"].is_string());
 }
 
 #[test]
@@ -1515,6 +1516,15 @@ fn deep_sleep_powerd_only_context_allows_running_runtime_to_park() {
         &test_static_runtime_spec("powerd-only-profile"),
     ));
     assert_eq!(start["ok"], Value::Bool(true), "{start}");
+    // While the engine is attached, the daemon must confess its own hold:
+    // the client sample excludes the daemon's pid, so this flag is the only
+    // status evidence that the daemon itself is the pin.
+    let running = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(
+        running["result"]["deep_sleep"]["daemon"]["engine_attached"],
+        Value::Bool(true),
+        "{running}"
+    );
 
     let mut parked = false;
     for _ in 0..120 {
@@ -1524,6 +1534,11 @@ fn deep_sleep_powerd_only_context_allows_running_runtime_to_park() {
             let clients = &status["result"]["deep_sleep"]["gpu_clients"];
             assert_eq!(clients["total_count"], 0, "{status}");
             assert_eq!(clients["ignored_count"], 1, "{status}");
+            assert_eq!(
+                status["result"]["deep_sleep"]["daemon"]["engine_attached"],
+                Value::Bool(false),
+                "{status}"
+            );
             parked = true;
             break;
         }

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1384,6 +1384,14 @@ fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
     .unwrap();
     let (sys, proc_root) =
         write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "active");
+    // Keep the old timer-driven repro fast: its quiet interval was this
+    // autosuspend delay plus one watcher tick, so the five-second observation
+    // below spans more than two complete retry deadlines.
+    std::fs::write(
+        sys.join("0000:01:00.0/power/autosuspend_delay_ms"),
+        "1000\n",
+    )
+    .unwrap();
     let clients = dir.join("clients");
     write_root_powerd_identity(&clients, 880);
     let contexts = dir.join("context-pids");
@@ -1454,6 +1462,9 @@ fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
         "Name:\tsome-game\nUid:\t1000\t1000\t1000\t1000\n",
     )
     .unwrap();
+    let game_fds = clients.join("4242/fd");
+    std::fs::create_dir_all(&game_fds).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", game_fds.join("7")).unwrap();
     std::fs::write(&contexts, "graphics 880 4242\ncompute 880\n").unwrap();
 
     let mut attached = false;
@@ -2071,8 +2082,31 @@ fn deep_sleep_fine_grained_ignores_idle_device_node_holders() {
         "an fd holder without a context re-attached the runtime: {status}"
     );
 
-    // A real context appears: re-materialize.
+    // With no context, the kernel completes a runtime-PM cycle. A later real
+    // context wakes the GPU; that external transition re-arms the one-shot
+    // context probe even though the long-lived fd holder did not change.
+    std::fs::write(
+        sys.join("0000:01:00.0/power/runtime_status"),
+        "suspended\n",
+    )
+    .unwrap();
+    let mut suspension_observed = false;
+    for _ in 0..80 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["runtime_status"] == "suspended" {
+            suspension_observed = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(suspension_observed, "runtime-PM suspension was not observed");
+
     std::fs::write(&contexts, "4242\n").unwrap();
+    std::fs::write(
+        sys.join("0000:01:00.0/power/runtime_status"),
+        "active\n",
+    )
+    .unwrap();
     let mut reattached = false;
     for _ in 0..200 {
         let status = daemon.request(r#"{"method":"status"}"#);

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -196,6 +196,18 @@ fn read_line<R: BufRead>(reader: &mut R) -> Option<String> {
     }
 }
 
+fn mock_gpu_lifetime(path: &std::path::Path) -> (u64, u64, u64) {
+    let values: Vec<u64> = std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    match values.as_slice() {
+        [opens, closes, live] => (*opens, *closes, *live),
+        _ => (0, 0, 0),
+    }
+}
+
 fn test_runtime_spec() -> Value {
     serde_json::json!({
         "format_version": 1,
@@ -1375,6 +1387,7 @@ fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
     let clients = dir.join("clients");
     write_root_powerd_identity(&clients, 880);
     let contexts = dir.join("context-pids");
+    let lifetime = dir.join("gpu-lifetime");
     std::fs::write(&contexts, "graphics 880\ncompute 880\n").unwrap();
 
     let daemon = Daemon::start(&[
@@ -1386,6 +1399,10 @@ fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
         (
             "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
             contexts.to_str().unwrap(),
+        ),
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_LIFETIME_FILE",
+            lifetime.to_str().unwrap(),
         ),
     ]);
 
@@ -1415,6 +1432,17 @@ fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
         gpu_clients["ignored_clients"][0]["name"],
         "nvidia-powerd",
         "{status}"
+    );
+    let (opens, closes, live) = mock_gpu_lifetime(&lifetime);
+    assert!(opens > 0, "the watcher never exercised the context probe");
+    assert_eq!(
+        opens, 1,
+        "powerd-only activity caused a repeated NVIDIA probe loop"
+    );
+    assert_eq!(
+        (opens, closes, live),
+        (opens, opens, 0),
+        "the watcher retained its NVIDIA session while only nvidia-powerd remained"
     );
 
     // Dynamic Boost remains present when a real workload arrives. The game
@@ -2142,6 +2170,7 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
     std::fs::create_dir_all(&game_fd_dir).unwrap();
     std::os::unix::fs::symlink("/dev/nvidia0", game_fd_dir.join("7")).unwrap();
     std::fs::write(clients.join("4242/comm"), "some-game\n").unwrap();
+    let lifetime = dir.join("gpu-lifetime");
 
     let daemon = Daemon::start(&[
         ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
@@ -2149,6 +2178,10 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
         ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
         MOCK_GPU,
         ("PENGUIN_BURNERD_TEST_MOCK_GPU_FAIL", "gpu_context_pids"),
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_LIFETIME_FILE",
+            lifetime.to_str().unwrap(),
+        ),
     ]);
 
     let start = daemon.request(&runtime_spec_request(
@@ -2170,6 +2203,13 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
     assert_eq!(gpu_clients["total_count"], 1, "{status}");
     assert_eq!(gpu_clients["device_node_count"], 2, "{status}");
     assert_eq!(gpu_clients["ignored_count"], 1, "{status}");
+    let (opens, closes, live) = mock_gpu_lifetime(&lifetime);
+    assert!(opens > 0, "the failing context probe was never exercised");
+    assert_eq!(
+        (opens, closes, live),
+        (opens, opens, 0),
+        "a failed context query retained its NVIDIA session"
+    );
 
     // Once the real holder exits, powerd alone must not starve parking.
     std::fs::remove_dir_all(clients.join("4242")).unwrap();

--- a/burnerd/tests/daemon.rs
+++ b/burnerd/tests/daemon.rs
@@ -1276,6 +1276,29 @@ fn write_rtd3_tree(
     (sys, proc_root)
 }
 
+fn write_fake_proc_identity(
+    proc_root: &std::path::Path,
+    pid: u32,
+    name: &str,
+    status: Option<&str>,
+) {
+    let process_dir = proc_root.join(pid.to_string());
+    std::fs::create_dir_all(&process_dir).unwrap();
+    std::fs::write(process_dir.join("comm"), format!("{name}\n")).unwrap();
+    if let Some(status) = status {
+        std::fs::write(process_dir.join("status"), status).unwrap();
+    }
+}
+
+fn write_root_powerd_identity(proc_root: &std::path::Path, pid: u32) {
+    write_fake_proc_identity(
+        proc_root,
+        pid,
+        "nvidia-powerd",
+        Some("Name:\tnvidia-powerd\nUid:\t0\t0\t0\t0\n"),
+    );
+}
+
 #[test]
 fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
     let n = COUNTER.fetch_add(1, Ordering::SeqCst);
@@ -1329,6 +1352,224 @@ fn deep_sleep_defers_autostart_while_the_gpu_is_suspended() {
     // Still no engine: the sleeping GPU was never attached.
     let status = daemon.request(r#"{"method":"status"}"#);
     assert_eq!(status["result"]["state"], "idle", "{status}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// NVIDIA's Dynamic Boost helper may retain an NVML context while no user
+/// workload exists. On fine-grained RTD3 that infrastructure context must not
+/// turn a daemon restart into a self-sustaining runtime attachment.
+#[test]
+fn deep_sleep_powerd_only_context_does_not_start_deferred_runtime() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let state_file = dir.join("state.json");
+    std::fs::write(
+        &state_file,
+        test_static_runtime_spec("deferred-profile").to_string(),
+    )
+    .unwrap();
+    let (sys, proc_root) =
+        write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "active");
+    let clients = dir.join("clients");
+    write_root_powerd_identity(&clients, 880);
+    let contexts = dir.join("context-pids");
+    std::fs::write(&contexts, "graphics 880\ncompute 880\n").unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_STATE_FILE", state_file.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
+    ]);
+
+    // Stay beyond the three-tick wake threshold. The helper is not a game,
+    // so it must never materialize the persisted profile.
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        assert_eq!(
+            status["result"]["state"], "idle",
+            "powerd-only context started the runtime: {status}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(
+        status["result"]["deep_sleep"]["autostart_deferred"],
+        Value::Bool(true),
+        "{status}"
+    );
+    let gpu_clients = &status["result"]["deep_sleep"]["gpu_clients"];
+    assert_eq!(gpu_clients["total_count"], 0, "{status}");
+    assert_eq!(gpu_clients["graphics_count"], 0, "{status}");
+    assert_eq!(gpu_clients["compute_count"], 0, "{status}");
+    assert_eq!(gpu_clients["ignored_count"], 1, "{status}");
+    assert_eq!(gpu_clients["ignored_clients"][0]["pid"], 880, "{status}");
+    assert_eq!(
+        gpu_clients["ignored_clients"][0]["name"],
+        "nvidia-powerd",
+        "{status}"
+    );
+
+    // Dynamic Boost remains present when a real workload arrives. The game
+    // context—not powerd—must still materialize the persisted profile.
+    std::fs::create_dir_all(clients.join("4242")).unwrap();
+    std::fs::write(clients.join("4242/comm"), "some-game\n").unwrap();
+    std::fs::write(
+        clients.join("4242/status"),
+        "Name:\tsome-game\nUid:\t1000\t1000\t1000\t1000\n",
+    )
+    .unwrap();
+    std::fs::write(&contexts, "graphics 880 4242\ncompute 880\n").unwrap();
+
+    let mut attached = false;
+    for _ in 0..120 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["state"] == "runtime_profile_running" {
+            let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+            assert_eq!(clients["total_count"], 1, "{status}");
+            assert_eq!(clients["graphics"][0]["pid"], 4242, "{status}");
+            assert_eq!(clients["ignored_count"], 1, "{status}");
+            attached = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(attached, "a real game context did not start the runtime");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// An explicitly applied profile initially owns GPU handles. A powerd-only
+/// context must still let the watcher park that runtime and release PB's hold.
+#[test]
+fn deep_sleep_powerd_only_context_allows_running_runtime_to_park() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) =
+        write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "active");
+    let clients = dir.join("clients");
+    write_root_powerd_identity(&clients, 880);
+    let contexts = dir.join("context-pids");
+    std::fs::write(&contexts, "graphics 880\n").unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
+    ]);
+
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("powerd-only-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    let mut parked = false;
+    for _ in 0..120 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
+            assert_eq!(status["result"]["state"], "idle", "{status}");
+            let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+            assert_eq!(clients["total_count"], 0, "{status}");
+            assert_eq!(clients["ignored_count"], 1, "{status}");
+            parked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(parked, "powerd-only context prevented runtime parking");
+    let log = daemon.stderr_log();
+    assert!(
+        log.contains("ignored infrastructure helpers=1 [880 nvidia-powerd]"),
+        "journal did not explain the powerd exclusion:\n{log}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deep_sleep_powerd_exclusion_requires_exact_root_identity() {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pb-rtd3-{}-{}", std::process::id(), n));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let (sys, proc_root) =
+        write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "active");
+    let clients = dir.join("clients");
+
+    for (pid, comm, status) in [
+        (880, "nvidia-powerd", Some("Uid:\t0\t0\t0\t0\n")),
+        (
+            881,
+            "nvidia-powerd",
+            Some("Uid:\t1000\t1000\t1000\t1000\n"),
+        ),
+        (882, "nvidia-powerd", None),
+        (883, "nvidia-powerd", Some("Uid:\tnot-a-uid\n")),
+        (884, "nvidia-powerd2", Some("Uid:\t0\t0\t0\t0\n")),
+        (885, "nvidia-powerd ", Some("Uid:\t0\t0\t0\t0\n")),
+        (886, "nvidia-powerd", Some("Uid:\t1000\t0\n")),
+        (
+            887,
+            "nvidia-powerd",
+            Some("Uid:\t1000\t0\tnot-a-uid\t0\n"),
+        ),
+        (
+            888,
+            "nvidia-powerd",
+            Some("Uid:\t0\t0\t0\t0\nUid:\t1000\t1000\t1000\t1000\n"),
+        ),
+    ] {
+        write_fake_proc_identity(&clients, pid, comm, status);
+    }
+    let contexts = dir.join("context-pids");
+    std::fs::write(
+        &contexts,
+        "graphics 880 881 882 883 884 885 886 887 888\n",
+    )
+    .unwrap();
+
+    let daemon = Daemon::start(&[
+        ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_RTD3_PROC", proc_root.to_str().unwrap()),
+        ("PENGUIN_BURNERD_TEST_CLIENT_PROC", clients.to_str().unwrap()),
+        MOCK_GPU,
+        (
+            "PENGUIN_BURNERD_TEST_MOCK_GPU_CONTEXT_PIDS",
+            contexts.to_str().unwrap(),
+        ),
+    ]);
+    let start = daemon.request(&runtime_spec_request(
+        "apply_runtime_spec",
+        &test_static_runtime_spec("identity-profile"),
+    ));
+    assert_eq!(start["ok"], Value::Bool(true), "{start}");
+
+    let mut sampled = false;
+    for _ in 0..100 {
+        let status = daemon.request(r#"{"method":"status"}"#);
+        let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+        if clients["ignored_count"] == 1 && clients["total_count"] == 8 {
+            assert_eq!(clients["ignored_clients"][0]["pid"], 880, "{status}");
+            assert_eq!(clients["graphics_count"], 8, "{status}");
+            sampled = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(sampled, "identity classification was not reported");
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -1649,12 +1890,12 @@ fn deep_sleep_parks_idle_runtime_and_reattaches_on_use() {
     let log = daemon.stderr_log();
     for expected in [
         "deep sleep: runtime_status suspended (initial)",
-        "deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, device-node holders=0",
+        "deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, ignored infrastructure helpers=0, device-node holders=0",
         "deep sleep: no GPU clients; parking the runtime in 1s unless one appears",
         "deep sleep: no GPU clients for the idle window; parking the runtime",
         "deep sleep: runtime parked; the GPU may suspend until its next real use",
         "deep sleep: runtime_status suspended -> active (suspended for ",
-        "deep sleep: gpu clients (nvml-contexts): counted=2 (GPU in use), graphics=1 [4242 some-game], compute=1 [555 cuda-worker], device-node holders=0",
+        "deep sleep: gpu clients (nvml-contexts): counted=2 (GPU in use), graphics=1 [4242 some-game], compute=1 [555 cuda-worker], ignored infrastructure helpers=0, device-node holders=0",
         "deep sleep: GPU is in use; starting the deferred persisted runtime",
         "deep sleep: runtime deferral cleared",
         "deep sleep: parked runtime re-materialized",
@@ -1828,9 +2069,10 @@ fn deep_sleep_coarse_grained_device_holder_blocks_park() {
     std::fs::create_dir_all(&dir).unwrap();
     let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (coarse-grained)", "auto", "active");
     let clients = dir.join("clients");
-    let fd_dir = clients.join("4242").join("fd");
+    let fd_dir = clients.join("880").join("fd");
     std::fs::create_dir_all(&fd_dir).unwrap();
     std::os::unix::fs::symlink("/dev/nvidia0", fd_dir.join("7")).unwrap();
+    write_root_powerd_identity(&clients, 880);
 
     let daemon = Daemon::start(&[
         ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
@@ -1863,10 +2105,11 @@ fn deep_sleep_coarse_grained_device_holder_blocks_park() {
     assert_eq!(stats["source"], "device-nodes", "{status}");
     assert_eq!(stats["device_node_count"], 1, "{status}");
     assert_eq!(stats["total_count"], 1, "{status}");
-    assert_eq!(stats["device_node_holders"][0]["pid"], 4242, "{status}");
+    assert_eq!(stats["ignored_count"], 0, "{status}");
+    assert_eq!(stats["device_node_holders"][0]["pid"], 880, "{status}");
 
     // The holder exits: the park policy releases the runtime.
-    std::fs::remove_dir_all(clients.join("4242")).unwrap();
+    std::fs::remove_dir_all(clients.join("880")).unwrap();
     let mut parked = false;
     for _ in 0..200 {
         let status = daemon.request(r#"{"method":"status"}"#);
@@ -1891,7 +2134,14 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
     std::fs::create_dir_all(&dir).unwrap();
     let (sys, proc_root) = write_rtd3_tree(&dir, "Enabled (fine-grained)", "auto", "suspended");
     let clients = dir.join("clients");
-    std::fs::create_dir_all(&clients).unwrap();
+    let powerd_fd_dir = clients.join("880/fd");
+    std::fs::create_dir_all(&powerd_fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", powerd_fd_dir.join("14")).unwrap();
+    write_root_powerd_identity(&clients, 880);
+    let game_fd_dir = clients.join("4242/fd");
+    std::fs::create_dir_all(&game_fd_dir).unwrap();
+    std::os::unix::fs::symlink("/dev/nvidia0", game_fd_dir.join("7")).unwrap();
+    std::fs::write(clients.join("4242/comm"), "some-game\n").unwrap();
 
     let daemon = Daemon::start(&[
         ("PENGUIN_BURNERD_TEST_RTD3_SYSFS", sys.to_str().unwrap()),
@@ -1907,16 +2157,33 @@ fn deep_sleep_fine_grained_falls_back_to_fd_scan_when_nvml_query_fails() {
     ));
     assert_eq!(start["ok"], Value::Bool(true), "{start}");
 
-    // The fd scan (empty client tree) governs: the runtime still parks.
+    // The fallback remains conservative for ordinary holders. Powerd is
+    // visible but ignored; the game beside it is counted and blocks parking.
+    std::thread::sleep(Duration::from_secs(4));
+    let status = daemon.request(r#"{"method":"status"}"#);
+    assert_eq!(
+        status["result"]["state"], "runtime_profile_running",
+        "fallback ignored a real holder: {status}"
+    );
+    let gpu_clients = &status["result"]["deep_sleep"]["gpu_clients"];
+    assert_eq!(gpu_clients["source"], "device-nodes", "{status}");
+    assert_eq!(gpu_clients["total_count"], 1, "{status}");
+    assert_eq!(gpu_clients["device_node_count"], 2, "{status}");
+    assert_eq!(gpu_clients["ignored_count"], 1, "{status}");
+
+    // Once the real holder exits, powerd alone must not starve parking.
+    std::fs::remove_dir_all(clients.join("4242")).unwrap();
     let mut parked = false;
     for _ in 0..200 {
         let status = daemon.request(r#"{"method":"status"}"#);
         if status["result"]["deep_sleep"]["parked"] == Value::Bool(true) {
             // The stats disclose that the decision fell back to the fd scan.
-            assert_eq!(
-                status["result"]["deep_sleep"]["gpu_clients"]["source"], "device-nodes",
-                "{status}"
-            );
+            let clients = &status["result"]["deep_sleep"]["gpu_clients"];
+            assert_eq!(clients["source"], "device-nodes", "{status}");
+            assert_eq!(clients["total_count"], 0, "{status}");
+            assert_eq!(clients["device_node_count"], 1, "{status}");
+            assert_eq!(clients["ignored_count"], 1, "{status}");
+            assert_eq!(clients["ignored_clients"][0]["pid"], 880, "{status}");
             parked = true;
             break;
         }

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -255,8 +255,10 @@ def parse_arguments(argv):
         "--install-systemd-service",
         action="store_true",
         help=(
-            "Install the PenguinBurner daemon service when absent, or update "
-            "its persistent boot profile through the running daemon."
+            "Install or update the PenguinBurner daemon service: refresh the "
+            "/usr/libexec daemon binary, rewrite the unit, and restart it. "
+            "With profile options, also set the persistent boot profile; "
+            "without them, an existing boot profile is kept."
         ),
     )
     daemon_group.add_argument(

--- a/cli/entry.py
+++ b/cli/entry.py
@@ -89,17 +89,16 @@ def dispatch_cli(
         _require_adaptive_profiles_available(runtime_flags, runtime_argv)
         _reject_auto_uv_scan_in_background(runtime_flags, runtime_argv)
         if runtime_flags["install_systemd_service"]:
-            try:
-                daemon_status(socket_path=DEFAULT_DAEMON_SOCKET)
-            except Exception:
-                install_systemd_service(
-                    program_file,
-                    runtime_argv,
-                    journal_hours=runtime_flags["journal_hours"],
-                    log=log,
-                )
-            else:
-                _apply_runtime_through_daemon(runtime_argv, persist_on_startup=True)
+            # Always run the real install: it refreshes the /usr/libexec daemon
+            # binary, rewrites the unit, and restarts the service. Probing the
+            # socket and "applying instead" when a daemon answered left users
+            # running a stale daemon with success-looking output (issue #30).
+            install_systemd_service(
+                program_file,
+                runtime_argv,
+                journal_hours=runtime_flags["journal_hours"],
+                log=log,
+            )
         elif runtime_flags["uninstall_systemd_service"]:
             uninstall_systemd_service(log=log)
         elif runtime_flags["daemonize"]:

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,8 @@ comparison.
   export, and clean up saved curves.
 - **[Curve Editors](./curve-editor.md)** — manual V/F and fan curve editing.
 - **[Silent Fan Curve](./silent-fan-curve.md)** — auto-generated quiet fan curve.
+- **[Laptop Deep Sleep](./deep-sleep.md)** — the daemon lets a hybrid laptop's
+  dGPU reach D3cold instead of pinning it awake.
 
 ## Help
 

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -78,6 +78,68 @@ The `deep_sleep` block reports the verdict:
 stays detached like Mobile mode until detection resolves. To confirm the GPU
 really sleeps with the service running:
 
+### Who is using the GPU right now
+
+In Mobile mode the block also carries `gpu_clients` — the daemon's latest
+sample of the processes it judged the park/wake decision by:
+
+```json
+"gpu_clients": {
+  "source": "nvml-contexts",
+  "graphics_count": 1,
+  "compute_count": 0,
+  "device_node_count": 2,
+  "total_count": 1,
+  "age_s": 0.6,
+  "graphics": [{"pid": 3117, "name": "vkcube"}],
+  "compute": [],
+  "device_node_holders": [
+    {"pid": 1450, "name": "plasmashell"},
+    {"pid": 3117, "name": "vkcube"}
+  ]
+}
+```
+
+- `graphics` / `compute` list the processes holding a live NVML context of
+  that kind; `device_node_holders` lists every process with `/dev/nvidia<N>`
+  open. Each entry is `pid` plus the process name (`null` if it exited
+  before the lookup).
+- `source` names the decisive signal: `"nvml-contexts"` under fine-grained
+  RTD3, `"device-nodes"` under coarse-grained RTD3 or when the NVML process
+  query is unavailable.
+- `total_count` is the number of unique clients the decision counted.
+  **Parking proceeds only while it stays 0**, so if the GPU never parks,
+  the named processes here are what is keeping it awake.
+- Under fine-grained RTD3 the `device_node_holders` list is informational:
+  a desktop shell holding the device open does not keep the GPU awake and
+  does not block parking — which is why `total_count` can be 0 while the
+  list is not empty.
+- `age_s` is the sample's age in seconds. It grows while the GPU sleeps,
+  because sampling only happens while the GPU is awake; a large value next
+  to `runtime_status: "suspended"` is normal.
+
+The daemon also writes the same evidence to its journal whenever the client
+sample changes — process starts and exits, not once per second — so an idle
+system stays quiet and the log reads as a timeline of who took and released
+the GPU:
+
+```
+deep sleep: gpu clients (nvml-contexts): graphics=1 [3117 vkcube], compute=0, device-node holders=2 [1450 plasmashell, 3117 vkcube]
+```
+
+To watch it live while reproducing a park/wake problem:
+
+```
+sudo journalctl -u penguin-burnerd.service -f
+```
+
+To capture a log file to attach to a bug report (adjust the window to cover
+your test):
+
+```
+sudo journalctl -u penguin-burnerd.service --since "-1 hour" --no-pager > penguin-burnerd-deep-sleep.log
+```
+
 ```
 cat /sys/bus/pci/devices/0000:01:00.0/power/runtime_status
 ```
@@ -102,7 +164,9 @@ the profile stays applied as a standing intent. The GPU is then free to
 enter D3cold. When something real starts using the GPU again, the profile
 re-attaches and reapplies within a few seconds — before a game finishes
 loading. `deep_sleep.parked: true` in `--daemon-status` shows a parked
-profile; `autostart_deferred: true` confirms it will reapply on use.
+profile; `autostart_deferred: true` confirms it will reapply on use. If a
+profile never parks, `gpu_clients` (above) names the processes still being
+counted as GPU users.
 
 Restoring stock behaves the same way, with one refinement: a stock
 runtime enforces nothing, so once parked it never re-attaches at all.

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -40,7 +40,12 @@ gets the deferred behavior:
   Under fine-grained RTD3 (`mode: "fine-grained"`) the driver lets the GPU
   sleep even while desktop shells or monitoring tools hold `/dev/nvidia<N>`
   open, so an open handle proves nothing — the daemon asks NVML for live
-  graphics/compute contexts instead. Under coarse-grained RTD3 any
+  graphics/compute contexts instead. Each watcher query uses a short-lived,
+  context-only NVML session and closes it before making the decision. If the
+  result is idle or only root-owned `nvidia-powerd`, the watcher pauses NVIDIA
+  queries for the kernel autosuspend delay (plus one tick); a changed numbered
+  device-holder set re-arms detection when a workload arrives. Under
+  coarse-grained RTD3 any
   `/dev/nvidia<N>` holder keeps the GPU awake, so there the device-handle
   scan is the accurate signal (auxiliary `nvidiactl`/`nvidia-uvm` handles
   never count).
@@ -151,7 +156,6 @@ deep sleep: no GPU clients for the idle window; parking the runtime
 deep sleep: persisted runtime deferred until the GPU is in use
 deep sleep: runtime parked; the GPU may suspend until its next real use
 deep sleep: runtime_status active -> suspended (active for 312.4s)
-deep sleep: released 1 idle GPU backend(s) so the GPU can suspend
 deep sleep: runtime_status suspended -> active (suspended for 1841.7s)
 deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), graphics=1 [9314 game.exe], compute=0, ignored infrastructure helpers=1 [880 nvidia-powerd], device-node holders=4 [880 nvidia-powerd, 1450 plasmashell, 1721 kwin_wayland, 9314 game.exe]
 deep sleep: GPU is in use; starting the deferred persisted runtime
@@ -168,8 +172,9 @@ Line by line:
 - **`runtime_status A -> B (A for Ns)`** — the kernel's own view of the
   GPU's power state, with how long the previous state was held. This is the
   ground truth that parking actually led to a suspend, and it timestamps
-  every wake. (The backend-release line lags the suspend by its 30s idle
-  TTL, as above.)
+  every wake. Watcher context probes have already closed before their client
+  decision is logged. A separate `released N idle GPU backend(s)` line refers
+  only to a one-off socket RPC backend reaching its 30-second idle TTL.
 - **`no GPU clients; parking the runtime in Ns unless one appears`** — the
   park countdown started; N is the remaining time, so the park line lands N
   seconds after this one. If a client shows up first you get

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -68,10 +68,19 @@ The `deep_sleep` block reports the verdict:
   "mode": "fine-grained",
   "pci_addr": "0000:01:00.0",
   "runtime_status": "suspended",
+  "runtime_active_ms": 512300,
+  "runtime_suspended_ms": 7203400,
   "autostart_deferred": true,
-  "suspended_observed": true
+  "suspended_observed": true,
+  "parked": false
 }
 ```
+
+`runtime_active_ms` / `runtime_suspended_ms` are the kernel's cumulative
+runtime-PM residency counters for the dGPU since boot (wake-free reads).
+They quantify how much the GPU actually sleeps: on a healthy setup the
+suspended counter should dominate after some idle time, and two status
+reads a few minutes apart show which state the interval was spent in.
 
 `state: "mobile"` means the daemon treats GPU handles as ephemeral;
 `"desktop"` (with a `reason`) means always-attached behavior. `"unknown"`
@@ -118,14 +127,54 @@ sample of the processes it judged the park/wake decision by:
   because sampling only happens while the GPU is awake; a large value next
   to `runtime_status: "suspended"` is normal.
 
-The daemon also writes the same evidence to its journal whenever the client
-sample changes — process starts and exits, not once per second — so an idle
-system stays quiet and the log reads as a timeline of who took and released
-the GPU:
+### The journal narrative
+
+The daemon writes every deep-sleep decision edge to its journal. All lines
+are change-triggered — process starts/exits, kernel state transitions,
+countdown edges — never per-tick, so an idle system stays quiet and the log
+reads as a timeline. A full park-then-wake cycle looks like this:
 
 ```
-deep sleep: gpu clients (nvml-contexts): graphics=1 [3117 vkcube], compute=0, device-node holders=2 [1450 plasmashell, 3117 vkcube]
+deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, device-node holders=2 [1450 plasmashell, 1721 kwin_wayland]
+deep sleep: no GPU clients; parking the runtime in 59s unless one appears
+deep sleep: no GPU clients for the idle window; parking the runtime
+deep sleep: persisted runtime deferred until the GPU is in use
+deep sleep: runtime parked; the GPU may suspend until its next real use
+deep sleep: runtime_status active -> suspended (active for 312.4s)
+deep sleep: released 1 idle GPU backend(s) so the GPU can suspend
+deep sleep: runtime_status suspended -> active (suspended for 1841.7s)
+deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), graphics=1 [9314 game.exe], compute=0, device-node holders=3 [1450 plasmashell, 1721 kwin_wayland, 9314 game.exe]
+deep sleep: GPU is in use; starting the deferred persisted runtime
+deep sleep: runtime deferral cleared
+deep sleep: parked runtime re-materialized
 ```
+
+Line by line:
+
+- **`gpu clients (...)`** — the client sample, logged whenever it changes.
+  `counted` is the number the park/wake decision used (`(GPU in use)` /
+  `(idle)` is the verdict); the lists that follow are the evidence.
+- **`runtime_status A -> B (A for Ns)`** — the kernel's own view of the
+  GPU's power state, with how long the previous state was held. This is the
+  ground truth that parking actually led to a suspend, and it timestamps
+  every wake. (The backend-release line lags the suspend by its 30s idle
+  TTL, as above.)
+- **`no GPU clients; parking the runtime in Ns unless one appears`** — the
+  park countdown started; N is the remaining time, so the park line lands N
+  seconds after this one. If a client shows up first you get
+  `park countdown reset after Ns: a GPU client appeared` and the sample
+  line names who; if the countdown's preconditions vanish instead (a scan
+  starts, the engine stops) you get `park countdown abandoned: <why>`. A
+  park the supervisor cannot perform says
+  `park refused (a game session owns the runtime or the engine did not
+  stop); retrying every idle window` — once per idle stretch.
+- **`GPU awake but no counted clients; keeping the runtime deferred
+  (transient wake?)`** — the GPU came out of suspend without any counted
+  client (a Vulkan capability probe from some app). This is why a wake does
+  not always apply the profile — deliberate, and now visible. It is only
+  logged for genuine wakes from suspend, so the normal post-park drain
+  (the GPU stays `active` for the driver's autosuspend delay after the
+  engine releases it) never produces it.
 
 To watch it live while reproducing a park/wake problem:
 

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -35,9 +35,15 @@ gets the deferred behavior:
 - A saved profile is not applied while the GPU sleeps. The daemon watches
   `runtime_status` once per second (a cached read — no GPU traffic) and
   applies the profile when the GPU is actually in use: sustained `active`
-  plus a real client holding a `/dev/nvidia<N>` device handle (a game, not
-  a transient Vulkan capability probe, and not monitoring tools that only
-  hold `nvidiactl`/`nvidia-uvm` handles).
+  plus a real GPU client (a game, not a transient Vulkan capability probe).
+- What counts as a real client follows the driver's runtime D3 granularity.
+  Under fine-grained RTD3 (`mode: "fine-grained"`) the driver lets the GPU
+  sleep even while desktop shells or monitoring tools hold `/dev/nvidia<N>`
+  open, so an open handle proves nothing — the daemon asks NVML for live
+  graphics/compute contexts instead. Under coarse-grained RTD3 any
+  `/dev/nvidia<N>` holder keeps the GPU awake, so there the device-handle
+  scan is the accurate signal (auxiliary `nvidiactl`/`nvidia-uvm` handles
+  never count).
 - One-off telemetry or capability queries release their GPU handles after 30
   idle seconds instead of keeping them for the daemon's lifetime.
 - GPU persistence mode is never enabled (it blocks runtime D3); the profile
@@ -88,8 +94,9 @@ module options.
 
 An applied profile does not keep the GPU awake. While the profile runtime
 is attached it polls the driver, which by itself prevents runtime D3 — so
-when no other process has held a real `/dev/nvidia<N>` handle for 60
-seconds, the daemon **parks** the runtime: the engine releases every GPU
+when no other process has really used the GPU for 60 seconds (the same
+mode-aware client signal as above), the daemon **parks** the runtime: the
+engine releases every GPU
 handle (fans return to hardware auto, the clock lock is released) while
 the profile stays applied as a standing intent. The GPU is then free to
 enter D3cold. When something real starts using the GPU again, the profile

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -42,10 +42,10 @@ gets the deferred behavior:
   open, so an open handle proves nothing — the daemon asks NVML for live
   graphics/compute contexts instead. Each watcher query uses a short-lived,
   context-only NVML session and closes it before making the decision. If the
-  result is idle or only root-owned `nvidia-powerd`, the watcher pauses NVIDIA
-  queries for the kernel autosuspend delay (plus one tick); a changed numbered
-  device-holder set re-arms detection when a workload arrives. Under
-  coarse-grained RTD3 any
+  result is idle or only root-owned `nvidia-powerd`, the watcher stops NVIDIA
+  queries entirely until a changed numbered-device holder set or a kernel
+  runtime-PM sleep/wake cycle signals a new workload. It never polls NVML on a
+  timer while waiting for suspension. Under coarse-grained RTD3 any
   `/dev/nvidia<N>` holder keeps the GPU awake, so there the device-handle
   scan is the accurate signal (auxiliary `nvidiactl`/`nvidia-uvm` handles
   never count).

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -97,22 +97,32 @@ sample of the processes it judged the park/wake decision by:
   "source": "nvml-contexts",
   "graphics_count": 1,
   "compute_count": 0,
-  "device_node_count": 2,
+  "device_node_count": 3,
+  "ignored_count": 1,
   "total_count": 1,
   "age_s": 0.6,
   "graphics": [{"pid": 3117, "name": "vkcube"}],
   "compute": [],
+  "ignored_clients": [{"pid": 880, "name": "nvidia-powerd"}],
   "device_node_holders": [
+    {"pid": 880, "name": "nvidia-powerd"},
     {"pid": 1450, "name": "plasmashell"},
     {"pid": 3117, "name": "vkcube"}
   ]
 }
 ```
 
-- `graphics` / `compute` list the processes holding a live NVML context of
-  that kind; `device_node_holders` lists every process with `/dev/nvidia<N>`
-  open. Each entry is `pid` plus the process name (`null` if it exited
-  before the lookup).
+- `graphics` / `compute` list the counted processes holding a live NVML
+  context of that kind; `device_node_holders` lists every process with
+  `/dev/nvidia<N>` open. Each entry is `pid` plus the process name (`null` if
+  it exited before the lookup).
+- `ignored_clients` names positively identified infrastructure helpers that
+  were observed but excluded from the fine-grained verdict. Currently the
+  only exception is an exact `nvidia-powerd` process running as root. It is
+  NVIDIA's Dynamic Boost controller, not a user workload; a game appearing
+  alongside it remains counted normally. Missing or malformed process
+  identity is counted conservatively, and coarse-grained/unknown modes never
+  apply this exception.
 - `source` names the decisive signal: `"nvml-contexts"` under fine-grained
   RTD3, `"device-nodes"` under coarse-grained RTD3 or when the NVML process
   query is unavailable.
@@ -135,7 +145,7 @@ countdown edges — never per-tick, so an idle system stays quiet and the log
 reads as a timeline. A full park-then-wake cycle looks like this:
 
 ```
-deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, device-node holders=2 [1450 plasmashell, 1721 kwin_wayland]
+deep sleep: gpu clients (nvml-contexts): counted=0 (idle), graphics=0, compute=0, ignored infrastructure helpers=1 [880 nvidia-powerd], device-node holders=3 [880 nvidia-powerd, 1450 plasmashell, 1721 kwin_wayland]
 deep sleep: no GPU clients; parking the runtime in 59s unless one appears
 deep sleep: no GPU clients for the idle window; parking the runtime
 deep sleep: persisted runtime deferred until the GPU is in use
@@ -143,7 +153,7 @@ deep sleep: runtime parked; the GPU may suspend until its next real use
 deep sleep: runtime_status active -> suspended (active for 312.4s)
 deep sleep: released 1 idle GPU backend(s) so the GPU can suspend
 deep sleep: runtime_status suspended -> active (suspended for 1841.7s)
-deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), graphics=1 [9314 game.exe], compute=0, device-node holders=3 [1450 plasmashell, 1721 kwin_wayland, 9314 game.exe]
+deep sleep: gpu clients (nvml-contexts): counted=1 (GPU in use), graphics=1 [9314 game.exe], compute=0, ignored infrastructure helpers=1 [880 nvidia-powerd], device-node holders=4 [880 nvidia-powerd, 1450 plasmashell, 1721 kwin_wayland, 9314 game.exe]
 deep sleep: GPU is in use; starting the deferred persisted runtime
 deep sleep: runtime deferral cleared
 deep sleep: parked runtime re-materialized
@@ -153,7 +163,8 @@ Line by line:
 
 - **`gpu clients (...)`** — the client sample, logged whenever it changes.
   `counted` is the number the park/wake decision used (`(GPU in use)` /
-  `(idle)` is the verdict); the lists that follow are the evidence.
+  `(idle)` is the verdict); the counted, explicitly ignored, and open-holder
+  lists that follow are the complete evidence.
 - **`runtime_status A -> B (A for Ns)`** — the kernel's own view of the
   GPU's power state, with how long the previous state was held. This is the
   ground truth that parking actually led to a suspend, and it timestamps

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -1,0 +1,82 @@
+# Laptop Deep Sleep (RTD3 / D3cold)
+
+On hybrid-graphics laptops (Intel/AMD iGPU + NVIDIA dGPU), the NVIDIA GPU can
+power off completely while nothing uses it — NVIDIA calls this runtime D3
+(RTD3); the kernel reports it as the `suspended` / D3cold state. Any program
+that keeps an NVML session or a `/dev/nvidia*` file handle open pins the GPU
+awake and silently drains the battery. Most GPU tools on Linux do exactly
+that, including their background services.
+
+PenguinBurner's daemon is deep-sleep aware. On RTD3-capable machines it holds
+**no** GPU handles while the GPU is idle, so the dGPU can reach D3cold with
+`penguin-burnerd.service` running.
+
+## How it works
+
+At startup the daemon classifies the machine using only cached kernel state
+(reads that never wake the GPU):
+
+- `/proc/driver/nvidia/gpus/<pci-addr>/power` — the driver's resolved
+  `Runtime D3 status`;
+- `/sys/bus/pci/devices/<pci-addr>/power/control` — must be `auto` for the
+  kernel to suspend the device;
+- `/sys/bus/pci/devices/<pci-addr>/power/runtime_status` — the live power
+  state. A GPU ever observed `suspended` arms deep-sleep handling even if the
+  config files were inconclusive.
+
+**Desktops** (runtime D3 disabled or unsupported) keep the classic behavior:
+the saved profile is applied at boot and the daemon stays attached.
+
+**RTD3 laptops** get the deferred behavior:
+
+- A saved profile is not applied while the GPU sleeps. The daemon watches
+  `runtime_status` once per second (a cached read — no GPU traffic) and
+  applies the profile when the GPU is actually in use: sustained `active`
+  plus a real client holding a `/dev/nvidia*` handle (a game, not a
+  transient Vulkan capability probe).
+- One-off telemetry or capability queries release their GPU handles after 30
+  idle seconds instead of keeping them for the daemon's lifetime.
+- GPU persistence mode is never enabled (it blocks runtime D3); the profile
+  is reapplied on wake instead.
+
+## Checking it on your machine
+
+```
+penguin-burner-cli --daemon-status
+```
+
+The `deep_sleep` block reports the verdict:
+
+```json
+"deep_sleep": {
+  "state": "armed",
+  "mode": "fine-grained",
+  "pci_addr": "0000:01:00.0",
+  "runtime_status": "suspended",
+  "autostart_deferred": true,
+  "suspended_observed": true
+}
+```
+
+`state: "armed"` means the daemon treats GPU handles as ephemeral;
+`"disabled"` (with a `reason`) means classic desktop behavior. To confirm the
+GPU really sleeps with the service running:
+
+```
+cat /sys/bus/pci/devices/0000:01:00.0/power/runtime_status
+```
+
+(replace the address with your dGPU's; it should read `suspended` when no
+game is running).
+
+If `state` is `"disabled"` with reason `power/control is not 'auto'`, your
+distribution has not enabled runtime power management for the dGPU — see the
+NVIDIA driver README chapter on runtime D3 for the required udev rules and
+module options.
+
+## Current limitations
+
+- After a game ends, the daemon keeps its handles until the profile is
+  stopped or the daemon restarts; automatic idle re-detach is planned.
+- Profile reapply after a deep-sleep cycle happens when the runtime is
+  started for the wake, not transparently mid-session.

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -84,10 +84,24 @@ distribution has not enabled runtime power management for the dGPU — see the
 NVIDIA driver README chapter on runtime D3 for the required udev rules and
 module options.
 
+## Applied profiles and deep sleep coexist
+
+An applied profile does not keep the GPU awake. While the profile runtime
+is attached it polls the driver, which by itself prevents runtime D3 — so
+when no other process has held a real `/dev/nvidia<N>` handle for 60
+seconds, the daemon **parks** the runtime: the engine releases every GPU
+handle (fans return to hardware auto, the clock lock is released) while
+the profile stays applied as a standing intent. The GPU is then free to
+enter D3cold. When something real starts using the GPU again, the profile
+re-attaches and reapplies within a few seconds — before a game finishes
+loading. `deep_sleep.parked: true` in `--daemon-status` shows a parked
+profile; `autostart_deferred: true` confirms it will reapply on use.
+
+Restoring stock behaves the same way, with one refinement: a stock
+runtime enforces nothing, so once parked it never re-attaches at all.
+
 ## Current limitations
 
-- After a game ends, the daemon keeps its handles until the profile is
-  stopped or the daemon restarts; automatic idle re-detach is planned.
 - Profile reapply after a deep-sleep cycle happens when the runtime is
   started for the wake, not transparently mid-session.
 - After an Auto-UV scan or verification finishes, the saved profile applies

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -32,8 +32,9 @@ the saved profile is applied at boot and the daemon stays attached.
 - A saved profile is not applied while the GPU sleeps. The daemon watches
   `runtime_status` once per second (a cached read — no GPU traffic) and
   applies the profile when the GPU is actually in use: sustained `active`
-  plus a real client holding a `/dev/nvidia*` handle (a game, not a
-  transient Vulkan capability probe).
+  plus a real client holding a `/dev/nvidia<N>` device handle (a game, not
+  a transient Vulkan capability probe, and not monitoring tools that only
+  hold `nvidiactl`/`nvidia-uvm` handles).
 - One-off telemetry or capability queries release their GPU handles after 30
   idle seconds instead of keeping them for the daemon's lifetime.
 - GPU persistence mode is never enabled (it blocks runtime D3); the profile
@@ -80,3 +81,8 @@ module options.
   stopped or the daemon restarts; automatic idle re-detach is planned.
 - Profile reapply after a deep-sleep cycle happens when the runtime is
   started for the wake, not transparently mid-session.
+- After an Auto-UV scan or verification finishes, the saved profile applies
+  at the next real GPU use instead of immediately, so the scan's end never
+  pins a GPU that is about to idle.
+- A runtime you explicitly stop stays stopped: the boot profile arms the
+  wake-apply at most once per daemon start.

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -77,7 +77,8 @@ The `deep_sleep` block reports the verdict:
   "runtime_suspended_ms": 7203400,
   "autostart_deferred": true,
   "suspended_observed": true,
-  "parked": false
+  "parked": false,
+  "daemon": {"engine_attached": false, "rpc_backends": 0}
 }
 ```
 
@@ -139,8 +140,27 @@ sample of the processes it judged the park/wake decision by:
   does not block parking — which is why `total_count` can be 0 while the
   list is not empty.
 - `age_s` is the sample's age in seconds. It grows while the GPU sleeps,
-  because sampling only happens while the GPU is awake; a large value next
-  to `runtime_status: "suspended"` is normal.
+  because sampling only happens while the GPU is awake — and it also grows
+  while an idle result is latched, because observing the GPU opens it and
+  would keep resetting the driver's autosuspend timer. A growing `age_s` is
+  the daemon deliberately not looking so the GPU can sleep; an unchanged
+  holder set re-probes only after a bounded awake window (~5 minutes), so a
+  latched holder that starts real work still re-materializes the profile.
+
+### What the daemon itself is holding
+
+The client lists above exclude the daemon's own process, so the `deep_sleep`
+block carries a separate `daemon` object with the daemon's own GPU holds:
+
+- `engine_attached: true` — the in-process profile engine is applied and
+  polling the driver. This alone keeps the GPU awake; it is exactly the hold
+  the park countdown removes.
+- `rpc_backends` — lazily-opened GPU backends still serving socket queries
+  (telemetry, capabilities). A steadily nonzero value means some client —
+  typically an open PenguinBurner GUI polling telemetry — queries faster
+  than the 30-second idle sweep and holds the GPU awake through the daemon,
+  even though `gpu_clients` shows no counted process. Close the GUI when
+  testing suspend.
 
 ### The journal narrative
 
@@ -217,6 +237,12 @@ distribution has not enabled runtime power management for the dGPU — see the
 NVIDIA driver README chapter on runtime D3 for the required udev rules and
 module options.
 
+When testing a fix, first confirm which build is actually running: the
+daemon's startup journal line reads `penguin-burnerd <version> (<commit>)
+starting`, and `--daemon-status` reports the same short commit as `build`.
+The package version alone does not change between builds of a branch, so a
+stale installed daemon can otherwise impersonate a fresh one.
+
 ## Applied profiles and deep sleep coexist
 
 An applied profile does not keep the GPU awake. While the profile runtime
@@ -231,7 +257,8 @@ re-attaches and reapplies within a few seconds — before a game finishes
 loading. `deep_sleep.parked: true` in `--daemon-status` shows a parked
 profile; `autostart_deferred: true` confirms it will reapply on use. If a
 profile never parks, `gpu_clients` (above) names the processes still being
-counted as GPU users.
+counted as GPU users, and the `daemon` object shows whether the daemon's own
+holds (an attached engine, a GUI polling telemetry) are the remaining pin.
 
 Restoring stock behaves the same way, with one refinement: a stock
 runtime enforces nothing, so once parked it never re-attaches at all.

--- a/docs/features/deep-sleep.md
+++ b/docs/features/deep-sleep.md
@@ -7,8 +7,10 @@ that keeps an NVML session or a `/dev/nvidia*` file handle open pins the GPU
 awake and silently drains the battery. Most GPU tools on Linux do exactly
 that, including their background services.
 
-PenguinBurner's daemon is deep-sleep aware. On RTD3-capable machines it holds
-**no** GPU handles while the GPU is idle, so the dGPU can reach D3cold with
+PenguinBurner's daemon is deep-sleep aware. It does not enable RTD3 itself;
+the NVIDIA driver and kernel must already expose working runtime power
+management. On RTD3-capable machines the daemon holds **no** GPU handles while
+the GPU is idle, so the dGPU can reach D3cold with
 `penguin-burnerd.service` running.
 
 ## How it works
@@ -21,13 +23,14 @@ At startup the daemon classifies the machine using only cached kernel state
 - `/sys/bus/pci/devices/<pci-addr>/power/control` — must be `auto` for the
   kernel to suspend the device;
 - `/sys/bus/pci/devices/<pci-addr>/power/runtime_status` — the live power
-  state. A GPU ever observed `suspended` arms deep-sleep handling even if the
+  state. A GPU ever observed `suspended` selects Mobile handling even if the
   config files were inconclusive.
 
-**Desktops** (runtime D3 disabled or unsupported) keep the classic behavior:
-the saved profile is applied at boot and the daemon stays attached.
+**Desktop mode** (runtime D3 disabled or unsupported) keeps the always-attached
+behavior: the saved profile is applied at boot and the daemon stays attached.
 
-**RTD3 laptops** get the deferred behavior:
+**Mobile mode** (runtime D3 enabled with automatic runtime power management)
+gets the deferred behavior:
 
 - A saved profile is not applied while the GPU sleeps. The daemon watches
   `runtime_status` once per second (a cached read — no GPU traffic) and
@@ -40,6 +43,11 @@ the saved profile is applied at boot and the daemon stays attached.
 - GPU persistence mode is never enabled (it blocks runtime D3); the profile
   is reapplied on wake instead.
 
+After upgrading from a version that previously enabled persistence mode,
+reboot once before testing deep sleep. NVIDIA persistence state can outlive a
+service restart, and PenguinBurner does not make implicit hardware writes to
+undo old state.
+
 ## Checking it on your machine
 
 ```
@@ -50,7 +58,7 @@ The `deep_sleep` block reports the verdict:
 
 ```json
 "deep_sleep": {
-  "state": "armed",
+  "state": "mobile",
   "mode": "fine-grained",
   "pci_addr": "0000:01:00.0",
   "runtime_status": "suspended",
@@ -59,9 +67,10 @@ The `deep_sleep` block reports the verdict:
 }
 ```
 
-`state: "armed"` means the daemon treats GPU handles as ephemeral;
-`"disabled"` (with a `reason`) means classic desktop behavior. To confirm the
-GPU really sleeps with the service running:
+`state: "mobile"` means the daemon treats GPU handles as ephemeral;
+`"desktop"` (with a `reason`) means always-attached behavior. `"unknown"`
+stays detached like Mobile mode until detection resolves. To confirm the GPU
+really sleeps with the service running:
 
 ```
 cat /sys/bus/pci/devices/0000:01:00.0/power/runtime_status
@@ -70,7 +79,7 @@ cat /sys/bus/pci/devices/0000:01:00.0/power/runtime_status
 (replace the address with your dGPU's; it should read `suspended` when no
 game is running).
 
-If `state` is `"disabled"` with reason `power/control is not 'auto'`, your
+If `state` is `"desktop"` with reason `power/control is not 'auto'`, your
 distribution has not enabled runtime power management for the dGPU — see the
 NVIDIA driver README chapter on runtime D3 for the required udev rules and
 module options.

--- a/runtime/support/runtime_service.py
+++ b/runtime/support/runtime_service.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import dataclasses
 import os
 from pathlib import Path
 import pwd
@@ -14,7 +15,6 @@ import time
 
 from runtime.daemon_client import DEFAULT_DAEMON_SOCKET
 from runtime.daemon_client import apply_runtime_spec
-from runtime.daemon_client import clear_boot_runtime_spec
 from runtime.daemon_client import daemon_status
 from runtime.daemon_client import set_boot_runtime_spec
 from runtime.daemon_client import stop_runtime_profile
@@ -515,11 +515,38 @@ def _atomic_install_daemon_binary(
                 pass
 
 
-def install_daemon_binary(program_file, *, source_path=None) -> bool:
+@dataclasses.dataclass(frozen=True)
+class DaemonBinaryRefresh:
+    """Outcome of one privileged daemon-binary install attempt."""
+
+    changed: bool
+    source: Path
+
+
+def describe_daemon_binary_refresh(refresh: DaemonBinaryRefresh) -> str:
+    """One mandatory user-facing line per install: what happened to the binary.
+
+    A stale root daemon with success-looking output cost issue #30 three test
+    cycles; every install action must now say whether /usr/libexec was
+    refreshed, and from where.
+    """
+    if refresh.source == LIBEXEC_DAEMON_BINARY:
+        return (
+            f"Daemon binary: KEPT the existing {LIBEXEC_DAEMON_BINARY} — this "
+            "install carries no daemon payload. Rebuild with cargo or "
+            "reinstall a daemon-bearing package, then re-run the install."
+        )
+    if refresh.changed:
+        return f"Daemon binary: updated {LIBEXEC_DAEMON_BINARY} from {refresh.source}."
+    return f"Daemon binary: already current (matches {refresh.source})."
+
+
+def install_daemon_binary(program_file, *, source_path=None) -> DaemonBinaryRefresh:
     if os.geteuid() != 0:
         raise RuntimeError("installing penguin-burnerd requires root privileges")
     source = daemon_install_source_path(program_file, source_path=source_path)
-    return _atomic_install_daemon_binary(source, LIBEXEC_DAEMON_BINARY)
+    changed = _atomic_install_daemon_binary(source, LIBEXEC_DAEMON_BINARY)
+    return DaemonBinaryRefresh(changed=changed, source=source)
 
 
 def _daemon_program_file_for_unit(program_file) -> Path:
@@ -715,7 +742,8 @@ def install_systemd_service(program_file, argv, *, journal_hours, log):
             "systemd service install requires root privileges. Re-run with sudo."
         )
 
-    install_daemon_binary(program_file)
+    refresh = install_daemon_binary(program_file)
+    log(describe_daemon_binary_refresh(refresh))
     _stop_active_runtime_before_daemon_restart()
     clear_last_runtime_state()
     clear_existing_penguin_burner_unit_for_install(log=log)
@@ -738,8 +766,10 @@ def install_systemd_service(program_file, argv, *, journal_hours, log):
     _wait_for_daemon_status(DEFAULT_DAEMON_SOCKET)
     if argv:
         _apply_persistent_runtime(argv)
-    else:
-        clear_boot_runtime_spec(socket_path=DEFAULT_DAEMON_SOCKET)
+    # With no profile argv this is an install/repair, not a boot-profile
+    # change: an existing boot spec is preserved as-is (the daemon re-read it
+    # on the restart above), matching migrate_to_daemon_service. Wiping the
+    # user's boot profile on a reinstall was never the intent.
     log(f"Installed and enabled {unit_path.name} at {unit_path}.")
     log(f"Follow the journal with: {journalctl_follow_command(journal_hours)}")
 
@@ -779,7 +809,8 @@ def migrate_to_daemon_service(program_file, *, socket_path=DEFAULT_DAEMON_SOCKET
                 "Recovered apply-on-startup profile from the previous "
                 f"PenguinBurner version: {shlex.join(recovered)}"
             )
-    install_daemon_binary(program_file)
+    refresh = install_daemon_binary(program_file)
+    log(describe_daemon_binary_refresh(refresh))
     _stop_active_runtime_before_daemon_restart()
     clear_last_runtime_state()
     unit_path = daemon_systemd_service_unit_path()
@@ -1017,7 +1048,7 @@ def daemonize_with_systemd(program_file, argv, *, journal_hours, log):
             "Re-run PenguinBurner with sudo."
         )
 
-    binary_changed = install_daemon_binary(program_file)
+    binary_changed = install_daemon_binary(program_file).changed
     clear_existing_penguin_burner_unit_for_daemonize(log=log)
     _ensure_daemon_service_started(
         program_file,

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,10 @@ class build_py(_build_py):
             )
             return
         if not DAEMON_MANIFEST.exists():
+            self._daemon_unavailable(
+                f"penguin-burnerd daemon sources are missing ({DAEMON_MANIFEST})",
+                require=require_daemon,
+            )
             return
         cargo = shutil.which("cargo")
         if not cargo:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -9,7 +12,31 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 
-import pytest
+@pytest.fixture
+def write_desktop_rtd3_tree() -> Callable[[Path], tuple[Path, Path]]:
+    """Build a fake NVIDIA PCI tree that explicitly selects Desktop mode."""
+
+    def _write(base: Path) -> tuple[Path, Path]:
+        address = "0000:01:00.0"
+        sys_root = base / "rtd3-sys"
+        proc_root = base / "rtd3-proc"
+        device = sys_root / address
+        (device / "power").mkdir(parents=True)
+        (device / "vendor").write_text("0x10de\n", encoding="utf-8")
+        (device / "class").write_text("0x030000\n", encoding="utf-8")
+        (device / "power" / "control").write_text("auto\n", encoding="utf-8")
+        (device / "power" / "runtime_status").write_text(
+            "active\n", encoding="utf-8"
+        )
+        proc_gpu = proc_root / address
+        proc_gpu.mkdir(parents=True)
+        (proc_gpu / "power").write_text(
+            "Runtime D3 status:          Disabled by default\n",
+            encoding="utf-8",
+        )
+        return sys_root, proc_root
+
+    return _write
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_burnerd_golden.py
+++ b/tests/test_burnerd_golden.py
@@ -160,7 +160,7 @@ def _terminate(handle: DaemonHandle) -> None:
 
 
 @pytest.fixture
-def make_daemon(tmp_path):
+def make_daemon(tmp_path, write_desktop_rtd3_tree):
     """Factory: start a fresh Rust daemon with the scan stub wired up.
 
     The stub's behavior is selected via keyword args (mapped to ``SCAN_STUB_*``
@@ -188,6 +188,7 @@ def make_daemon(tmp_path):
             state_file.write_text(json.dumps(seed_state), encoding="utf-8")
         stub = base / "scan_stub.py"
         stub.write_text(_STUB, encoding="utf-8")
+        rtd3_sys, rtd3_proc = write_desktop_rtd3_tree(base)
 
         env = os.environ.copy()
         env["PENGUIN_BURNER_DAEMON_PROGRAM_FILE"] = str(stub)
@@ -195,6 +196,8 @@ def make_daemon(tmp_path):
         env["PENGUIN_BURNERD_TEST_STATE_FILE"] = str(state_file)
         env["PENGUIN_BURNERD_TEST_INERT_ENGINE"] = "1"  # engine idles (no GPU under test)
         env["PENGUIN_BURNERD_TEST_TIMINGS"] = "1"  # fast kill ladder
+        env["PENGUIN_BURNERD_TEST_RTD3_SYSFS"] = str(rtd3_sys)
+        env["PENGUIN_BURNERD_TEST_RTD3_PROC"] = str(rtd3_proc)
         env.pop("PENGUIN_BURNER_DAEMON_ALLOWED_UID", None)  # open the peercred gate
         env.pop("NOTIFY_SOCKET", None)  # no systemd watchdog under test
         if exit_after_lines:

--- a/tests/test_burnerd_gpu_writes.py
+++ b/tests/test_burnerd_gpu_writes.py
@@ -111,7 +111,7 @@ def _wait_for_socket(handle: DaemonHandle) -> None:
 
 
 @pytest.fixture
-def make_daemon(tmp_path, monkeypatch):
+def make_daemon(tmp_path, monkeypatch, write_desktop_rtd3_tree):
     """Start a fresh Rust daemon with the mock-GPU RPC seam enabled.
 
     Points ``PENGUIN_BURNER_DAEMON_SOCKET`` at the daemon's temp socket, so the
@@ -134,6 +134,7 @@ def make_daemon(tmp_path, monkeypatch):
         socket_path = base / "sock"
         stub = base / "verify_stub.py"
         stub.write_text(_STUB, encoding="utf-8")
+        rtd3_sys, rtd3_proc = write_desktop_rtd3_tree(base)
 
         env = os.environ.copy()
         env["PENGUIN_BURNERD_TEST_MOCK_GPU"] = "1"
@@ -142,6 +143,8 @@ def make_daemon(tmp_path, monkeypatch):
         env["PENGUIN_BURNERD_TEST_STATE_FILE"] = str(base / "state.json")
         env["PENGUIN_BURNERD_TEST_INERT_ENGINE"] = "1"
         env["PENGUIN_BURNERD_TEST_TIMINGS"] = "1"
+        env["PENGUIN_BURNERD_TEST_RTD3_SYSFS"] = str(rtd3_sys)
+        env["PENGUIN_BURNERD_TEST_RTD3_PROC"] = str(rtd3_proc)
         env.pop("PENGUIN_BURNER_DAEMON_ALLOWED_UID", None)
         env.pop("NOTIFY_SOCKET", None)
         if mock_fail:

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -175,7 +175,13 @@ def test_dispatch_cli_daemonize_applies_through_running_daemon(monkeypatch) -> N
     ]
 
 
-def test_dispatch_cli_persistent_update_uses_running_daemon(monkeypatch) -> None:
+def test_dispatch_cli_persistent_update_reinstalls_even_with_daemon_running(
+    monkeypatch,
+) -> None:
+    # A running daemon must not short-circuit an explicit install: skipping the
+    # binary refresh left users on a stale /usr/libexec daemon with
+    # success-looking output (issue #30). The boot-profile apply happens inside
+    # install_systemd_service, never as a bare apply-through-daemon.
     applied = []
     installed = []
     monkeypatch.setattr(entry, "daemon_status", lambda **_kwargs: {"state": "idle"})
@@ -188,7 +194,9 @@ def test_dispatch_cli_persistent_update_uses_running_daemon(monkeypatch) -> None
     monkeypatch.setattr(
         entry,
         "install_systemd_service",
-        lambda *args, **kwargs: installed.append((args, kwargs)),
+        lambda program_file, argv, **kwargs: installed.append(
+            (program_file, list(argv), kwargs)
+        ),
     )
     monkeypatch.setattr(entry, "read_auto_uv_profiles", lambda: [{"profile_id": "p1"}])
     monkeypatch.setattr(
@@ -212,6 +220,5 @@ def test_dispatch_cli_persistent_update_uses_running_daemon(monkeypatch) -> None
     )
 
     assert exit_code == 0
-    assert installed == []
-    assert applied[0][0]["adaptive_auto_uv"] is True
-    assert applied[0][1]["persist_on_startup"] is True
+    assert installed[0][1] == ["--adaptive-auto-uv"]
+    assert applied == []

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -771,6 +771,9 @@ def test_wheel_bundles_rust_daemon_as_package_data() -> None:
     assert "cargo" in setup_py
     assert "--release" in setup_py and "--locked" in setup_py
     assert 'Path(self.build_lib) / "runtime" / "daemon_bin"' in setup_py
+    # Every skip path must consult the REQUIRE gate — a missing crate manifest
+    # once bypassed it silently, shipping a daemon-less wheel under REQUIRE=1.
+    assert "daemon sources are missing" in setup_py
 
     # The sdist carries the crate sources + committed lockfile so a pip install
     # from sdist can cargo-build the daemon into the wheel.

--- a/tests/test_runtime_service.py
+++ b/tests/test_runtime_service.py
@@ -52,7 +52,6 @@ def _no_live_daemon_runtime_calls(monkeypatch):
         "_apply_persistent_runtime",
         lambda _argv, **_kwargs: {"pid": 4321},
     )
-    monkeypatch.setattr(runtime_service, "clear_boot_runtime_spec", lambda **_kwargs: {})
 
 
 def _write_fake_elf(path: Path, payload: bytes = b"daemon") -> None:
@@ -454,7 +453,13 @@ def test_install_systemd_service_replaces_transient_unit_before_enabling(
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(
         runtime_service, "LAST_RUNTIME_STATE_PATH", state_file
     )
@@ -520,6 +525,91 @@ def test_install_systemd_service_replaces_transient_unit_before_enabling(
     assert any("persistent service install" in message for message in logs)
 
 
+def test_describe_daemon_binary_refresh_messages() -> None:
+    updated = runtime_service.describe_daemon_binary_refresh(
+        runtime_service.DaemonBinaryRefresh(
+            changed=True, source=Path("/pkg/penguin-burnerd")
+        )
+    )
+    assert "updated" in updated
+    assert "/pkg/penguin-burnerd" in updated
+
+    unchanged = runtime_service.describe_daemon_binary_refresh(
+        runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        )
+    )
+    assert "already current" in unchanged
+
+    # Source resolving to the installed copy itself means this install ships
+    # no daemon payload: the "refresh" was a no-op against a possibly stale
+    # binary and the message must say so loudly (issue #30).
+    kept = runtime_service.describe_daemon_binary_refresh(
+        runtime_service.DaemonBinaryRefresh(
+            changed=False, source=runtime_service.LIBEXEC_DAEMON_BINARY
+        )
+    )
+    assert "KEPT" in kept
+    assert "no daemon payload" in kept
+
+
+def test_install_systemd_service_without_argv_preserves_boot_spec(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    program = tmp_path / "penguin_burner.py"
+    daemon_unit = tmp_path / "penguin-burnerd.service"
+    program.write_text("# program\n", encoding="utf-8")
+    actions = []
+    logs = []
+
+    monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
+    monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
+    monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=True, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
+    monkeypatch.setattr(runtime_service, "clear_last_runtime_state", lambda: None)
+    monkeypatch.setattr(
+        runtime_service,
+        "clear_existing_penguin_burner_unit_for_install",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        runtime_service,
+        "_apply_persistent_runtime",
+        lambda argv, **_kwargs: actions.append(("persist-runtime", list(argv)))
+        or {"pid": 4321},
+    )
+    monkeypatch.setattr(
+        runtime_service, "daemon_systemd_service_unit_path", lambda: daemon_unit
+    )
+    monkeypatch.setattr(runtime_service, "_wait_for_daemon_status", lambda *_args: None)
+    monkeypatch.setattr(
+        runtime_service.subprocess,
+        "run",
+        lambda args, **_kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        runtime_service,
+        "run_checked_subprocess",
+        lambda args: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    runtime_service.install_systemd_service(
+        program, [], journal_hours=4, log=logs.append
+    )
+
+    # An install/repair with no profile argv must not rewrite or clear the
+    # boot spec — the existing boot profile survives the reinstall.
+    assert actions == []
+    assert any(message.startswith("Daemon binary: updated") for message in logs)
+
+
 def test_install_systemd_service_restarts_active_daemon_after_unit_update(
     tmp_path: Path,
     monkeypatch,
@@ -546,7 +636,13 @@ def test_install_systemd_service_restarts_active_daemon_after_unit_update(
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(
         runtime_service, "LAST_RUNTIME_STATE_PATH", state_file
     )
@@ -633,7 +729,13 @@ def test_migrate_to_daemon_service_disables_legacy_after_daemon_reachable(
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(
         runtime_service, "LAST_RUNTIME_STATE_PATH", state_file
     )
@@ -780,7 +882,13 @@ def test_daemonize_starts_daemon_service_and_runtime_profile(tmp_path, monkeypat
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(
         runtime_service,
         "daemon_systemd_service_unit_path",
@@ -853,7 +961,9 @@ def test_daemonize_restarts_only_when_existing_binary_changed(
     monkeypatch.setattr(
         runtime_service,
         "install_daemon_binary",
-        lambda *_args, **_kwargs: binary_changed,
+        lambda *_args, **_kwargs: runtime_service.DaemonBinaryRefresh(
+            changed=binary_changed, source=Path("/pkg/penguin-burnerd")
+        ),
     )
     monkeypatch.setattr(
         runtime_service,
@@ -917,7 +1027,13 @@ def test_daemonize_preserves_pkexec_desktop_user_env(tmp_path, monkeypatch) -> N
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(
         runtime_service,
         "daemon_systemd_service_unit_path",
@@ -1062,7 +1178,13 @@ def test_migrate_recovers_066_boot_profile_without_legacy_capitalized_unit(
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(runtime_service, "LAST_RUNTIME_STATE_PATH", state_file)
     monkeypatch.setattr(
         runtime_service, "clear_last_runtime_state", lambda: None
@@ -1116,7 +1238,13 @@ def test_migrate_preserves_existing_boot_spec_when_nothing_recovered(
     monkeypatch.setattr(runtime_service, "SYSTEMCTL", "/bin/systemctl")
     monkeypatch.setattr(runtime_service, "systemd_is_available", lambda: True)
     monkeypatch.setattr(runtime_service.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runtime_service, "install_daemon_binary", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        runtime_service,
+        "install_daemon_binary",
+        lambda *_a, **_k: runtime_service.DaemonBinaryRefresh(
+            changed=False, source=Path("/pkg/penguin-burnerd")
+        ),
+    )
     monkeypatch.setattr(runtime_service, "LAST_RUNTIME_STATE_PATH", missing_state)
     monkeypatch.setattr(runtime_service, "clear_last_runtime_state", lambda: None)
     monkeypatch.setattr(
@@ -1124,11 +1252,6 @@ def test_migrate_preserves_existing_boot_spec_when_nothing_recovered(
         "_apply_persistent_runtime",
         lambda argv, **_kwargs: actions.append(("persist-runtime", list(argv)))
         or {"pid": 1},
-    )
-    monkeypatch.setattr(
-        runtime_service,
-        "clear_boot_runtime_spec",
-        lambda **_kwargs: actions.append(("clear-boot-runtime", [])),
     )
     monkeypatch.setattr(
         runtime_service, "legacy_systemd_service_unit_path", lambda: missing_legacy
@@ -1149,7 +1272,6 @@ def test_migrate_preserves_existing_boot_spec_when_nothing_recovered(
     )
 
     # A repair/reinstall must not wipe an existing 0.7 boot profile.
-    assert ("clear-boot-runtime", []) not in actions
     assert not any(action[0] == "persist-runtime" for action in actions)
 
 


### PR DESCRIPTION
## What

Phase 1 of the deep-sleep work for #30. On hybrid laptops, `penguin-burnerd` could pin the dGPU in D0 because boot autostart and long-lived NVML/NVAPI handles prevented NVIDIA runtime D3 (RTD3).

The daemon now has explicit **Desktop**, **Mobile**, and **Unknown** deep-sleep modes:

- Startup classification is wake-free and reads the NVIDIA proc power file plus sysfs `power/control` and `runtime_status`. A saved PCI address is only a hint; a visible NVIDIA device is preferred when topology changes.
- Desktop mode preserves eager saved-profile startup.
- Mobile mode defers the saved profile until sustained `active` state plus a real numbered `/dev/nvidia<N>` client indicates actual GPU use.
- Unknown stays detached and is re-evaluated until it resolves, avoiding boot races and time-based fallback engines that could permanently block D3cold.
- A GPU ever observed `suspended` selects Mobile handling for the daemon lifetime.
- Scan and verification children cannot satisfy the wake policy. The final autostart decision checks child ownership atomically under the supervisor lock.
- Idle RPC backends are released after 30 seconds in Mobile/Unknown mode.
- Persistence mode is suppressed by profile application and rejected by the public GPU RPC in Mobile/Unknown mode. Users upgrading from a version that already enabled persistence should reboot once because driver state can outlive a service restart.
- `status` exposes a `deep_sleep` block and the `deep-sleep-status-v1` capability using the Desktop/Mobile/Unknown terminology.
- `docs/features/deep-sleep.md` explains that PenguinBurner does not enable RTD3; the driver and kernel must already provide it.

## Why

Issue #30 reports that the daemon prevented an RTX 2050 hybrid-laptop dGPU from reaching D3cold until the service was stopped. The daemon should not hold the GPU awake merely to preserve a saved runtime profile.

## Impact

- Mobile users: the daemon stays detached while the dGPU sleeps and applies the saved profile when a real client wakes it.
- Desktop users: saved profiles still start eagerly and remain attached.
- Unknown hardware state fails conservatively by remaining detached until detection resolves.

Known Phase-1 limit: after a runtime engine starts, it retains GPU handles until explicitly stopped or the daemon restarts; automatic idle re-detach is future work.

## Checks run

- `cargo test`: 219 unit tests passed, 2 hardware-only tests ignored; 36 integration tests passed.
- `cargo build`: passed with no warnings.
- `python -m pytest tests/ -q`: 1768 passed.
- `scripts/check-feature-static-analysis.sh`: passed; Ruff clean, with 119 advisory Pyright baseline errors in untouched application files.
- `git diff --check`: passed.
- Two-axis code review: no remaining Standards or Spec findings.

Rustfmt, Clippy, and cargo-deny components are not installed in this environment.

## Live validation remaining

This machine has no NVIDIA GPU, so no live RTD3/hardware validation was run. On the affected laptop:

1. `penguin-burner-cli --daemon-status` should report `deep_sleep.state: "mobile"`.
2. With no game running, `power/runtime_status` should reach `suspended` while `penguin-burnerd.service` remains active.
3. Launching a game should wake the GPU and apply the saved profile within a few seconds.
