### PR TITLE
Fix Auto-UV without power telemetry

### DIFF
--- a/auto_uv/curve/base_load_telemetry.py
+++ b/auto_uv/curve/base_load_telemetry.py
@@ -6,7 +6,7 @@ It ignores ramp-up/idle samples so curve flattening preserves sustained load clo
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from ..shared.probe_data_fields import numeric_values, percent, read_field
 
@@ -23,7 +23,35 @@ class LoadedTelemetryRules:
     active_core_clock_percentile: float = 0.75
 
 
-def decision_samples(samples: list[Any], *, rules: LoadedTelemetryRules) -> list[Any]:
+class LoadedTelemetryRulesLike(Protocol):
+    @property
+    def loaded_sample_warmup_s(self) -> float: ...
+
+    @property
+    def saturated_tail_power_pct(self) -> float: ...
+
+    @property
+    def saturated_tail_core_clock_pct(self) -> float: ...
+
+    @property
+    def saturated_tail_min_samples(self) -> int: ...
+
+    @property
+    def power_saturation_headroom_pct(self) -> float: ...
+
+    @property
+    def loaded_sample_power_floor_pct(self) -> float: ...
+
+    @property
+    def loaded_sample_gpu_util_pct(self) -> float: ...
+
+    @property
+    def active_core_clock_percentile(self) -> float: ...
+
+
+def decision_samples(
+    samples: list[Any], *, rules: LoadedTelemetryRulesLike
+) -> list[Any]:
     # Ramp-up samples are not steady load; keep raw samples only when filtering would erase all evidence.
     warmup_s = max(0.0, float(rules.loaded_sample_warmup_s))
     if warmup_s <= 0.0:
@@ -40,7 +68,7 @@ def decision_samples(samples: list[Any], *, rules: LoadedTelemetryRules) -> list
 def saturated_tail_samples(
     telemetry_samples: list[Any],
     *,
-    rules: LoadedTelemetryRules = LoadedTelemetryRules(),
+    rules: LoadedTelemetryRulesLike = LoadedTelemetryRules(),
 ) -> list[Any]:
     samples = decision_samples(telemetry_samples, rules=rules)
     power_values = sample_values(samples, "power_w")
@@ -82,7 +110,7 @@ def derive_power_saturated_clock_mhz(
     telemetry_samples: list[Any],
     *,
     power_limit_w: int | None,
-    rules: LoadedTelemetryRules = LoadedTelemetryRules(),
+    rules: LoadedTelemetryRulesLike = LoadedTelemetryRules(),
 ) -> tuple[float | None, int, float | None]:
     if power_limit_w is None or int(power_limit_w) <= 0:
         return None, 0, None
@@ -106,7 +134,7 @@ def derive_active_core_clock_mhz(
     *,
     power_limit_w: int | None,
     use_power_limit_floor: bool,
-    rules: LoadedTelemetryRules = LoadedTelemetryRules(),
+    rules: LoadedTelemetryRulesLike = LoadedTelemetryRules(),
 ) -> tuple[float | None, float | None, int, float | None]:
     samples = decision_samples(telemetry_samples, rules=rules)
     active_power_floor_w = derive_active_power_floor_w(
@@ -144,7 +172,7 @@ def derive_active_core_clock_mhz(
         float(avg_clock_mhz),
         float(preferred_clock_mhz),
         len(clocks),
-        float(active_power_floor_w),
+        active_power_floor_w,
     )
 
 
@@ -153,7 +181,7 @@ def derive_active_power_floor_w(
     *,
     power_limit_w: int | None,
     use_power_limit_floor: bool,
-    rules: LoadedTelemetryRules = LoadedTelemetryRules(),
+    rules: LoadedTelemetryRulesLike = LoadedTelemetryRules(),
 ) -> float | None:
     power_values = sample_values(
         decision_samples(telemetry_samples, rules=rules),
@@ -170,7 +198,7 @@ def sample_is_loaded(
     sample: Any,
     *,
     active_power_floor_w: float | None,
-    rules: LoadedTelemetryRules = LoadedTelemetryRules(),
+    rules: LoadedTelemetryRulesLike = LoadedTelemetryRules(),
 ) -> bool:
     if sample is None:
         return False

--- a/auto_uv/curve/base_load_voltage.py
+++ b/auto_uv/curve/base_load_voltage.py
@@ -36,8 +36,6 @@ def derive_loaded_voltage_band(
         use_power_limit_floor=use_power_limit_floor,
         rules=telemetry_rules,
     )
-    if active_power_floor_w is None:
-        return LoadedVoltageBand(None)
 
     voltages = sorted(
         int(round(float(read_field(sample, "voltage_mv"))))

--- a/auto_uv/curve/performance_sweep_profile.py
+++ b/auto_uv/curve/performance_sweep_profile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Protocol, TypeGuard
 
 from auto_uv.domain.types import AutoUvProbeSummary, VfCurveCandidate
 from auto_uv.run.voltage_sweep_state import VoltageProbeOutcome
@@ -15,6 +15,14 @@ class SweepProfileAnchor:
     voltage_mv: int
     target_mhz: int
     source: str
+
+
+class AutoOcAttemptLike(Protocol):
+    @property
+    def candidate(self) -> VfCurveCandidate: ...
+
+    @property
+    def outcome(self) -> VoltageProbeOutcome: ...
 
 
 def build_performance_sweep_profile_candidate(
@@ -193,7 +201,7 @@ def monotonic_anchors(anchors: list[SweepProfileAnchor]) -> list[SweepProfileAnc
     return normalized
 
 
-def passed_attempt(attempt: object) -> bool:
+def passed_attempt(attempt: object) -> TypeGuard[AutoOcAttemptLike]:
     outcome = getattr(attempt, "outcome", None)
     if not isinstance(outcome, VoltageProbeOutcome):
         return False

--- a/auto_uv/curve/rising_tail.py
+++ b/auto_uv/curve/rising_tail.py
@@ -6,10 +6,12 @@ higher-voltage bins rise softly while still capping the rest of the tail.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 
 def normalize_tail_rise_bins(value: object) -> int:
     try:
-        return max(0, int(value or 0))
+        return max(0, int(cast(Any, value or 0)))
     except (TypeError, ValueError):
         return 0
 

--- a/auto_uv/probes/summary.py
+++ b/auto_uv/probes/summary.py
@@ -219,9 +219,6 @@ def loaded_telemetry_samples(
         use_power_limit_floor=use_power_limit_floor,
         rules=AUTO_UV_METRIC_TUNING,
     )
-    if active_power_floor_w is None:
-        return [], None
-
     active_samples = [
         sample
         for sample in samples
@@ -261,11 +258,8 @@ def loaded_telemetry_means(
         use_power_limit_floor=use_power_limit_floor,
         skip_elapsed_warmup=skip_elapsed_warmup,
     )
-    if active_power_floor_w is None and not active_samples:
-        return None, None, None, None, None, 0, None
-
     if not active_samples:
-        return None, None, None, None, None, 0, float(active_power_floor_w)
+        return None, None, None, None, None, 0, active_power_floor_w
 
     return (
         mean([read_field(sample, "power_w") for sample in active_samples]),

--- a/scripts/check-feature-static-analysis.sh
+++ b/scripts/check-feature-static-analysis.sh
@@ -23,6 +23,18 @@ python_paths=(
     penguin_burner.py
 )
 
+blocking_pyright_paths=(
+    auto_uv/curve
+    auto_uv/domain
+    auto_uv/final_verification
+    auto_uv/gpu
+    auto_uv/probes
+    auto_uv/scan_mode
+    drivers
+    runtime
+    stability
+)
+
 count_paths=(
     auto_uv
     cli
@@ -105,6 +117,10 @@ PY
 run ruff check "${python_paths[@]}"
 
 run vulture "${python_paths[@]}" --min-confidence "${VULTURE_MIN_CONFIDENCE:-80}"
+
+echo
+echo "==> blocking pyright ${blocking_pyright_paths[*]}"
+pyright "${blocking_pyright_paths[@]}"
 
 echo
 echo "==> pyright ${python_paths[*]} (advisory until the repo has a clean baseline)"

--- a/tests/auto_uv/test_base_load_and_flattening.py
+++ b/tests/auto_uv/test_base_load_and_flattening.py
@@ -95,6 +95,31 @@ def test_baseline_target_accepts_busy_util_below_power_limit_floor() -> None:
     assert target.active_sample_count == 4
 
 
+def test_baseline_target_accepts_busy_util_without_power_telemetry() -> None:
+    curve = base_curve(850, 1250, 5, 1800, 15)
+    telemetry = [
+        {
+            "elapsed_s": 5.0 + index,
+            "power_w": None,
+            "gpu_util_pct": 99.0,
+            "core_clock_mhz": clock_mhz,
+        }
+        for index, clock_mhz in enumerate((2700.0, 2715.0, 2730.0, 2715.0))
+    ]
+
+    target = choose_base_load_flatten_target(
+        curve,
+        telemetry,
+        power_limit_w=115,
+        fallback_clock_mhz=None,
+    )
+
+    assert target.measured_clock_mhz == pytest.approx(2715.0)
+    assert target.target_clock_mhz == 2715
+    assert target.active_sample_count == 4
+    assert target.saturated_sample_count == 0
+
+
 def test_baseline_target_failure_includes_telemetry_diagnostic() -> None:
     curve = base_curve(850, 1000, 25, 1770, 15)
     telemetry = [

--- a/tests/auto_uv/test_base_load_coverage.py
+++ b/tests/auto_uv/test_base_load_coverage.py
@@ -267,3 +267,26 @@ def test_loaded_voltage_band_accepts_busy_util_below_power_limit_floor() -> None
     )
 
     assert band == LoadedVoltageBand(1028)
+
+
+def test_loaded_voltage_band_accepts_busy_util_without_power_telemetry() -> None:
+    band = derive_loaded_voltage_band(
+        [
+            {
+                "elapsed_s": 6.0,
+                "power_w": None,
+                "gpu_util_pct": 99.0,
+                "voltage_mv": 1025.0,
+            },
+            {
+                "elapsed_s": 7.0,
+                "power_w": None,
+                "gpu_util_pct": 99.0,
+                "voltage_mv": 1030.0,
+            },
+        ],
+        power_limit_w=115,
+        use_power_limit_floor=True,
+    )
+
+    assert band == LoadedVoltageBand(1028)

--- a/tests/auto_uv/test_q2rtx_probe_summary.py
+++ b/tests/auto_uv/test_q2rtx_probe_summary.py
@@ -251,6 +251,60 @@ def test_probe_summary_accepts_busy_util_below_power_limit_floor() -> None:
     assert summary.loaded_qualified_sample_count == 4
 
 
+def test_probe_summary_accepts_busy_util_without_power_telemetry() -> None:
+    samples = [
+        {
+            "elapsed_s": 5.0 + index,
+            "power_w": None,
+            "gpu_util_pct": 99.0,
+            "core_clock_mhz": clock_mhz,
+            "voltage_mv": voltage_mv,
+            "temperature_c": 60.0,
+            "fan_speed_pct": 36.0,
+        }
+        for index, (clock_mhz, voltage_mv) in enumerate(
+            ((2700.0, 1015.0), (2715.0, 1020.0), (2730.0, 1025.0))
+        )
+    ]
+    result = SimpleNamespace(
+        telemetry_samples=samples,
+        companion_telemetry_samples=[],
+        telemetry_summary=lambda: {},
+        reason="ok",
+        log_path=Path("/tmp/q2rtx.log"),
+    )
+
+    loaded = loaded_telemetry_means(
+        samples,
+        power_limit_w=115,
+        use_power_limit_floor=True,
+        skip_elapsed_warmup=True,
+    )
+    summary = summarize_q2rtx_cuda_probe(
+        candidate_voltage_mv=1025,
+        lock_clock_mhz=2730,
+        live_voltage_before_mv=1015,
+        live_voltage_after_mv=1025,
+        used_companion_load=False,
+        power_limit_w=115,
+        result=result,
+        telemetry_samples=samples,
+        use_power_limit_floor=True,
+    )
+
+    assert loaded[0] is None
+    assert loaded[1] == pytest.approx(2715.0)
+    assert loaded[2] == pytest.approx(1020.0)
+    assert loaded[5] == 3
+    assert loaded[6] is None
+    assert summary.avg_power_w is None
+    assert summary.avg_core_clock_mhz == pytest.approx(2715.0)
+    assert summary.avg_voltage_mv == pytest.approx(1020.0)
+    assert summary.avg_temperature_c == pytest.approx(60.0)
+    assert summary.avg_fan_speed_pct == pytest.approx(36.0)
+    assert summary.efficiency_fps_per_w is None
+
+
 def test_loaded_perf_cap_reason_suppresses_idle_as_none() -> None:
     loaded_samples = [
         {"elapsed_s": 6.0, "power_w": 220.0, "perf_cap_reason": "idle"},


### PR DESCRIPTION
## Summary

- keep unavailable GPU power telemetry as `None` instead of converting it or inventing zero watts
- allow busy GPU utilization to qualify loaded samples and preserve clock, voltage, temperature, and fan measurements when NVML power draw is unavailable
- add regression coverage for baseline selection, loaded voltage derivation, and Q2RTX probe summaries matching issue #47
- make Pyright blocking for clean Auto-UV core modules plus drivers, runtime, and stability while retaining the remaining repository-wide baseline as advisory

## Root cause

Issue #47's RTX 4060 run returned valid utilization, clock, voltage, temperature, and fan telemetry but no power-draw samples. The utilization fallback correctly classified those samples as loaded, then `derive_active_core_clock_mhz()` called `float()` on the absent power floor. Pyright already diagnosed that optional-value conversion, but the repository-wide Pyright run was advisory.

The fix preserves the optional power floor and removes two early exits that incorrectly discarded otherwise-valid utilization-qualified telemetry.

Fixes #47.

## Impact

Performance Auto-UV can continue when power draw is unavailable. Power-dependent efficiency metrics remain unavailable rather than being fabricated. New optional-value errors in the protected core paths now fail the static-analysis routine.

## Validation

- `python -m pytest tests/ -q` - 1773 passed
- `scripts/check-feature-static-analysis.sh` - passed
  - blocking Pyright scope: 0 errors
  - Ruff, Vulture, compile/import checks, and `git diff --check`: passed

Live RTX 4060/NVIDIA 610.57.04 validation was not available; the reporter's exact missing-power telemetry shape is covered with deterministic regression tests.
