### PR TITLE
Add per-GPU profile and Steam targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ prompts.
    to switch to it. Tick **Apply on startup** to also make the applied profile
    your boot profile — off by default, so a tuned curve is never re-applied at
    boot unless you opted in. Toggle **Silent fan curve** for the quiet fan
-   profile, or **Restore defaults** to return the GPU to stock.
+   profile, or **Restore defaults** to return the GPU to stock. Multi-GPU
+   systems show an explicit target only when saved profiles span multiple GPUs.
 5. For per-game tuning — including **Adaptive**, which switches tiers as your
    frame rate changes — use the **Steam** tab to pick a mode per game.
 
@@ -144,6 +145,8 @@ standing profile when it exits, with no password prompt.
 Steam integration is what unlocks the fully customizable, **per-game** setup:
 
 - **Per-game profiles** — a different GPU behavior saved for each game.
+- **Per-game GPU target** — on multi-GPU systems, choose the physical card by
+  stable UUID; single-GPU systems keep the selector hidden.
 - **Per-game adaptive pre-frame-generation FPS target** — the adaptive engine's
   promote/demote target, set individually per game (a 60 Hz story game and a
   144 Hz shooter each get their own).

--- a/auto_uv/final_verification/main_loop.py
+++ b/auto_uv/final_verification/main_loop.py
@@ -70,6 +70,7 @@ def run_final_verification_and_save(
     clock_ceiling,
     discovery_summary,
     translated_gpu_policy,
+    gpu_identity,
     min_performance_core_clock_pct,
     runtime_default_plan,
     final_clock_drop_margin_pct,
@@ -256,6 +257,7 @@ def run_final_verification_and_save(
         tail_rise_bins=int(tail_rise_bins),
         auto_uv_mode=str(auto_uv_mode or ""),
         generated_profile_tier=str(generated_profile_tier or ""),
+        gpu_identity=gpu_identity,
     )
     log_final_summary(
         log,

--- a/auto_uv/final_verification/result_files.py
+++ b/auto_uv/final_verification/result_files.py
@@ -10,6 +10,7 @@ import re
 from pathlib import Path
 
 from auto_uv.domain.types import AutoUvProbeSummary
+from profiles.gpu_identity import normalized_gpu_identity
 from ..persistence.auto_uv_persisted_json_files import (
     auto_uv_user_config_dir,
     safe_json_write,
@@ -101,6 +102,7 @@ def write_final_verified_profile(
     tail_rise_bins: int = 0,
     auto_uv_mode: str = "",
     generated_profile_tier: str = "",
+    gpu_identity: dict | None = None,
 ) -> Path:
     # The plan is archived EXACTLY as final verification proved it. The old
     # save-time "verified envelope" raised below-lock bins to the best clock
@@ -133,6 +135,9 @@ def write_final_verified_profile(
         payload["auto_uv_mode"] = str(auto_uv_mode).strip()
     if str(generated_profile_tier or "").strip():
         payload["generated_profile_tier"] = str(generated_profile_tier).strip()
+    normalized_identity = normalized_gpu_identity(gpu_identity or {})
+    if str(normalized_identity.get("uuid") or "").strip():
+        payload["gpu_identity"] = normalized_identity
     append_verified_candidate(payload)
     return archive_final_verified_profile(payload)
 

--- a/auto_uv/gpu/gpu_vf_curve_applier.py
+++ b/auto_uv/gpu/gpu_vf_curve_applier.py
@@ -5,10 +5,11 @@ This is the only Auto-UV module that creates NVAPI/NVML helpers and applies curv
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, cast
 
 from drivers.nvidia.daemon_gpu import DaemonGpuClient
+from profiles.gpu_identity import normalized_gpu_identity
 from runtime.support.vf_curve_plan import apply_plan
 from runtime.support.nvidia_runtime_defaults import reset_nvidia_runtime_defaults
 
@@ -28,6 +29,7 @@ class LiveGpuVfCurveApplier:
     gpu: DaemonGpuClient
     runtime_default_plan: list[dict]
     translated_gpu_policy: dict
+    gpu_identity: dict[str, str | int] = field(default_factory=dict)
     power_limit_set_supported: bool = True
     baseline_power_limit_w: int | None = None
     requested_power_limit_w: int | None = None
@@ -151,12 +153,18 @@ def open_live_gpu_vf_curve_applier(
     gpu = DaemonGpuClient(gpu_index=int(gpu_index))
     try:
         gpu.refresh_points()
+        gpu_identity = normalized_gpu_identity(
+            gpu.capabilities().identity,
+            index_at_verification=int(gpu_index),
+        )
     except Exception as exc:
         raise AutoUvError(
             "failed to create Linux NVAPI VF helper"
             f": {exc}. This driver/GPU combination may not expose editable "
             "voltage-based V/F points."
         ) from exc
+    if not str(gpu_identity.get("uuid") or "").strip():
+        raise AutoUvError(f"GPU {int(gpu_index)} did not report a stable UUID")
 
     runtime_reset = reset_nvidia_runtime_defaults(
         gpu_index=int(gpu_index),
@@ -284,6 +292,7 @@ def open_live_gpu_vf_curve_applier(
     return LiveGpuVfCurveApplier(
         gpu_index=int(gpu_index),
         gpu=gpu,
+        gpu_identity=gpu_identity,
         min_power_limit_w=min_power_limit_w,
         max_power_limit_w=max_power_limit_w,
         runtime_default_plan=runtime_default_plan,

--- a/auto_uv/main_loop.py
+++ b/auto_uv/main_loop.py
@@ -576,6 +576,7 @@ def run_voltage_frequency_undervolt_main_loop(
                 clock_ceiling=gpu.clock_ceiling,
                 discovery_summary=selected_discovery_summary,
                 translated_gpu_policy=gpu.translated_gpu_policy,
+            gpu_identity=getattr(gpu, "gpu_identity", {}),
                 min_performance_core_clock_pct=float(
                     final_min_core_clock_pct
                     if final_min_core_clock_pct is not None
@@ -2251,6 +2252,7 @@ def run_recovered_previous_crash_selection(
         clock_ceiling=gpu.clock_ceiling,
         discovery_summary=discovery_summary,
         translated_gpu_policy=gpu.translated_gpu_policy,
+        gpu_identity=getattr(gpu, "gpu_identity", {}),
         min_performance_core_clock_pct=float(settings.min_performance_core_clock_pct),
         runtime_default_plan=gpu.runtime_default_plan,
         final_clock_drop_margin_pct=float(settings.final_clock_drop_margin_pct),

--- a/docs/features/profile-management.md
+++ b/docs/features/profile-management.md
@@ -9,8 +9,10 @@ verify, tier, export, and clean up curves.
 
 ## The table
 
-Each row shows: Date, Profile name, mV, Target MHz, Effective MHz, FPS/W, FPS,
-Power W, and Memory offset. Sort by any column to compare runs.
+Each row shows: Date, Profile name, GPU, mV, Target MHz, Effective MHz, FPS/W,
+FPS, Power W, and Memory offset. Sort by any column to compare runs. Verified
+profiles retain the GPU name, UUID, and PCI identity from verification, so a
+saved curve cannot silently move to another card if driver indices change.
 
 ## Actions
 
@@ -22,6 +24,12 @@ Top bar:
   and clears any saved boot profile, so the GPU starts at stock.
 - **Silent fan curve** — use the saved fan curve with the applied profile.
 - **Restore defaults** — return the GPU to stock now and at boot.
+
+On a one-GPU system, GPU targeting stays out of the way and **Apply** works as
+before. If saved profiles belong to multiple physical GPUs, the tab shows a
+target selector and requires an explicit choice. Tier assignments are kept per
+GPU. A legacy profile without GPU identity can be used directly on a one-GPU
+system; on a multi-GPU system it must be verified on the intended card first.
 
 With **Apply on startup** ticked, Apply saves the selected profile as the
 standing boot state. Restore defaults saves stock as that state instead. The

--- a/docs/steam.md
+++ b/docs/steam.md
@@ -32,6 +32,10 @@ in `~/.config/PenguinBurner/steam-game-settings.json`.
 
 The per-game editor exposes:
 
+- **Game GPU** — shown only when two or more physical NVIDIA GPUs are detected.
+  Choose the card PenguinBurner should tune for this game before enabling the
+  wrapper. The setting stores the GPU UUID and resolves its current index at
+  launch; PenguinBurner does not guess from the active display or GPU load.
 - **Compatibility tool** — Steam's current per-game override, or its effective
   default Proton when no override was saved. PenguinBurner reads the effective
   tool from Steam's live per-app details API; it does not infer "native" from a
@@ -62,7 +66,8 @@ your whole library in one confirmed step:
 
 - **Enable / Disable PenguinBurner for all games** — add or remove the wrapper
   everywhere. Enabling keeps the overlay off and leaves each game's saved mode
-  intact; disabling restores every game's original Steam launch options.
+  intact; disabling restores every game's original Steam launch options. On a
+  multi-GPU host, every game needs a Game GPU before bulk enable can run.
 - **Show / Hide In-Game overlay for enabled games.**
 
 Each action confirms first and shows the game count. Directions that would change

--- a/integrations/steam/game_runtime.py
+++ b/integrations/steam/game_runtime.py
@@ -11,10 +11,13 @@ a daemon problem must never block a game launch.
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 import os
 from pathlib import Path
 import sys
 
+from drivers.nvidia.daemon_gpu import DaemonGpuClient
+from profiles.gpu_identity import gpu_index_for_uuid
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR, read_auto_uv_profiles
 from profiles.uv.profile_tiers import PROFILE_TIERS, resolve_profile_tier_profiles
 
@@ -54,7 +57,12 @@ def game_account_id(env: dict[str, str], *, home: Path | None = None) -> str:
     return users[0].account_id if users else ""
 
 
-def profile_argv_for_setting(setting: SteamGameSetting) -> list[str] | None:
+def profile_argv_for_setting(
+    setting: SteamGameSetting,
+    *,
+    gpu_index: int | None = None,
+    gpu_uuid: str = "",
+) -> list[str] | None:
     """Daemon runtime argv for a preset; None when there is nothing to apply."""
     if not setting.enabled:
         return None
@@ -63,8 +71,15 @@ def profile_argv_for_setting(setting: SteamGameSetting) -> list[str] | None:
     if setting.mode == GAME_MODE_STOCK:
         # Explicit per-game stock: pin factory GPU state while this game
         # runs, even when a standing adaptive/tier profile is active.
-        return ["--auto-uv-profile", STOCK_PROFILE_SELECTOR]
-    resolved = resolve_profile_tier_profiles(read_auto_uv_profiles())
+        argv = ["--auto-uv-profile", STOCK_PROFILE_SELECTOR]
+        return _argv_with_gpu_index(argv, gpu_index)
+    selected_uuid = str(gpu_uuid or setting.gpu_uuid or "").strip()
+    profiles = read_auto_uv_profiles()
+    resolved = (
+        resolve_profile_tier_profiles(profiles, gpu_uuid=selected_uuid)
+        if selected_uuid
+        else resolve_profile_tier_profiles(profiles)
+    )
     if setting.mode == GAME_MODE_ADAPTIVE:
         # Start from the highest explicitly assigned/available tier, not the
         # newest file. "latest" lets a newer scratch or verification profile
@@ -82,7 +97,7 @@ def profile_argv_for_setting(setting: SteamGameSetting) -> list[str] | None:
         argv = ["--auto-uv-profile", profile_id, "--adaptive-auto-uv"]
         if setting.target_fps is not None:
             argv += ["--adaptive-target-fps", f"{float(setting.target_fps):g}"]
-        return argv
+        return _argv_with_gpu_index(argv, gpu_index)
     profile = resolved.get(setting.mode)
     profile_id = (
         str(profile.get("profile_id") or "").strip()
@@ -91,7 +106,30 @@ def profile_argv_for_setting(setting: SteamGameSetting) -> list[str] | None:
     )
     if not profile_id:
         return None
-    return ["--auto-uv-profile", profile_id]
+    return _argv_with_gpu_index(["--auto-uv-profile", profile_id], gpu_index)
+
+
+def _argv_with_gpu_index(argv: list[str], gpu_index: int | None) -> list[str]:
+    if gpu_index is None:
+        return argv
+    return [*argv, "--gpu-index", str(max(0, int(gpu_index)))]
+
+
+def game_gpu_target(
+    setting: SteamGameSetting,
+    identities: Sequence[object],
+) -> tuple[str, int] | None:
+    """Resolve a saved UUID to today's index, or infer the only physical GPU."""
+    selected_uuid = str(setting.gpu_uuid or "").strip()
+    if selected_uuid:
+        index = gpu_index_for_uuid(identities, selected_uuid)
+        return (selected_uuid, index) if index is not None else None
+    if len(identities) != 1:
+        return None
+    identity = identities[0]
+    uuid = str(getattr(identity, "uuid", "") or "").strip()
+    index = gpu_index_for_uuid(identities, uuid)
+    return (uuid, index) if uuid and index is not None else None
 
 
 def game_runtime_profile_argv(
@@ -109,7 +147,19 @@ def game_runtime_profile_argv(
     setting = steam_game_setting(account_id, app_id, path=settings_path)
     if setting is None:
         return None
-    argv = profile_argv_for_setting(setting)
+    try:
+        identities = list(DaemonGpuClient.discover_identities())
+    except Exception:
+        return None
+    target = game_gpu_target(setting, identities)
+    if target is None:
+        return None
+    gpu_uuid, gpu_index = target
+    argv = profile_argv_for_setting(
+        setting,
+        gpu_index=gpu_index,
+        gpu_uuid=gpu_uuid,
+    )
     if argv is None:
         return None
     return argv, app_id

--- a/integrations/steam/manager.py
+++ b/integrations/steam/manager.py
@@ -307,6 +307,13 @@ class SteamIntegrationManager:
         setting = self._setting(app_id)
         return self._apply(app_id, replace(setting, mode=mode))
 
+    def set_game_gpu(self, app_id: str, gpu_uuid: str) -> ApplyResult:
+        setting = self._setting(app_id)
+        return self._apply(
+            app_id,
+            replace(setting, gpu_uuid=str(gpu_uuid or "").strip()),
+        )
+
     def set_game_enabled(self, app_id: str, enabled: bool) -> ApplyResult:
         setting = self._setting(app_id)
         return self._apply(

--- a/integrations/steam/settings.py
+++ b/integrations/steam/settings.py
@@ -71,6 +71,9 @@ class SteamGameSetting:
     injected_launch_options: str = ""
     # None = follow the global [adaptive] target_fps from the runtime config.
     target_fps: float | None = None
+    # Stable NVML UUID. Empty keeps legacy/single-GPU settings compatible;
+    # multi-GPU hosts require an explicit value before enabling the wrapper.
+    gpu_uuid: str = ""
 
     @property
     def active(self) -> bool:
@@ -115,6 +118,7 @@ def load_steam_game_settings(
                 original_launch_options=str(entry.get("original_launch_options") or ""),
                 injected_launch_options=injected,
                 target_fps=normalize_game_target_fps(entry.get("target_fps")),
+                gpu_uuid=str(entry.get("gpu_uuid") or "").strip(),
             )
         if parsed:
             settings[str(account_id)] = parsed
@@ -196,7 +200,7 @@ def _write_settings(
     settings_path = _settings_path(path)
     names = display_names or {}
     payload = {
-        "format_version": 1,
+        "format_version": 2,
         "updated_at": datetime.now().astimezone().isoformat(),
         "accounts": {
             account_id: {
@@ -215,6 +219,7 @@ def _write_settings(
                             if setting.target_fps is not None
                             else {}
                         ),
+                        **({"gpu_uuid": setting.gpu_uuid} if setting.gpu_uuid else {}),
                         "original_launch_options": setting.original_launch_options,
                         "injected_launch_options": setting.injected_launch_options,
                     }

--- a/profiles/gpu_identity.py
+++ b/profiles/gpu_identity.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+GPU_IDENTITY_KEY = "gpu_identity"
+GPU_COMPATIBILITY_MATCH = "match"
+GPU_COMPATIBILITY_LEGACY = "legacy"
+GPU_COMPATIBILITY_MISMATCH = "mismatch"
+GPU_COMPATIBILITY_TARGET_UNKNOWN = "target-unknown"
+
+
+def normalized_gpu_identity(
+    identity: object,
+    *,
+    index_at_verification: int | None = None,
+) -> dict[str, str | int]:
+    """Return the stable, JSON-safe identity stored with a verified profile."""
+
+    raw = identity if isinstance(identity, Mapping) else None
+
+    def value(key: str) -> object:
+        if raw is not None:
+            return raw.get(key)
+        return getattr(identity, key, None)
+
+    result: dict[str, str | int] = {}
+    for key in ("name", "uuid", "pci_bus_id", "pci_device_id"):
+        text = str(value(key) or "").strip()
+        if text:
+            result[key] = text
+
+    raw_index = (
+        index_at_verification
+        if index_at_verification is not None
+        else value("index_at_verification")
+    )
+    if raw_index is None:
+        raw_index = value("index")
+    try:
+        if raw_index is not None:
+            result["index_at_verification"] = max(0, int(str(raw_index)))
+    except (TypeError, ValueError):
+        pass
+    return result
+
+
+def profile_gpu_identity(profile: Mapping[str, Any] | object) -> dict[str, str | int]:
+    if not isinstance(profile, Mapping):
+        return {}
+    identity = profile.get(GPU_IDENTITY_KEY)
+    if not isinstance(identity, Mapping):
+        return {}
+    return normalized_gpu_identity(identity)
+
+
+def profile_gpu_uuid(profile: Mapping[str, Any] | object) -> str:
+    return str(profile_gpu_identity(profile).get("uuid") or "").strip()
+
+
+def bound_profile_gpu_uuids(profiles: Iterable[Mapping[str, Any]]) -> tuple[str, ...]:
+    values: dict[str, str] = {}
+    for profile in profiles:
+        uuid = profile_gpu_uuid(profile)
+        if uuid:
+            values.setdefault(uuid.casefold(), uuid)
+    return tuple(values[key] for key in sorted(values))
+
+
+def profile_gpu_compatibility(
+    profile: Mapping[str, Any] | object,
+    target_uuid: object,
+) -> str:
+    profile_uuid = profile_gpu_uuid(profile)
+    if not profile_uuid:
+        return GPU_COMPATIBILITY_LEGACY
+    selected_uuid = str(target_uuid or "").strip()
+    if not selected_uuid:
+        return GPU_COMPATIBILITY_TARGET_UNKNOWN
+    if profile_uuid.casefold() == selected_uuid.casefold():
+        return GPU_COMPATIBILITY_MATCH
+    return GPU_COMPATIBILITY_MISMATCH
+
+
+def gpu_index_for_uuid(identities: Iterable[object], target_uuid: object) -> int | None:
+    selected_uuid = str(target_uuid or "").strip()
+    if not selected_uuid:
+        return None
+    for identity in identities:
+        raw = identity if isinstance(identity, Mapping) else None
+        uuid = (
+            str(raw.get("uuid") or "").strip()
+            if raw is not None
+            else str(getattr(identity, "uuid", "") or "").strip()
+        )
+        if uuid.casefold() != selected_uuid.casefold():
+            continue
+        raw_index = raw.get("index") if raw is not None else getattr(identity, "index", None)
+        try:
+            return max(0, int(str(raw_index)))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def gpu_identity_label(identity: Mapping[str, Any] | object) -> str:
+    normalized = normalized_gpu_identity(identity)
+    if not normalized:
+        return "Unassigned (legacy)"
+    name = str(normalized.get("name") or "").strip() or "NVIDIA GPU"
+    bus = _short_bus_id(str(normalized.get("pci_bus_id") or ""))
+    return f"{name} ({bus})" if bus else name
+
+
+def profile_gpu_label(profile: Mapping[str, Any] | object) -> str:
+    identity = profile_gpu_identity(profile)
+    return gpu_identity_label(identity) if identity else "Unassigned (legacy)"
+
+
+def _short_bus_id(bus_id: str) -> str:
+    text = str(bus_id or "").strip()
+    if not text:
+        return ""
+    parts = text.split(":")
+    return ":".join(parts[-2:]) if len(parts) >= 2 else text

--- a/profiles/uv/profile_store.py
+++ b/profiles/uv/profile_store.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 import json
 from pathlib import Path
 import re
 
 from common.atomic_write import atomic_write_json
+from profiles.gpu_identity import (
+    normalized_gpu_identity,
+    profile_gpu_identity,
+    profile_gpu_uuid,
+)
 from common.penguin_burner_paths import claim_desktop_user_ownership, default_user_config_dir
 
 from .profile_tiers import (
     load_profile_tier_assignments,
     load_profile_tier_disabled_profile_ids,
+    migrate_legacy_profile_tier_to_gpu,
     profile_tier_summary_fields,
 )
 
@@ -113,6 +120,7 @@ def mark_auto_uv_profile_verified(
     verification: dict | None = None,
     metrics: dict | None = None,
     base_metrics: dict | None = None,
+    gpu_identity: dict | None = None,
 ) -> Path:
     resolved = resolve_auto_uv_profile(str(selector), allow_unverified=True)
     if resolved is None:
@@ -129,6 +137,9 @@ def mark_auto_uv_profile_verified(
     updated["verification_status"] = "verified"
     updated["verified_at"] = now
     updated.setdefault("profile_source", "auto-uv-final")
+    normalized_identity = normalized_gpu_identity(gpu_identity or {})
+    if str(normalized_identity.get("uuid") or "").strip():
+        updated["gpu_identity"] = normalized_identity
 
     merged_verification = {}
     if isinstance(updated.get("verification"), dict):
@@ -158,7 +169,46 @@ def mark_auto_uv_profile_verified(
                 continue
             updated[target_key] = value
 
-    return atomic_write_json(path, updated)
+    written_path = atomic_write_json(path, updated)
+    if str(normalized_identity.get("uuid") or "").strip():
+        migrate_legacy_profile_tier_to_gpu(
+            str(updated.get("profile_id") or path.stem),
+            str(normalized_identity["uuid"]),
+        )
+    return written_path
+
+
+def bind_auto_uv_profile_gpu_identity(
+    selector: str | Path,
+    gpu_identity: dict,
+) -> Path:
+    """Bind a legacy profile during an explicit, unambiguous user action."""
+
+    resolved = resolve_auto_uv_profile(str(selector), allow_unverified=True)
+    if resolved is None:
+        raise FileNotFoundError(f"Auto-UV profile not found: {selector}")
+    path, _resolved_payload = resolved
+    payload = _read_json(path)
+    if payload is None:
+        raise FileNotFoundError(f"Auto-UV profile not readable: {path}")
+    normalized_identity = normalized_gpu_identity(gpu_identity)
+    target_uuid = str(normalized_identity.get("uuid") or "").strip()
+    if not target_uuid:
+        raise ValueError("GPU identity requires a stable UUID")
+    existing_identity = profile_gpu_identity(payload)
+    existing_uuid = str(existing_identity.get("uuid") or "").strip()
+    if existing_uuid and existing_uuid.casefold() != target_uuid.casefold():
+        raise ValueError(
+            f"profile is already bound to {existing_uuid}, not {target_uuid}"
+        )
+    updated = dict(payload)
+    updated["gpu_identity"] = normalized_identity
+    written_path = atomic_write_json(path, updated)
+    migrate_legacy_profile_tier_to_gpu(
+        str(updated.get("profile_id") or path.stem),
+        target_uuid,
+    )
+    return written_path
 
 
 def mark_auto_uv_profile_verification_failed(
@@ -419,6 +469,7 @@ def profile_summary(
         "requires_verification": bool(profile.get("requires_verification", False)),
         "verification_status": profile.get("verification_status"),
         "manual_edit": profile.get("manual_edit"),
+        "gpu_identity": profile_gpu_identity(profile),
     }
     summary.update(
         profile_tier_summary_fields(
@@ -460,16 +511,26 @@ def _display_date(value) -> str:
 
 
 def read_auto_uv_profile_summaries() -> list[dict]:
-    tier_assignments = load_profile_tier_assignments()
-    disabled_profile_tier_ids = load_profile_tier_disabled_profile_ids()
-    return [
-        profile_summary(
-            profile,
-            tier_assignments=tier_assignments,
-            disabled_profile_tier_ids=disabled_profile_tier_ids,
+    assignments_by_gpu: dict[str, dict[str, str]] = {}
+    disabled_by_gpu: dict[str, set[str]] = {}
+    summaries: list[dict] = []
+    for profile in read_auto_uv_profiles():
+        gpu_uuid = profile_gpu_uuid(profile)
+        if gpu_uuid not in assignments_by_gpu:
+            assignments_by_gpu[gpu_uuid] = load_profile_tier_assignments(
+                gpu_uuid=gpu_uuid
+            )
+            disabled_by_gpu[gpu_uuid] = load_profile_tier_disabled_profile_ids(
+                gpu_uuid=gpu_uuid
+            )
+        summaries.append(
+            profile_summary(
+                profile,
+                tier_assignments=assignments_by_gpu[gpu_uuid],
+                disabled_profile_tier_ids=disabled_by_gpu[gpu_uuid],
+            )
         )
-        for profile in read_auto_uv_profiles()
-    ]
+    return summaries
 
 
 def delete_auto_uv_profiles(selectors: list[str | Path]) -> list[Path]:
@@ -486,7 +547,7 @@ def delete_auto_uv_profiles(selectors: list[str | Path]) -> list[Path]:
     return delete_auto_uv_profile_paths(paths)
 
 
-def delete_auto_uv_profile_paths(paths: list[str | Path]) -> list[Path]:
+def delete_auto_uv_profile_paths(paths: Sequence[str | Path]) -> list[Path]:
     deleted: list[Path] = []
     seen: set[Path] = set()
     for raw_path in paths:

--- a/profiles/uv/profile_tiers.py
+++ b/profiles/uv/profile_tiers.py
@@ -7,6 +7,7 @@ import time
 
 from common.atomic_write import atomic_write_json
 from common.penguin_burner_paths import default_user_config_dir
+from profiles.gpu_identity import profile_gpu_uuid
 
 
 PROFILE_TIER_EFFICIENCY = "efficiency"
@@ -113,14 +114,19 @@ def profile_tier_assignments_path() -> Path:
     return default_user_config_dir() / "auto-uv-profile-tier-assignments.json"
 
 
-def load_profile_tier_assignments(path: str | Path | None = None) -> dict[str, str]:
+def load_profile_tier_assignments(
+    path: str | Path | None = None,
+    *,
+    gpu_uuid: str = "",
+) -> dict[str, str]:
     payload = _read_profile_tier_assignments(path)
-    raw_tiers = payload.get("tiers") if isinstance(payload, dict) else None
+    group = _profile_tier_group(payload, gpu_uuid)
+    raw_tiers = group.get("tiers")
     if not isinstance(raw_tiers, dict):
         return {}
     assignments: dict[str, str] = {}
     seen_profiles: set[str] = set()
-    disabled_profile_ids = _disabled_profile_ids_from_payload(payload)
+    disabled_profile_ids = _disabled_profile_ids_from_payload(group)
     for raw_tier, raw_profile_id in raw_tiers.items():
         tier = normalize_profile_tier(raw_tier)
         profile_id = str(raw_profile_id or "").strip()
@@ -138,8 +144,11 @@ def load_profile_tier_assignments(path: str | Path | None = None) -> dict[str, s
 
 def load_profile_tier_disabled_profile_ids(
     path: str | Path | None = None,
+    *,
+    gpu_uuid: str = "",
 ) -> set[str]:
-    return _disabled_profile_ids_from_payload(_read_profile_tier_assignments(path))
+    payload = _read_profile_tier_assignments(path)
+    return _disabled_profile_ids_from_payload(_profile_tier_group(payload, gpu_uuid))
 
 
 def save_profile_tier_assignment(
@@ -147,21 +156,30 @@ def save_profile_tier_assignment(
     tier: object | None,
     *,
     path: str | Path | None = None,
+    gpu_uuid: str = "",
 ) -> dict[str, str]:
     selected_profile_id = str(profile_id or "").strip()
     selected_tier = normalize_profile_tier(tier)
     if not selected_profile_id:
         raise ValueError("profile_id is required")
     if profile_tier_is_none(tier):
-        return save_profile_tier_none_assignment(selected_profile_id, path=path)
+        return save_profile_tier_none_assignment(
+            selected_profile_id,
+            path=path,
+            gpu_uuid=gpu_uuid,
+        )
     if not selected_tier:
         raise ValueError("profile tier is required")
 
-    disabled_profile_ids = load_profile_tier_disabled_profile_ids(path)
+    disabled_profile_ids = load_profile_tier_disabled_profile_ids(
+        path, gpu_uuid=gpu_uuid
+    )
     disabled_profile_ids.discard(selected_profile_id)
     assignments = {
         key: value
-        for key, value in load_profile_tier_assignments(path).items()
+        for key, value in load_profile_tier_assignments(
+            path, gpu_uuid=gpu_uuid
+        ).items()
         if value != selected_profile_id
     }
     assignments[selected_tier] = selected_profile_id
@@ -169,6 +187,7 @@ def save_profile_tier_assignment(
         assignments,
         disabled_profile_ids=disabled_profile_ids,
         path=path,
+        gpu_uuid=gpu_uuid,
     )
     return assignments
 
@@ -177,6 +196,7 @@ def save_profile_tier_none_assignment(
     profile_id: str,
     *,
     path: str | Path | None = None,
+    gpu_uuid: str = "",
 ) -> dict[str, str]:
     selected_profile_id = str(profile_id or "").strip()
     if not selected_profile_id:
@@ -184,17 +204,83 @@ def save_profile_tier_none_assignment(
 
     assignments = {
         key: value
-        for key, value in load_profile_tier_assignments(path).items()
+        for key, value in load_profile_tier_assignments(
+            path, gpu_uuid=gpu_uuid
+        ).items()
         if value != selected_profile_id
     }
-    disabled_profile_ids = load_profile_tier_disabled_profile_ids(path)
+    disabled_profile_ids = load_profile_tier_disabled_profile_ids(
+        path, gpu_uuid=gpu_uuid
+    )
     disabled_profile_ids.add(selected_profile_id)
     _write_profile_tier_assignments(
         assignments,
         disabled_profile_ids=disabled_profile_ids,
         path=path,
+        gpu_uuid=gpu_uuid,
     )
     return assignments
+
+
+def migrate_legacy_profile_tier_to_gpu(
+    profile_id: str,
+    gpu_uuid: str,
+    *,
+    path: str | Path | None = None,
+) -> None:
+    """Move one legacy global assignment into its newly bound GPU group."""
+    selected_profile_id = str(profile_id or "").strip()
+    selected_gpu_uuid = str(gpu_uuid or "").strip()
+    if not selected_profile_id or not selected_gpu_uuid:
+        return
+    legacy_assignments = load_profile_tier_assignments(path)
+    legacy_disabled = load_profile_tier_disabled_profile_ids(path)
+    assigned_tier = next(
+        (
+            tier
+            for tier, assigned_id in legacy_assignments.items()
+            if assigned_id == selected_profile_id
+        ),
+        "",
+    )
+    was_disabled = selected_profile_id in legacy_disabled
+    if not assigned_tier and not was_disabled:
+        return
+
+    gpu_assignments = load_profile_tier_assignments(
+        path, gpu_uuid=selected_gpu_uuid
+    )
+    gpu_disabled = load_profile_tier_disabled_profile_ids(
+        path, gpu_uuid=selected_gpu_uuid
+    )
+    gpu_assignments = {
+        tier: assigned_id
+        for tier, assigned_id in gpu_assignments.items()
+        if assigned_id != selected_profile_id
+    }
+    if assigned_tier:
+        gpu_assignments[assigned_tier] = selected_profile_id
+        gpu_disabled.discard(selected_profile_id)
+    if was_disabled:
+        gpu_disabled.add(selected_profile_id)
+    _write_profile_tier_assignments(
+        gpu_assignments,
+        disabled_profile_ids=gpu_disabled,
+        path=path,
+        gpu_uuid=selected_gpu_uuid,
+    )
+
+    legacy_assignments = {
+        tier: assigned_id
+        for tier, assigned_id in legacy_assignments.items()
+        if assigned_id != selected_profile_id
+    }
+    legacy_disabled.discard(selected_profile_id)
+    _write_profile_tier_assignments(
+        legacy_assignments,
+        disabled_profile_ids=legacy_disabled,
+        path=path,
+    )
 
 
 def profile_tier_disabled(
@@ -209,7 +295,9 @@ def profile_tier_disabled(
     disabled = (
         disabled_profile_ids
         if disabled_profile_ids is not None
-        else load_profile_tier_disabled_profile_ids()
+        else load_profile_tier_disabled_profile_ids(
+            gpu_uuid=profile_gpu_uuid(profile)
+        )
     )
     return profile_id in disabled
 
@@ -221,7 +309,11 @@ def assigned_tier_for_profile(
     profile_id = str(profile.get("profile_id") or "").strip()
     if not profile_id:
         return ""
-    tier_assignments = assignments if assignments is not None else load_profile_tier_assignments()
+    tier_assignments = (
+        assignments
+        if assignments is not None
+        else load_profile_tier_assignments(gpu_uuid=profile_gpu_uuid(profile))
+    )
     for tier, assigned_profile_id in tier_assignments.items():
         if str(assigned_profile_id or "").strip() == profile_id:
             return normalize_profile_tier(tier)
@@ -233,6 +325,13 @@ def profile_tier_summary_fields(
     assignments: dict[str, str] | None = None,
     disabled_profile_ids: set[str] | None = None,
 ) -> dict[str, object]:
+    gpu_uuid = profile_gpu_uuid(profile)
+    if assignments is None:
+        assignments = load_profile_tier_assignments(gpu_uuid=gpu_uuid)
+    if disabled_profile_ids is None:
+        disabled_profile_ids = load_profile_tier_disabled_profile_ids(
+            gpu_uuid=gpu_uuid
+        )
     generated_tier = generated_profile_tier(profile)
     disabled = profile_tier_disabled(profile, disabled_profile_ids)
     assigned_tier = "" if disabled else assigned_tier_for_profile(profile, assignments)
@@ -252,18 +351,29 @@ def resolve_profile_tier_profiles(
     profiles: list[dict],
     assignments: dict[str, str] | None = None,
     disabled_profile_ids: set[str] | None = None,
+    *,
+    gpu_uuid: str = "",
 ) -> dict[str, dict | None]:
-    tier_assignments = assignments if assignments is not None else load_profile_tier_assignments()
+    selected_gpu_uuid = str(gpu_uuid or "").strip()
+    tier_assignments = (
+        assignments
+        if assignments is not None
+        else load_profile_tier_assignments(gpu_uuid=selected_gpu_uuid)
+    )
     disabled = (
         disabled_profile_ids
         if disabled_profile_ids is not None
-        else load_profile_tier_disabled_profile_ids()
+        else load_profile_tier_disabled_profile_ids(gpu_uuid=selected_gpu_uuid)
     )
     visible_profiles = [
         profile
         for profile in profiles
         if bool(profile.get("final_verified", False))
         and not profile_tier_disabled(profile, disabled)
+        and (
+            not selected_gpu_uuid
+            or profile_gpu_uuid(profile).casefold() == selected_gpu_uuid.casefold()
+        )
     ]
     visible_profiles.sort(key=_profile_sort_time, reverse=True)
     by_profile_id = {
@@ -331,6 +441,7 @@ def _write_profile_tier_assignments(
     *,
     disabled_profile_ids: set[str] | None = None,
     path: str | Path | None = None,
+    gpu_uuid: str = "",
 ) -> Path:
     assignment_path = Path(path).expanduser() if path is not None else profile_tier_assignments_path()
     disabled = sorted(
@@ -338,9 +449,7 @@ def _write_profile_tier_assignments(
         for profile_id in (disabled_profile_ids or set())
         if str(profile_id).strip()
     )
-    payload = {
-        "format_version": 2,
-        "updated_at": datetime.now().astimezone().isoformat(),
+    group: dict[str, object] = {
         "tiers": {
             tier: str(assignments[tier])
             for tier in PROFILE_TIERS
@@ -348,7 +457,29 @@ def _write_profile_tier_assignments(
         },
     }
     if disabled:
-        payload["disabled_profile_ids"] = disabled
+        group["disabled_profile_ids"] = disabled
+    selected_gpu_uuid = str(gpu_uuid or "").strip()
+    existing = _read_profile_tier_assignments(path)
+    gpu_profiles = existing.get("gpu_profiles")
+    groups = dict(gpu_profiles) if isinstance(gpu_profiles, dict) else {}
+    if selected_gpu_uuid:
+        for key in tuple(groups):
+            if str(key).casefold() == selected_gpu_uuid.casefold():
+                groups.pop(key, None)
+        groups[selected_gpu_uuid] = group
+        payload = {
+            **existing,
+            "format_version": 3,
+            "updated_at": datetime.now().astimezone().isoformat(),
+            "gpu_profiles": groups,
+        }
+    else:
+        payload = {
+            **existing,
+            "format_version": 3 if groups else 2,
+            "updated_at": datetime.now().astimezone().isoformat(),
+            **group,
+        }
     return atomic_write_json(assignment_path, payload)
 
 
@@ -374,11 +505,26 @@ def _disabled_profile_ids_from_payload(payload: dict) -> set[str]:
     }
 
 
+def _profile_tier_group(payload: dict, gpu_uuid: str) -> dict:
+    selected_gpu_uuid = str(gpu_uuid or "").strip()
+    if not selected_gpu_uuid:
+        return payload if isinstance(payload, dict) else {}
+    groups = payload.get("gpu_profiles") if isinstance(payload, dict) else None
+    if not isinstance(groups, dict):
+        return {}
+    for key, group in groups.items():
+        if str(key).casefold() == selected_gpu_uuid.casefold() and isinstance(
+            group, dict
+        ):
+            return group
+    return {}
+
+
 def _optional_int(value: object | None) -> int | None:
     if value in (None, ""):
         return None
     try:
-        return int(value)
+        return int(str(value))
     except (TypeError, ValueError):
         return None
 
@@ -422,7 +568,7 @@ def _optional_float(value: object | None) -> float | None:
     if value in (None, ""):
         return None
     try:
-        return float(value)
+        return float(str(value))
     except (TypeError, ValueError):
         return None
 

--- a/profiles/verification/runner.py
+++ b/profiles/verification/runner.py
@@ -8,6 +8,7 @@ import tempfile
 
 from common.penguin_burner_errors import NvmlError
 from drivers.nvidia.daemon_gpu import DaemonGpuClient
+from profiles.gpu_identity import normalized_gpu_identity
 from runtime.support.vf_curve_plan import (
     apply_plan,
     backup_current_offsets,
@@ -86,8 +87,14 @@ def run_profile_verification(
     try:
         gpu_client = deps.gpu_client_factory(gpu_index=gpu_index)
         gpu_client.refresh_points()
+        gpu_identity = normalized_gpu_identity(
+            gpu_client.capabilities().identity,
+            index_at_verification=int(gpu_index),
+        )
     except Exception as exc:
         raise NvmlError(f"could not open the daemon GPU client: {exc}") from exc
+    if not str(gpu_identity.get("uuid") or "").strip():
+        raise NvmlError(f"GPU {int(gpu_index)} did not report a stable UUID")
     vf_curve_reader = gpu_client
     gpu_policy_controller = gpu_client
 
@@ -263,6 +270,7 @@ def run_profile_verification(
             },
             metrics=profile_verification_metrics_from_result(result),
             base_metrics=base_metrics,
+            gpu_identity=gpu_identity,
         )
         deps.log(f"Marked profile verified: path={verified_path}")
         deps.log(f"Profile verification passed: profile={label}.")

--- a/runtime/runtime_spec.py
+++ b/runtime/runtime_spec.py
@@ -23,6 +23,8 @@ from profiles.uv.profile_tiers import (
     normalize_profile_tier,
     resolve_profile_tier_profiles,
 )
+from profiles.gpu_identity import gpu_index_for_uuid, profile_gpu_uuid
+from drivers.nvidia.daemon_gpu import DaemonGpuClient
 from profiles.uv.runtime_auto_uv_profile import load_auto_uv_final_curve
 from runtime.daemon_client import gpu_capabilities, require_daemon_capabilities
 from runtime.gpu_control.adaptive_profile_policy import AdaptiveProfilePolicyConfig
@@ -141,18 +143,6 @@ def build_runtime_spec(
         "gpu-capabilities-v1",
         socket_path=socket_path,
     )
-    config, _config_path = load_runtime_config()
-    configured_gpu = config.get("gpu", {}) if isinstance(config, dict) else {}
-    selected_index = (
-        _nonnegative_int(configured_gpu.get("index"), default=0)
-        if gpu_index is None
-        else max(0, int(gpu_index))
-    )
-    capabilities = gpu_capabilities(selected_index, socket_path=socket_path)
-    identity = capabilities.get("identity")
-    if not isinstance(identity, dict) or not str(identity.get("uuid") or "").strip():
-        raise RuntimeError(f"GPU {selected_index} did not report a stable UUID")
-
     selector = str(profile_selector or "").strip()
     selected_curve = (
         # Static mode keeps the documented "empty selector = latest saved
@@ -162,11 +152,38 @@ def build_runtime_spec(
         if selector == STOCK_PROFILE_SELECTOR or (adaptive_auto_uv and not selector)
         else load_auto_uv_final_curve(selector)
     )
+    config, _config_path = load_runtime_config()
+    configured_gpu = config.get("gpu", {}) if isinstance(config, dict) else {}
+    bound_uuid = profile_gpu_uuid(selected_curve or {})
+    selected_index = (
+        _nonnegative_int(configured_gpu.get("index"), default=0)
+        if gpu_index is None
+        else max(0, int(gpu_index))
+    )
+    if bound_uuid:
+        identities = DaemonGpuClient.discover_identities()
+        bound_index = gpu_index_for_uuid(identities, bound_uuid)
+        if bound_index is None:
+            raise RuntimeError(f"profile GPU {bound_uuid} is not currently detected")
+        if gpu_index is not None and int(selected_index) != int(bound_index):
+            raise RuntimeError(
+                f"profile is bound to GPU {bound_index} ({bound_uuid}), "
+                f"not requested GPU {selected_index}"
+            )
+        selected_index = int(bound_index)
+    capabilities = gpu_capabilities(selected_index, socket_path=socket_path)
+    identity = capabilities.get("identity")
+    if not isinstance(identity, dict) or not str(identity.get("uuid") or "").strip():
+        raise RuntimeError(f"GPU {selected_index} did not report a stable UUID")
     mode = "stock"
     static_profile = None
     adaptive = None
     if adaptive_auto_uv:
-        adaptive = _adaptive_spec(selected_curve, target_fps_override=adaptive_target_fps)
+        adaptive = _adaptive_spec(
+            selected_curve,
+            target_fps_override=adaptive_target_fps,
+            gpu_uuid=str(identity["uuid"]),
+        )
         if adaptive is not None:
             mode = "adaptive"
     elif selected_curve is not None:
@@ -204,8 +221,11 @@ def _adaptive_spec(
     selected_curve: dict | None,
     *,
     target_fps_override: float | None = None,
+    gpu_uuid: str = "",
 ) -> dict[str, Any] | None:
-    resolved = resolve_profile_tier_profiles(read_auto_uv_profiles())
+    resolved = resolve_profile_tier_profiles(
+        read_auto_uv_profiles(), gpu_uuid=str(gpu_uuid or "")
+    )
     tier_profiles: dict[str, dict[str, Any]] = {}
     for tier in available_adaptive_tiers(resolved):
         summary = resolved.get(tier)

--- a/tests/auto_uv/test_final_verification_modules.py
+++ b/tests/auto_uv/test_final_verification_modules.py
@@ -195,6 +195,13 @@ def test_final_verified_profile_contains_fan_payload_and_memory_offset(
         memory_offset_mhz=500,
         power_limit_w=360,
         tail_rise_bins=2,
+        gpu_identity={
+            "name": "NVIDIA RTX 5090",
+            "uuid": "GPU-final-a",
+            "pci_bus_id": "00000000:01:00.0",
+            "pci_device_id": "0x2B8510DE",
+            "index": 0,
+        },
     )
     payload = json.loads(profile_path.read_text(encoding="utf-8"))
 
@@ -208,6 +215,13 @@ def test_final_verified_profile_contains_fan_payload_and_memory_offset(
     assert payload["final_verification_metrics"] is True
     assert payload["flatten_target"]["tail_rise_bins"] == 2
     assert payload["fan_curve_payload"]["fan"]["curve"][-1] == [90.0, 100.0]
+    assert payload["gpu_identity"] == {
+        "name": "NVIDIA RTX 5090",
+        "uuid": "GPU-final-a",
+        "pci_bus_id": "00000000:01:00.0",
+        "pci_device_id": "0x2B8510DE",
+        "index_at_verification": 0,
+    }
     assert (tmp_path / "uv-result" / "auto-uv-verified-candidates.json").exists()
 
 

--- a/tests/auto_uv/test_gpu_vf_curve_applier.py
+++ b/tests/auto_uv/test_gpu_vf_curve_applier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -15,6 +16,34 @@ _POWER_LIMIT_ERROR = (
 
 
 def _patch_applier_environment(monkeypatch, gpu_client_type) -> None:
+    if not hasattr(gpu_client_type, "capabilities"):
+        def fake_capabilities(self, *, refresh: bool = False):
+            _ = refresh
+            applied_w = (
+                self.power_limit_calls[-1]
+                if getattr(self, "power_limit_calls", [])
+                else 360
+            )
+            return SimpleNamespace(
+                identity=SimpleNamespace(
+                    index=self.gpu_index,
+                    uuid=f"GPU-test-{self.gpu_index}",
+                    name="NVIDIA GeForce RTX Test",
+                    pci_bus_id=f"0000:{self.gpu_index + 1:02x}:00.0",
+                    pci_device_id="0x1234",
+                ),
+                power=SimpleNamespace(
+                    current_w=applied_w,
+                    enforced_w=applied_w,
+                ),
+            )
+
+        monkeypatch.setattr(
+            gpu_client_type,
+            "capabilities",
+            fake_capabilities,
+            raising=False,
+        )
     monkeypatch.setattr(gpu_vf_curve_applier, "DaemonGpuClient", gpu_client_type)
     monkeypatch.setattr(
         gpu_vf_curve_applier,

--- a/tests/test_afterburner_imports.py
+++ b/tests/test_afterburner_imports.py
@@ -127,6 +127,27 @@ def _patch_afterburner_import_io(monkeypatch, tmp_path: Path) -> tuple[dict, Pat
         lambda **_kwargs: _FakeVfCurveReader(),
     )
     monkeypatch.setattr(ui_app, "archive_auto_uv_profile", archive)
+    monkeypatch.setattr(
+        ui_app.DaemonGpuClient,
+        "capabilities",
+        lambda self: type(
+            "Caps",
+            (),
+            {
+                "identity": type(
+                    "Identity",
+                    (),
+                    {
+                        "index": 0,
+                        "uuid": "GPU-import-test",
+                        "name": "RTX Import Test",
+                        "pci_bus_id": "0000:01:00.0",
+                        "pci_device_id": "0x1234",
+                    },
+                )()
+            },
+        )(),
+    )
     return captured_payload, profile_path
 
 
@@ -274,6 +295,13 @@ def test_gui_afterburner_import_persists_selected_profile(
     result = _persist_afterburner_import_selection(entry)
 
     assert result["afterburner_root"] == str(managed_root)
+    assert captured_payload["gpu_identity"] == {
+        "name": "RTX Import Test",
+        "uuid": "GPU-import-test",
+        "pci_bus_id": "0000:01:00.0",
+        "pci_device_id": "0x1234",
+        "index_at_verification": 0,
+    }
     assert result["section"] == "Profile1"
     assert result["profile_path"] == str(profile_path)
     assert (managed_root / result["device_profile_relative_path"]).is_file()

--- a/tests/test_auto_uv_profiles.py
+++ b/tests/test_auto_uv_profiles.py
@@ -19,6 +19,7 @@ import ui.features.curves.fan_profiles as ui_app
 from runtime.gpu_control.flattened_clock_ceiling import FlattenedClockCeilingController
 from profiles.uv.profile_store import (
     archive_auto_uv_profile,
+    bind_auto_uv_profile_gpu_identity,
     delete_auto_uv_profile_paths,
     delete_auto_uv_profiles,
     format_profile_table,
@@ -91,6 +92,7 @@ from ui.features.profiles.profiles import (
 )
 from ui.features.tuning.verify import elapsed_from_line as _verify_elapsed_from_line
 from ui.features.tuning.verify import progress_percent as _verify_progress_percent
+from ui.features.tuning.gpu_selection import GpuChoice
 from ui.components.profile_list import (
     PROFILE_SORTABLE_COLUMNS,
     ProfileList,
@@ -238,18 +240,19 @@ def test_profile_metric_delta_text_and_color_vs_base() -> None:
 
 
 def test_profile_table_headers_and_sorting_scope() -> None:
-    assert ProfileList.COLUMNS[2] == "mV"
-    assert ProfileList.COLUMNS[3] == "Target MHz"
-    assert ProfileList.COLUMNS[4] == "Effective MHz"
-    assert ProfileList.COLUMNS[5] == "FPS/W"
-    assert ProfileList.COLUMNS[7] == "Power W"
-    assert ProfileList.COLUMNS[8] == "Mem"
-    assert ProfileList.COLUMNS[9] == "Tier"
+    assert ProfileList.COLUMNS[2] == "GPU"
+    assert ProfileList.COLUMNS[3] == "mV"
+    assert ProfileList.COLUMNS[4] == "Target MHz"
+    assert ProfileList.COLUMNS[5] == "Effective MHz"
+    assert ProfileList.COLUMNS[6] == "FPS/W"
+    assert ProfileList.COLUMNS[8] == "Power W"
+    assert ProfileList.COLUMNS[9] == "Mem"
+    assert ProfileList.COLUMNS[10] == "Tier"
     assert "Autostart" not in ProfileList.COLUMNS
     assert "Voltage vs base" not in ProfileList.COLUMNS
     assert "FPS/W vs base" not in ProfileList.COLUMNS
     assert "Power vs base" not in ProfileList.COLUMNS
-    assert PROFILE_SORTABLE_COLUMNS == frozenset({0, 2, 3, 4, 5, 6, 7})
+    assert PROFILE_SORTABLE_COLUMNS == frozenset({0, 2, 3, 4, 5, 6, 7, 8})
 
 
 def test_existing_profile_uses_matching_latest_long_verification_clock(
@@ -387,13 +390,14 @@ def test_profile_non_sort_columns_have_no_sort_keys() -> None:
     )
 
     assert sort_values[1] == ""
-    assert sort_values[4] == pytest.approx(2605.25)
-    assert sort_values[5] == pytest.approx(0.80)
-    assert sort_values[6] == pytest.approx(160.0)
-    assert sort_values[7] == pytest.approx(200.0)
-    assert sort_values[8] == ""
+    assert sort_values[2] == "unassigned (legacy)"
+    assert sort_values[5] == pytest.approx(2605.25)
+    assert sort_values[6] == pytest.approx(0.80)
+    assert sort_values[7] == pytest.approx(160.0)
+    assert sort_values[8] == pytest.approx(200.0)
     assert sort_values[9] == ""
     assert sort_values[10] == ""
+    assert sort_values[11] == ""
 
 
 def test_profile_table_keeps_regular_font_for_highlight_and_deltas() -> None:
@@ -605,6 +609,100 @@ def test_profile_list_uses_one_apply_button() -> None:
     assert "default power limit" in restore_tooltip
 
     profile_list.select_profile("profile-a")
+    assert profile_list.daemonize_button.isEnabled()
+
+
+def test_profile_list_single_gpu_keeps_clean_apply_and_legacy_profile() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6")
+    from PySide6 import QtCore, QtGui, QtWidgets
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    _ = app
+    profile_list = ProfileList(QtCore=QtCore, QtGui=QtGui, QtWidgets=QtWidgets)
+    profiles = [{"profile_id": "legacy", "final_verified": True}]
+    profile_list.set_profiles(profiles)
+    profile_list.configure_gpu_targets(
+        profiles,
+        [GpuChoice(0, "NVIDIA RTX 5090", "00000000:01:00.0", "GPU-A")],
+    )
+    profile_list.select_profile("legacy")
+
+    assert profile_list.target_gpu_combo.isHidden()
+    assert profile_list.daemonize_button.text() == "Apply"
+    assert profile_list.daemonize_button.isEnabled()
+    assert profile_list.target_gpu_index() == 0
+    assert profile_list.table.item(0, profile_list.GPU_COLUMN).text() == (
+        "Unassigned (legacy)"
+    )
+
+
+def test_profile_list_multiple_profile_gpus_requires_explicit_target() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6")
+    from PySide6 import QtCore, QtGui, QtWidgets
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    _ = app
+    profile_list = ProfileList(QtCore=QtCore, QtGui=QtGui, QtWidgets=QtWidgets)
+    profiles = [
+        {
+            "profile_id": "profile-a",
+            "final_verified": True,
+            "gpu_identity": {"name": "RTX 5090", "uuid": "GPU-A"},
+        },
+        {
+            "profile_id": "profile-b",
+            "final_verified": True,
+            "gpu_identity": {"name": "RTX 5090", "uuid": "GPU-B"},
+        },
+    ]
+    choices = [
+        GpuChoice(0, "RTX 5090", "00000000:01:00.0", "GPU-A"),
+        GpuChoice(1, "RTX 5090", "00000000:02:00.0", "GPU-B"),
+    ]
+    profile_list.set_profiles(profiles)
+    profile_list.configure_gpu_targets(profiles, choices)
+    profile_list.select_profile("profile-b")
+
+    assert not profile_list.target_gpu_combo.isHidden()
+    assert profile_list.target_gpu_index() is None
+    assert not profile_list.daemonize_button.isEnabled()
+
+    profile_list.target_gpu_combo.setCurrentIndex(2)
+
+    assert profile_list.target_gpu_uuid() == "GPU-B"
+    assert profile_list.target_gpu_index() == 1
+    assert profile_list.daemonize_button.text() == "Apply to GPU 1"
+    assert profile_list.daemonize_button.isEnabled()
+
+
+def test_profile_list_multiple_hardware_gpus_one_profile_group_needs_no_choice() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6")
+    from PySide6 import QtCore, QtGui, QtWidgets
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    _ = app
+    profile_list = ProfileList(QtCore=QtCore, QtGui=QtGui, QtWidgets=QtWidgets)
+    profiles = [
+        {
+            "profile_id": "profile-b",
+            "final_verified": True,
+            "gpu_identity": {"name": "RTX 5090", "uuid": "GPU-B"},
+        }
+    ]
+    choices = [
+        GpuChoice(0, "RTX 4090", "00000000:01:00.0", "GPU-A"),
+        GpuChoice(1, "RTX 5090", "00000000:02:00.0", "GPU-B"),
+    ]
+    profile_list.set_profiles(profiles)
+    profile_list.configure_gpu_targets(profiles, choices)
+    profile_list.select_profile("profile-b")
+
+    assert profile_list.target_gpu_combo.isHidden()
+    assert profile_list.target_gpu_index() == 1
+    assert profile_list.daemonize_button.text() == "Apply"
     assert profile_list.daemonize_button.isEnabled()
 
 
@@ -924,6 +1022,53 @@ def test_mark_auto_uv_profile_verified_promotes_user_edited_draft(
     assert payload["avg_power_w"] == 240.0
     assert payload["efficiency_fps_per_w"] == 0.50625
     assert payload["base_avg_fps"] == 100.0
+
+
+def test_bind_legacy_profile_identity_preserves_verified_payload(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(profile_store, "default_user_config_dir", lambda: tmp_path)
+    stored_path = archive_auto_uv_profile(
+        {
+            "candidate_voltage_mv": 900,
+            "lock_clock_mhz": 2600,
+            "final_verified": True,
+            "points": [],
+        }
+    )
+
+    bind_auto_uv_profile_gpu_identity(
+        stored_path,
+        {
+            "name": "NVIDIA RTX 5090",
+            "uuid": "GPU-A",
+            "pci_bus_id": "00000000:01:00.0",
+            "pci_device_id": "0x2B8510DE",
+            "index": 0,
+        },
+    )
+
+    payload = json.loads(stored_path.read_text(encoding="utf-8"))
+    assert payload["final_verified"] is True
+    assert payload["gpu_identity"]["uuid"] == "GPU-A"
+    assert payload["gpu_identity"]["pci_bus_id"] == "00000000:01:00.0"
+
+
+def test_binding_cannot_silently_move_profile_to_another_gpu(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(profile_store, "default_user_config_dir", lambda: tmp_path)
+    stored_path = archive_auto_uv_profile(
+        {
+            "final_verified": True,
+            "gpu_identity": {"uuid": "GPU-A", "name": "RTX 5090"},
+        }
+    )
+
+    with pytest.raises(ValueError, match="already bound"):
+        bind_auto_uv_profile_gpu_identity(stored_path, {"uuid": "GPU-B"})
 
 
 def test_mark_auto_uv_profile_verified_preserves_existing_metrics(
@@ -1393,6 +1538,17 @@ def test_profile_verification_promotes_verified_profile(
         def refresh_points(self) -> None:
             pass
 
+        def capabilities(self):
+            return SimpleNamespace(
+                identity=SimpleNamespace(
+                    index=0,
+                    name="NVIDIA RTX 5090",
+                    uuid="GPU-verify-a",
+                    pci_bus_id="00000000:01:00.0",
+                    pci_device_id="0x2B8510DE",
+                )
+            )
+
     config = SimpleNamespace(abort_callback=None)
     result = SimpleNamespace(
         success=True,
@@ -1472,6 +1628,13 @@ def test_profile_verification_promotes_verified_profile(
     assert payload["base_avg_fps"] == 100.0
     assert payload["base_avg_power_w"] == 250.0
     assert payload["base_efficiency_fps_per_w"] == 0.4
+    assert payload["gpu_identity"] == {
+        "name": "NVIDIA RTX 5090",
+        "uuid": "GPU-verify-a",
+        "pci_bus_id": "00000000:01:00.0",
+        "pci_device_id": "0x2B8510DE",
+        "index_at_verification": 0,
+    }
     assert baseline_calls
     assert baseline_calls[0]["base_plan"][0]["target_mhz"] == 2500
     assert baseline_calls[0]["base_plan"][0]["new_offset_mhz"] == 0
@@ -1511,6 +1674,17 @@ def test_profile_verification_wires_live_telemetry_events_when_target_known(
     class FakeGpuClient:
         def refresh_points(self) -> None:
             pass
+
+        def capabilities(self):
+            return SimpleNamespace(
+                identity=SimpleNamespace(
+                    index=0,
+                    name="NVIDIA RTX 5090",
+                    uuid="GPU-verify-a",
+                    pci_bus_id="00000000:01:00.0",
+                    pci_device_id="0x2B8510DE",
+                )
+            )
 
     config = SimpleNamespace(abort_callback=None)
     result = SimpleNamespace(

--- a/tests/test_profile_gpu_identity.py
+++ b/tests/test_profile_gpu_identity.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from profiles.gpu_identity import (
+    GPU_COMPATIBILITY_LEGACY,
+    GPU_COMPATIBILITY_MATCH,
+    GPU_COMPATIBILITY_MISMATCH,
+    GPU_COMPATIBILITY_TARGET_UNKNOWN,
+    bound_profile_gpu_uuids,
+    gpu_identity_label,
+    gpu_index_for_uuid,
+    normalized_gpu_identity,
+    profile_gpu_compatibility,
+    profile_gpu_identity,
+    profile_gpu_label,
+)
+
+
+@dataclass
+class Identity:
+    index: int
+    name: str
+    uuid: str
+    pci_bus_id: str
+    pci_device_id: str
+
+
+def _identity(index: int, uuid: str, *, name: str = "NVIDIA RTX 5090") -> Identity:
+    return Identity(
+        index=index,
+        name=name,
+        uuid=uuid,
+        pci_bus_id=f"00000000:0{index + 1}:00.0",
+        pci_device_id="0x2B8510DE",
+    )
+
+
+def test_normalized_gpu_identity_is_json_safe_and_keeps_stable_fields() -> None:
+    assert normalized_gpu_identity(_identity(2, "GPU-C")) == {
+        "name": "NVIDIA RTX 5090",
+        "uuid": "GPU-C",
+        "pci_bus_id": "00000000:03:00.0",
+        "pci_device_id": "0x2B8510DE",
+        "index_at_verification": 2,
+    }
+
+
+def test_profile_gpu_identity_rejects_flat_or_invalid_legacy_payloads() -> None:
+    assert profile_gpu_identity({"gpu_name": "old value", "gpu_index": 1}) == {}
+    assert profile_gpu_identity({"gpu_identity": "GPU-A"}) == {}
+    assert profile_gpu_label({}) == "Unassigned (legacy)"
+
+
+def test_gpu_identity_label_keeps_name_and_short_pci_bus() -> None:
+    assert (
+        gpu_identity_label(normalized_gpu_identity(_identity(2, "GPU-C")))
+        == "NVIDIA RTX 5090 (03:00.0)"
+    )
+
+
+def test_profile_compatibility_uses_uuid_not_name_or_device_id() -> None:
+    profile = {"gpu_identity": normalized_gpu_identity(_identity(0, "GPU-A"))}
+    assert profile_gpu_compatibility(profile, "gpu-a") == GPU_COMPATIBILITY_MATCH
+    assert profile_gpu_compatibility(profile, "GPU-B") == GPU_COMPATIBILITY_MISMATCH
+    assert profile_gpu_compatibility(profile, "") == GPU_COMPATIBILITY_TARGET_UNKNOWN
+    assert profile_gpu_compatibility({}, "GPU-A") == GPU_COMPATIBILITY_LEGACY
+
+
+def test_bound_profile_gpu_uuids_are_unique_for_identical_models() -> None:
+    profiles = [
+        {"gpu_identity": normalized_gpu_identity(_identity(0, "GPU-B"))},
+        {"gpu_identity": normalized_gpu_identity(_identity(1, "GPU-A"))},
+        {"gpu_identity": normalized_gpu_identity(_identity(2, "gpu-b"))},
+        {},
+    ]
+    assert bound_profile_gpu_uuids(profiles) == ("GPU-A", "GPU-B")
+
+
+def test_gpu_index_is_resolved_from_uuid_after_index_reordering() -> None:
+    identities = [_identity(0, "GPU-C"), _identity(1, "GPU-A"), _identity(2, "GPU-B")]
+    assert gpu_index_for_uuid(identities, "gpu-a") == 1
+    assert gpu_index_for_uuid(identities, "GPU-missing") is None

--- a/tests/test_profile_tiers.py
+++ b/tests/test_profile_tiers.py
@@ -13,6 +13,7 @@ from profiles.uv.profile_tiers import (
     generated_profile_tier,
     load_profile_tier_disabled_profile_ids,
     load_profile_tier_assignments,
+    migrate_legacy_profile_tier_to_gpu,
     normalize_profile_tier,
     profile_tier_disabled,
     profile_tier_summary_fields,
@@ -88,6 +89,71 @@ def test_profile_tier_none_assignment_disables_generated_tier(tmp_path) -> None:
     assert fields["profile_tier"] == ""
     assert fields["profile_tier_key"] == ""
     assert fields["profile_tier_disabled"] is True
+
+
+def test_profile_tier_assignments_are_isolated_by_gpu_uuid(tmp_path) -> None:
+    path = tmp_path / "assignments.json"
+
+    save_profile_tier_assignment(
+        "profile-a",
+        "performance",
+        path=path,
+        gpu_uuid="GPU-a",
+    )
+    save_profile_tier_assignment(
+        "profile-b",
+        "performance",
+        path=path,
+        gpu_uuid="GPU-b",
+    )
+    save_profile_tier_none_assignment(
+        "disabled-a",
+        path=path,
+        gpu_uuid="GPU-a",
+    )
+
+    assert load_profile_tier_assignments(path, gpu_uuid="GPU-a") == {
+        PROFILE_TIER_PERFORMANCE: "profile-a"
+    }
+    assert load_profile_tier_assignments(path, gpu_uuid="gpu-B") == {
+        PROFILE_TIER_PERFORMANCE: "profile-b"
+    }
+    assert load_profile_tier_disabled_profile_ids(
+        path, gpu_uuid="GPU-a"
+    ) == {"disabled-a"}
+    assert load_profile_tier_disabled_profile_ids(path, gpu_uuid="GPU-b") == set()
+    assert load_profile_tier_assignments(path) == {}
+
+
+def test_binding_migrates_legacy_tier_assignment_to_gpu(tmp_path) -> None:
+    path = tmp_path / "assignments.json"
+    save_profile_tier_assignment("profile-a", "balanced", path=path)
+
+    migrate_legacy_profile_tier_to_gpu("profile-a", "GPU-a", path=path)
+
+    assert load_profile_tier_assignments(path) == {}
+    assert load_profile_tier_assignments(path, gpu_uuid="GPU-a") == {
+        PROFILE_TIER_BALANCED: "profile-a"
+    }
+
+
+def test_resolve_profile_tiers_only_uses_selected_gpu_group(tmp_path) -> None:
+    path = tmp_path / "assignments.json"
+    profile_a = _profile("profile-a", "Performance", "2026-06-01T12:00:00+00:00")
+    profile_a["gpu_identity"] = {"uuid": "GPU-a", "name": "A"}
+    profile_b = _profile("profile-b", "Performance", "2026-06-02T12:00:00+00:00")
+    profile_b["gpu_identity"] = {"uuid": "GPU-b", "name": "B"}
+    save_profile_tier_assignment(
+        "profile-a", "performance", path=path, gpu_uuid="GPU-a"
+    )
+
+    resolved = resolve_profile_tier_profiles(
+        [profile_a, profile_b],
+        assignments=load_profile_tier_assignments(path, gpu_uuid="GPU-a"),
+        gpu_uuid="GPU-a",
+    )
+
+    assert resolved[PROFILE_TIER_PERFORMANCE] == profile_a
 
 
 def test_resolve_profile_tier_profiles_prefers_pinned_then_latest_generated() -> None:

--- a/tests/test_runtime_spec.py
+++ b/tests/test_runtime_spec.py
@@ -90,6 +90,64 @@ def test_build_static_runtime_spec_resolves_gpu_and_profile(monkeypatch) -> None
     assert spec["overlay"] == {"enabled": True, "update_interval_s": 2}
 
 
+def test_bound_profile_resolves_current_index_from_uuid_after_reordering(
+    monkeypatch,
+) -> None:
+    curve = _curve("gpu-a-profile")
+    curve["gpu_identity"] = {
+        "name": "Test GPU",
+        "uuid": "GPU-bound-a",
+        "pci_bus_id": "0000:01:00.0",
+        "pci_device_id": "0x123410DE",
+        "index_at_verification": 0,
+    }
+    _stub_runtime_sources(monkeypatch, curve=curve)
+    monkeypatch.setattr(
+        runtime_spec.DaemonGpuClient,
+        "discover_identities",
+        lambda: [
+            SimpleNamespace(index=0, uuid="GPU-other"),
+            SimpleNamespace(index=1, uuid="GPU-bound-a"),
+        ],
+    )
+    monkeypatch.setattr(
+        runtime_spec,
+        "gpu_capabilities",
+        lambda index, **_kwargs: {
+            "identity": {
+                "uuid": "GPU-bound-a" if int(index) == 1 else "GPU-other",
+                "pci_bus_id": "0000:01:00.0",
+                "name": "Test GPU",
+            }
+        },
+    )
+
+    spec = runtime_spec.build_runtime_spec(profile_selector="gpu-a-profile")
+
+    assert spec["gpu"]["uuid"] == "GPU-bound-a"
+    assert spec["gpu"]["index_at_resolution"] == 1
+
+
+def test_explicit_gpu_index_cannot_override_bound_profile_uuid(monkeypatch) -> None:
+    curve = _curve("gpu-a-profile")
+    curve["gpu_identity"] = {"uuid": "GPU-bound-a", "name": "Test GPU"}
+    _stub_runtime_sources(monkeypatch, curve=curve)
+    monkeypatch.setattr(
+        runtime_spec.DaemonGpuClient,
+        "discover_identities",
+        lambda: [
+            SimpleNamespace(index=0, uuid="GPU-bound-a"),
+            SimpleNamespace(index=1, uuid="GPU-other"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="not requested GPU 1"):
+        runtime_spec.build_runtime_spec(
+            profile_selector="gpu-a-profile",
+            gpu_index=1,
+        )
+
+
 def test_runtime_spec_leaves_power_capability_decision_to_daemon(monkeypatch) -> None:
     legacy_curve = _curve("legacy-laptop")
     legacy_curve["power_limit_w"] = 150
@@ -242,7 +300,7 @@ def test_adaptive_runtime_keeps_explicit_old_profile_as_initial_tier(monkeypatch
     monkeypatch.setattr(
         runtime_spec,
         "resolve_profile_tier_profiles",
-        lambda _profiles: {
+        lambda _profiles, **_kwargs: {
             "efficiency": {"profile_id": "eff-new"},
             "balanced": {"profile_id": "balanced-new"},
             "performance": None,
@@ -277,7 +335,7 @@ def test_adaptive_runtime_accepts_one_profile_without_switching(monkeypatch) -> 
     monkeypatch.setattr(
         runtime_spec,
         "resolve_profile_tier_profiles",
-        lambda _profiles: {"balanced": {"profile_id": "balanced-only"}},
+        lambda _profiles, **_kwargs: {"balanced": {"profile_id": "balanced-only"}},
     )
     monkeypatch.setattr(
         runtime_spec,
@@ -315,7 +373,7 @@ def test_adaptive_without_explicit_profile_starts_at_fastest_available_tier(
     monkeypatch.setattr(
         runtime_spec,
         "resolve_profile_tier_profiles",
-        lambda _profiles: {
+        lambda _profiles, **_kwargs: {
             tier: {"profile_id": f"{tier}-profile"} for tier in tiers
         },
     )
@@ -346,7 +404,7 @@ def test_adaptive_runtime_uses_per_game_target_fps_override(monkeypatch) -> None
     monkeypatch.setattr(
         runtime_spec,
         "resolve_profile_tier_profiles",
-        lambda _profiles: {"balanced": {"profile_id": "balanced-only"}},
+        lambda _profiles, **_kwargs: {"balanced": {"profile_id": "balanced-only"}},
     )
     monkeypatch.setattr(
         runtime_spec,

--- a/tests/test_steam_game_runtime.py
+++ b/tests/test_steam_game_runtime.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -8,6 +9,7 @@ from integrations.steam.game_runtime import (
     game_account_id,
     game_app_id,
     game_runtime_profile_argv,
+    game_gpu_target,
     profile_argv_for_setting,
 )
 from integrations.steam.settings import (
@@ -67,11 +69,20 @@ def _stub_adaptive_profiles(monkeypatch) -> None:
     monkeypatch.setattr(
         game_runtime,
         "resolve_profile_tier_profiles",
-        lambda profiles: {
+        lambda profiles, **kwargs: {
             "efficiency": {"profile_id": "efficiency-profile"},
             "balanced": {"profile_id": "balanced-profile"},
             "performance": {"profile_id": "performance-profile"},
         },
+    )
+    monkeypatch.setattr(
+        game_runtime.DaemonGpuClient,
+        "discover_identities",
+        classmethod(
+            lambda cls: [
+                SimpleNamespace(index=0, uuid="GPU-primary", name="RTX Test")
+            ]
+        ),
     )
 
 
@@ -197,6 +208,8 @@ def test_apply_calls_daemon_with_own_pid(
                 "--auto-uv-profile",
                 "performance-profile",
                 "--adaptive-auto-uv",
+                "--gpu-index",
+                "0",
             ],
             "watch_pid": os.getpid(),
             "app_id": "1089130",
@@ -283,6 +296,37 @@ def test_apply_soft_fails_when_daemon_unreachable(
         env, home=steam_home, settings_path=settings_path
     )
     assert "skipped" in capsys.readouterr().err
+
+
+def test_game_gpu_target_requires_choice_with_multiple_gpus() -> None:
+    identities = [
+        SimpleNamespace(index=0, uuid="GPU-a"),
+        SimpleNamespace(index=1, uuid="GPU-b"),
+    ]
+
+    assert game_gpu_target(SteamGameSetting(), identities) is None
+    assert game_gpu_target(
+        SteamGameSetting(gpu_uuid="GPU-b"), identities
+    ) == ("GPU-b", 1)
+
+
+def test_profile_argv_filters_tiers_by_gpu_uuid(monkeypatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(game_runtime, "read_auto_uv_profiles", lambda: [])
+    monkeypatch.setattr(
+        game_runtime,
+        "resolve_profile_tier_profiles",
+        lambda profiles, *, gpu_uuid="": seen.append(gpu_uuid)
+        or {"balanced": {"profile_id": "profile-b"}},
+    )
+
+    argv = profile_argv_for_setting(
+        SteamGameSetting(enabled=True, mode="balanced", gpu_uuid="GPU-b"),
+        gpu_index=2,
+    )
+
+    assert seen == ["GPU-b"]
+    assert argv == ["--auto-uv-profile", "profile-b", "--gpu-index", "2"]
 
 
 def test_client_resolves_and_applies_game_spec_on_the_same_socket(monkeypatch) -> None:

--- a/tests/test_steam_panel.py
+++ b/tests/test_steam_panel.py
@@ -68,6 +68,7 @@ class _FakeManager:
         self.launch_changes: list[tuple[str, str]] = []
         self.enabled_changes: list[tuple[str, bool]] = []
         self.target_fps_changes: list[tuple[str, float | None]] = []
+        self.gpu_changes: list[tuple[str, str]] = []
         self.bulk_enabled: list[tuple[list[str], bool]] = []
         self.bulk_overlay: list[tuple[list[str], bool]] = []
         self.stop_ok = True
@@ -164,6 +165,16 @@ class _FakeManager:
         self.target_fps_changes.append((app_id, target_fps))
         self.rows = tuple(
             replace(row, setting=replace(row.setting, target_fps=target_fps))
+            if row.game.app_id == app_id
+            else row
+            for row in self.rows
+        )
+        return SimpleNamespace(ok=True, message="Applied live.")
+
+    def set_game_gpu(self, app_id: str, gpu_uuid: str):
+        self.gpu_changes.append((app_id, gpu_uuid))
+        self.rows = tuple(
+            replace(row, setting=replace(row.setting, gpu_uuid=gpu_uuid))
             if row.game.app_id == app_id
             else row
             for row in self.rows
@@ -472,6 +483,62 @@ def test_panel_keeps_library_left_and_one_selected_game_editor(
     assert panel.launch_edit.textCursor().position() == 0
 
     panel._sync_timer.stop()
+
+
+def test_multi_gpu_game_requires_explicit_gpu_before_enable(
+    qtbot,
+    tmp_path: Path,
+) -> None:
+    QtCore, QtGui, QtWidgetsModule, _pg = import_qt()
+    manager = _FakeManager((_row(tmp_path, "10", "Alpha", 100),))
+    choices = (
+        SimpleNamespace(uuid="GPU-a", label="GPU 0 - RTX A"),
+        SimpleNamespace(uuid="GPU-b", label="GPU 1 - RTX B"),
+    )
+    panel = SteamPanel(
+        QtCore=QtCore,
+        QtGui=QtGui,
+        QtWidgets=QtWidgetsModule,
+        manager=cast(SteamIntegrationManager, manager),
+        gpu_choices=lambda: choices,
+    )
+    qtbot.addWidget(panel.widget)
+    panel.widget.show()
+    qtbot.waitUntil(lambda: not panel._scan_running, timeout=2000)
+
+    assert panel.game_gpu_combo.isVisibleTo(panel.widget)
+    assert panel.game_gpu_combo.currentData() == ""
+
+    panel.enabled_checkbox.click()
+    assert manager.enabled_changes == []
+    assert not panel.enabled_checkbox.isChecked()
+    assert "Choose a Game GPU" in panel.status_label.text()
+
+    panel.game_gpu_combo.setCurrentIndex(panel.game_gpu_combo.findData("GPU-b"))
+    assert manager.gpu_changes == [("10", "GPU-b")]
+    panel.enabled_checkbox.click()
+    assert manager.enabled_changes == [("10", True)]
+
+
+def test_single_gpu_keeps_game_gpu_selector_hidden(qtbot, tmp_path: Path) -> None:
+    QtCore, QtGui, QtWidgetsModule, _pg = import_qt()
+    manager = _FakeManager((_row(tmp_path, "10", "Alpha", 100),))
+    panel = SteamPanel(
+        QtCore=QtCore,
+        QtGui=QtGui,
+        QtWidgets=QtWidgetsModule,
+        manager=cast(SteamIntegrationManager, manager),
+        gpu_choices=lambda: (
+            SimpleNamespace(uuid="GPU-only", label="GPU 0 - RTX Only"),
+        ),
+    )
+    qtbot.addWidget(panel.widget)
+    panel.widget.show()
+    qtbot.waitUntil(lambda: not panel._scan_running, timeout=2000)
+
+    assert not panel.game_gpu_combo.isVisibleTo(panel.widget)
+    panel.enabled_checkbox.click()
+    assert manager.enabled_changes == [("10", True)]
 
 
 def test_all_games_menu_bulk_enables_and_disables_with_confirmation(

--- a/tests/test_steam_settings.py
+++ b/tests/test_steam_settings.py
@@ -73,6 +73,16 @@ def test_target_fps_roundtrip(tmp_path: Path) -> None:
     assert steam_game_setting("78675700", "1089130", path=path) == setting
 
 
+def test_gpu_uuid_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "steam-game-settings.json"
+    setting = SteamGameSetting(enabled=True, gpu_uuid="GPU-stable-a")
+    store_steam_game_setting("78675700", "1089130", setting, path=path)
+
+    assert steam_game_setting("78675700", "1089130", path=path) == setting
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["format_version"] == 2
+
+
 def test_target_fps_stays_unset_by_default(tmp_path: Path) -> None:
     path = tmp_path / "steam-game-settings.json"
     store_steam_game_setting("78675700", "1089130", SteamGameSetting(), path=path)

--- a/tests/test_ui_window_actions.py
+++ b/tests/test_ui_window_actions.py
@@ -413,7 +413,11 @@ def test_run_runtime_action_blocked_when_busy(win) -> None:
 
 def test_run_adaptive_requires_at_least_one_tier(win) -> None:
     window, monkeypatch = win
-    monkeypatch.setattr(actions_mod, "adaptive_profile_tier_labels", lambda profs: [])
+    monkeypatch.setattr(
+        actions_mod,
+        "adaptive_profile_tier_labels",
+        lambda profs, **kwargs: [],
+    )
     shown: list = []
     monkeypatch.setattr(window.errors, "show", lambda title, msg: shown.append(title))
     fake = _FakeController()

--- a/ui/components/profile_list.py
+++ b/ui/components/profile_list.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 
 from profiles.uv.profile_store import profile_display_name
+from profiles.gpu_identity import (
+    bound_profile_gpu_uuids,
+    profile_gpu_compatibility,
+    profile_gpu_label,
+    profile_gpu_uuid,
+)
+from profiles.gpu_identity import GPU_COMPATIBILITY_LEGACY, GPU_COMPATIBILITY_MATCH
 from profiles.uv.profile_tiers import (
     normalize_profile_tier,
     resolve_profile_tier_profiles,
@@ -13,13 +20,14 @@ from .. import theme
 GOOD_DELTA_COLOR = theme.GOOD
 BAD_DELTA_COLOR = theme.ERROR
 PROFILE_SORT_ROLE = 261
-PROFILE_SORTABLE_COLUMNS = frozenset({0, 2, 3, 4, 5, 6, 7})
+PROFILE_SORTABLE_COLUMNS = frozenset({0, 2, 3, 4, 5, 6, 7, 8})
 
 
 class ProfileList:
     COLUMNS = [
         "Date",
         "Profile",
+        "GPU",
         "mV",
         "Target MHz",
         "Effective MHz",
@@ -32,19 +40,22 @@ class ProfileList:
     ]
     DATE_COLUMN = 0
     PROFILE_COLUMN = 1
-    VOLTAGE_COLUMN = 2
-    TARGET_MHZ_COLUMN = 3
-    EFFECTIVE_MHZ_COLUMN = 4
-    FPSW_COLUMN = 5
-    FPS_COLUMN = 6
-    POWER_COLUMN = 7
-    MEMORY_OFFSET_COLUMN = 8
-    SOURCE_COLUMN = 10
+    GPU_COLUMN = 2
+    VOLTAGE_COLUMN = 3
+    TARGET_MHZ_COLUMN = 4
+    EFFECTIVE_MHZ_COLUMN = 5
+    FPSW_COLUMN = 6
+    FPS_COLUMN = 7
+    POWER_COLUMN = 8
+    MEMORY_OFFSET_COLUMN = 9
+    SOURCE_COLUMN = 11
     PROFILE_ID_ROLE = 257
     CANDIDATE_ID_ROLE = 258
     PROFILE_PATH_ROLE = 259
     PROFILE_DELETABLE_ROLE = 260
     PROFILE_APPLY_ROLE = 262
+    PROFILE_GPU_UUID_ROLE = 263
+    PROFILE_VERIFIED_ROLE = 264
     SORT_VALUE_ROLE = PROFILE_SORT_ROLE
     SORTABLE_COLUMNS = PROFILE_SORTABLE_COLUMNS
 
@@ -54,6 +65,11 @@ class ProfileList:
         self.QtWidgets = QtWidgets
         self._item_class = _sortable_item_class(QtWidgets, self.SORT_VALUE_ROLE)
         self._runtime_actions_available = True
+        self._gpu_choices: list[object] = []
+        self._target_gpu_uuid = ""
+        self._target_gpu_index: int | None = None
+        self._target_selection_required = False
+        self.on_target_gpu_changed = None
         self._sort_column = self.DATE_COLUMN
         self._sort_order = QtCore.Qt.DescendingOrder
         self.widget = QtWidgets.QWidget()
@@ -62,6 +78,15 @@ class ProfileList:
         layout.setSpacing(8)
 
         top = QtWidgets.QHBoxLayout()
+        self.target_gpu_label = QtWidgets.QLabel("Target GPU")
+        self.target_gpu_combo = QtWidgets.QComboBox()
+        self.target_gpu_combo.setObjectName("profileTargetGpu")
+        self.target_gpu_combo.setToolTip(
+            "Choose which GPU this Profiles action targets. Changing this selection "
+            "does not modify hardware settings."
+        )
+        self.target_gpu_label.setVisible(False)
+        self.target_gpu_combo.setVisible(False)
         self.silent_fan_checkbox = QtWidgets.QCheckBox("Silent fan curve")
         self.boot_apply_checkbox = QtWidgets.QCheckBox("Apply on startup")
         self.boot_apply_checkbox.setToolTip(
@@ -87,6 +112,8 @@ class ProfileList:
             "and restore the default power limit."
         )
         top.addWidget(QtWidgets.QLabel("Stored undervolt profiles"))
+        top.addWidget(self.target_gpu_label)
+        top.addWidget(self.target_gpu_combo)
         top.addStretch(1)
         top.addWidget(self.silent_fan_checkbox)
         top.addWidget(self.boot_apply_checkbox)
@@ -136,6 +163,7 @@ class ProfileList:
         adaptive_note.setWordWrap(True)
         layout.addWidget(adaptive_note)
         self.table.itemSelectionChanged.connect(self._sync_action_state)
+        self.target_gpu_combo.currentIndexChanged.connect(self._target_gpu_changed)
         self._sync_action_state()
 
     def set_profiles(
@@ -181,6 +209,7 @@ class ProfileList:
                 values = [
                     _date_text(profile),
                     _profile_name(profile),
+                    profile_gpu_label(profile),
                     _format_profile_metric_with_delta(
                         profile.get("candidate_voltage_mv"),
                         _profile_base_metric(profile, "candidate_voltage_mv"),
@@ -223,6 +252,15 @@ class ProfileList:
                     item.setData(self.PROFILE_PATH_ROLE, profile_path)
                     item.setData(self.PROFILE_DELETABLE_ROLE, bool(is_deletable))
                     item.setData(self.PROFILE_APPLY_ROLE, bool(is_applicable))
+                    item.setData(
+                        self.PROFILE_GPU_UUID_ROLE,
+                        str(
+                            (profile.get("gpu_identity") or {}).get("uuid")
+                            if isinstance(profile.get("gpu_identity"), dict)
+                            else ""
+                        ).strip(),
+                    )
+                    item.setData(self.PROFILE_VERIFIED_ROLE, bool(is_applicable))
                     item.setData(self.SORT_VALUE_ROLE, sort_values[column])
                     if (
                         column in self.SORTABLE_COLUMNS - {self.DATE_COLUMN}
@@ -310,6 +348,124 @@ class ProfileList:
         elif silent_fan_checked is not None:
             self._set_silent_fan_checked(bool(silent_fan_checked))
         self._sync_action_state()
+
+    def configure_gpu_targets(
+        self,
+        profiles: list[dict],
+        choices: list[object],
+        *,
+        preferred_index: int | None = None,
+    ) -> None:
+        previous_uuid = self._target_gpu_uuid
+        self._gpu_choices = list(choices)
+        bound_uuids = bound_profile_gpu_uuids(profiles)
+        choice_by_uuid = {
+            str(getattr(choice, "uuid", "") or "").strip().casefold(): choice
+            for choice in self._gpu_choices
+            if str(getattr(choice, "uuid", "") or "").strip()
+        }
+        self._target_selection_required = len(bound_uuids) >= 2 or (
+            not bound_uuids and len(self._gpu_choices) >= 2 and bool(profiles)
+        )
+
+        target_uuid = ""
+        if self._target_selection_required:
+            preferred_choice = next(
+                (
+                    choice
+                    for choice in self._gpu_choices
+                    if preferred_index is not None
+                    and int(getattr(choice, "index", -1)) == int(preferred_index)
+                ),
+                None,
+            )
+            preferred_uuid = str(getattr(preferred_choice, "uuid", "") or "").strip()
+            if preferred_uuid and (
+                preferred_uuid.casefold() in {item.casefold() for item in bound_uuids}
+                or not bound_uuids
+            ):
+                target_uuid = preferred_uuid
+            elif previous_uuid.casefold() in {item.casefold() for item in bound_uuids}:
+                target_uuid = previous_uuid
+        elif len(bound_uuids) == 1:
+            target_uuid = bound_uuids[0]
+        elif len(self._gpu_choices) == 1:
+            target_uuid = str(getattr(self._gpu_choices[0], "uuid", "") or "").strip()
+
+        target_choice = choice_by_uuid.get(target_uuid.casefold())
+        if target_choice is None and not target_uuid and len(self._gpu_choices) == 1:
+            target_choice = self._gpu_choices[0]
+        self._target_gpu_uuid = target_uuid
+        self._target_gpu_index = (
+            int(getattr(target_choice, "index")) if target_choice is not None else None
+        )
+        self._populate_target_gpu_combo(target_uuid)
+        self._sync_target_gpu_presentation()
+        self._sync_action_state()
+
+    def target_gpu_index(self) -> int | None:
+        return self._target_gpu_index
+
+    def target_gpu_uuid(self) -> str:
+        return self._target_gpu_uuid
+
+    def target_selection_required(self) -> bool:
+        return self._target_selection_required
+
+    def profile_matches_target(self, profile: dict) -> bool:
+        compatibility = profile_gpu_compatibility(profile, self._target_gpu_uuid)
+        if compatibility == GPU_COMPATIBILITY_MATCH:
+            return self._target_gpu_index is not None
+        if compatibility == GPU_COMPATIBILITY_LEGACY:
+            return len(self._gpu_choices) == 1 and self._target_gpu_index is not None
+        return False
+
+    def _populate_target_gpu_combo(self, target_uuid: str) -> None:
+        blocked = self.target_gpu_combo.blockSignals(True)
+        try:
+            self.target_gpu_combo.clear()
+            self.target_gpu_combo.addItem("Choose target GPU...", "")
+            selected_combo_index = 0
+            for choice in self._gpu_choices:
+                uuid = str(getattr(choice, "uuid", "") or "").strip()
+                if not uuid:
+                    continue
+                label = str(getattr(choice, "label", "") or "").strip()
+                self.target_gpu_combo.addItem(label or uuid, uuid)
+                if uuid.casefold() == target_uuid.casefold():
+                    selected_combo_index = self.target_gpu_combo.count() - 1
+            self.target_gpu_combo.setCurrentIndex(selected_combo_index)
+        finally:
+            self.target_gpu_combo.blockSignals(blocked)
+
+    def _target_gpu_changed(self, _combo_index: int) -> None:
+        uuid = str(self.target_gpu_combo.currentData() or "").strip()
+        choice = next(
+            (
+                item
+                for item in self._gpu_choices
+                if str(getattr(item, "uuid", "") or "").strip().casefold()
+                == uuid.casefold()
+            ),
+            None,
+        )
+        self._target_gpu_uuid = uuid
+        self._target_gpu_index = (
+            int(getattr(choice, "index")) if choice is not None else None
+        )
+        self._sync_target_gpu_presentation()
+        self._sync_action_state()
+        if callable(self.on_target_gpu_changed):
+            self.on_target_gpu_changed(self._target_gpu_index, self._target_gpu_uuid)
+
+    def _sync_target_gpu_presentation(self) -> None:
+        visible = self._target_selection_required
+        self.target_gpu_label.setVisible(visible)
+        self.target_gpu_combo.setVisible(visible)
+        if visible and self._target_gpu_index is not None:
+            self.daemonize_button.setText(f"Apply to GPU {self._target_gpu_index}")
+        else:
+            self.daemonize_button.setText("Apply")
 
     def _active_sort_column(self) -> int:
         column = int(self._sort_column)
@@ -449,7 +605,9 @@ class ProfileList:
         self.daemonize_button.setEnabled(has_apply_selection)
         self.boot_apply_checkbox.setEnabled(self._runtime_actions_available)
         self.delete_button.setEnabled(has_delete_selection)
-        self.restore_defaults_button.setEnabled(self._runtime_actions_available)
+        self.restore_defaults_button.setEnabled(
+            self._runtime_actions_available and self._target_gpu_index is not None
+        )
 
     def _set_silent_fan_checked(self, checked: bool) -> None:
         signals_blocked = self.silent_fan_checkbox.blockSignals(True)
@@ -507,7 +665,17 @@ class ProfileList:
 
     def _row_is_applicable(self, row: int) -> bool:
         item = self.table.item(int(row), 0)
-        return bool(item is not None and item.data(self.PROFILE_APPLY_ROLE))
+        if item is None or not item.data(self.PROFILE_VERIFIED_ROLE):
+            return False
+        profile_uuid = str(item.data(self.PROFILE_GPU_UUID_ROLE) or "").strip()
+        if profile_uuid:
+            return bool(
+                self._target_gpu_index is not None
+                and profile_uuid.casefold() == self._target_gpu_uuid.casefold()
+            )
+        if not self._gpu_choices and not self._target_selection_required:
+            return True
+        return bool(len(self._gpu_choices) == 1 and self._target_gpu_index is not None)
 
 
 def _standard_trash_icon(QtWidgets, widget):
@@ -545,11 +713,11 @@ def _sort_value_less(left, right, *, descending: bool = False) -> bool:
     return left_key < right_key
 
 
-def _sort_key(value) -> float | str:
+def _sort_key(value) -> tuple[int, float, str]:
     number = _to_float(value)
     if number is not None:
-        return float(number)
-    return str(value).casefold()
+        return (0, float(number), "")
+    return (1, 0.0, str(value).casefold())
 
 
 def _selection_flags(QtCore, *names: str):
@@ -783,6 +951,7 @@ def _profile_sort_values(profile: dict) -> list[float | str]:
     return [
         _date_sort_value(profile),
         "",
+        profile_gpu_label(profile).casefold(),
         _profile_value_sort_value(profile, "candidate_voltage_mv"),
         _profile_value_sort_value(profile, "lock_clock_mhz"),
         _profile_value_sort_value(profile, "avg_core_clock_mhz"),
@@ -809,14 +978,16 @@ def _resolved_tier_winner_ids(profiles: list[dict]) -> dict[str, str]:
     # resolve_profile_tier_profiles); the table mirrors that so each tier label
     # appears on exactly one row -- the profile adaptive mode would actually
     # pick. Superseded duplicates fall back to a blank tier in the UI.
-    resolved = resolve_profile_tier_profiles(profiles)
     winners: dict[str, str] = {}
-    for tier, profile in resolved.items():
-        if not isinstance(profile, dict):
-            continue
-        profile_id = str(profile.get("profile_id") or "").strip()
-        if profile_id:
-            winners[tier] = profile_id
+    for gpu_uuid in {profile_gpu_uuid(profile) for profile in profiles}:
+        resolved = resolve_profile_tier_profiles(profiles, gpu_uuid=gpu_uuid)
+        for tier, profile in resolved.items():
+            if not isinstance(profile, dict):
+                continue
+            profile_id = str(profile.get("profile_id") or "").strip()
+            if profile_id:
+                winner_key = f"{gpu_uuid}\0{tier}" if gpu_uuid else tier
+                winners[winner_key] = profile_id
     return winners
 
 
@@ -836,7 +1007,9 @@ def _profile_tier_label(
         return ""
     if tier_winner_ids:
         tier_key = normalize_profile_tier(label)
-        winner_id = str(tier_winner_ids.get(tier_key) or "").strip()
+        gpu_uuid = profile_gpu_uuid(profile)
+        winner_key = f"{gpu_uuid}\0{tier_key}" if gpu_uuid else tier_key
+        winner_id = str(tier_winner_ids.get(winner_key) or "").strip()
         profile_id = str(profile.get("profile_id") or "").strip()
         # Only the resolved winner keeps the tier; duplicates show no tier so
         # the column stays unique and matches adaptive mode's choice.

--- a/ui/components/steam_panel.py
+++ b/ui/components/steam_panel.py
@@ -126,12 +126,15 @@ class SteamPanel:
         QtWidgets,
         manager: SteamIntegrationManager | None = None,
         adaptive_available=None,
+        gpu_choices=None,
     ):
         self.QtCore = QtCore
         self.QtGui = QtGui
         self.QtWidgets = QtWidgets
         self.manager = manager if manager is not None else SteamIntegrationManager()
-        self.adaptive_available = adaptive_available or (lambda: True)
+        self.adaptive_available = adaptive_available
+        self.gpu_choices = gpu_choices or (lambda: [])
+        self._gpu_choices: tuple[object, ...] = ()
         self._syncing = False
         self._scan_running = False
         self._rows: dict[str, SteamGameRow] = {}
@@ -372,6 +375,20 @@ class SteamPanel:
         )
         details_layout.addWidget(self.launch_edit)
 
+        self.game_gpu_label = QtWidgets.QLabel("Game GPU")
+        self.game_gpu_label.setObjectName("steamFieldLabel")
+        self.game_gpu_label.setToolTip(
+            _wrapped_tooltip(
+                "Choose the physical GPU PenguinBurner will tune while this "
+                "game runs. This is required only on multi-GPU systems."
+            )
+        )
+        details_layout.addWidget(self.game_gpu_label)
+        self.game_gpu_combo = QtWidgets.QComboBox()
+        self.game_gpu_combo.setObjectName("steamGameGpu")
+        self.game_gpu_combo.setToolTip(self.game_gpu_label.toolTip())
+        details_layout.addWidget(self.game_gpu_combo)
+
         self.mode_label = QtWidgets.QLabel("Auto-UV mode")
         self.mode_label.setObjectName("steamFieldLabel")
         details_layout.addWidget(self.mode_label)
@@ -441,6 +458,7 @@ class SteamPanel:
         self.game_list.currentItemChanged.connect(self._selection_changed)
         self.proton_combo.currentIndexChanged.connect(self._proton_changed)
         self.mode_combo.currentIndexChanged.connect(self._mode_changed)
+        self.game_gpu_combo.currentIndexChanged.connect(self._game_gpu_changed)
         self.target_fps_spin.valueChanged.connect(self._target_fps_changed)
         self.enabled_checkbox.toggled.connect(self._enabled_changed)
         self.overlay_checkbox.toggled.connect(self._overlay_changed)
@@ -460,6 +478,7 @@ class SteamPanel:
         self._game_state_timer.setInterval(_GAME_STATE_POLL_MS)
         self._game_state_timer.timeout.connect(self._poll_game_states)
 
+        self._sync_game_gpu_choices()
         self._sync_selected_details()
         # Startup discovery is read-only. Only an explicit Rescan button click
         # records the disabled, Adaptive-preselected defaults for new games.
@@ -566,6 +585,7 @@ class SteamPanel:
     def _populate(self, rows: tuple[SteamGameRow, ...]) -> None:
         previous_app_id = self._selected_app_id or self._current_app_id()
         self._rows = {row.game.app_id: row for row in rows}
+        self._sync_game_gpu_choices()
         self._sync_default_mode_label()
         self._refresh_game_list(preferred_app_id=previous_app_id)
         self._sync_status()
@@ -584,7 +604,17 @@ class SteamPanel:
         finally:
             self.mode_combo.blockSignals(signals_were_blocked)
 
-        adaptive_ok = bool(self.adaptive_available())
+        row = self._rows.get(self._current_app_id())
+        gpu_uuid = str(row.setting.gpu_uuid or "").strip() if row else ""
+        if not gpu_uuid and len(self._gpu_choices) == 1:
+            gpu_uuid = str(getattr(self._gpu_choices[0], "uuid", "") or "").strip()
+        if not callable(self.adaptive_available):
+            adaptive_ok = True
+        else:
+            try:
+                adaptive_ok = bool(self.adaptive_available(gpu_uuid))
+            except TypeError:
+                adaptive_ok = bool(self.adaptive_available())
         adaptive_index = self.mode_combo.findData(GAME_MODE_ADAPTIVE)
         if adaptive_index >= 0:
             item = self.mode_combo.model().item(adaptive_index)
@@ -668,6 +698,7 @@ class SteamPanel:
                 self.proton_combo.clear()
                 self.proton_combo.addItem("Steam default", "")
                 self.launch_edit.clear()
+                self.game_gpu_combo.setCurrentIndex(0)
                 self.mode_combo.setCurrentIndex(
                     max(0, self.mode_combo.findData(GAME_MODE_ADAPTIVE))
                 )
@@ -702,6 +733,8 @@ class SteamPanel:
                 cursor.setPosition(0)
                 self.launch_edit.setTextCursor(cursor)
                 self._resize_launch_editor()
+                gpu_index = self.game_gpu_combo.findData(row.setting.gpu_uuid)
+                self.game_gpu_combo.setCurrentIndex(max(0, gpu_index))
                 mode_index = self.mode_combo.findData(normalize_game_mode(row.setting.mode))
                 self.mode_combo.setCurrentIndex(max(0, mode_index))
                 self.target_fps_spin.setValue(
@@ -731,6 +764,11 @@ class SteamPanel:
         self.launch_edit.setEnabled(has_selection)
         self.launch_edit.setReadOnly(not editable)
         self.enabled_checkbox.setEnabled(editable)
+        multi_gpu = len(self._gpu_choices) >= 2
+        self.game_gpu_label.setVisible(multi_gpu)
+        self.game_gpu_combo.setVisible(multi_gpu)
+        self.game_gpu_label.setEnabled(editable)
+        self.game_gpu_combo.setEnabled(editable)
         wrapper_enabled = editable and self.enabled_checkbox.isChecked()
         self.mode_label.setEnabled(wrapper_enabled)
         self.mode_combo.setEnabled(wrapper_enabled)
@@ -942,6 +980,42 @@ class SteamPanel:
         hot = self.manager.hot_reapply(app_id) if result.ok else None
         self._after_apply(app_id, result, extra=hot)
 
+    def _sync_game_gpu_choices(self) -> None:
+        try:
+            choices = tuple(self.gpu_choices())
+        except Exception:
+            choices = ()
+        current_uuid = str(self.game_gpu_combo.currentData() or "").strip()
+        signals_were_blocked = self.game_gpu_combo.blockSignals(True)
+        try:
+            self._gpu_choices = choices
+            self.game_gpu_combo.clear()
+            if len(choices) >= 2:
+                self.game_gpu_combo.addItem("Choose a GPU…", "")
+            for choice in choices:
+                uuid = str(getattr(choice, "uuid", "") or "").strip()
+                if uuid:
+                    self.game_gpu_combo.addItem(str(getattr(choice, "label", uuid)), uuid)
+            index = self.game_gpu_combo.findData(current_uuid)
+            self.game_gpu_combo.setCurrentIndex(max(0, index))
+        finally:
+            self.game_gpu_combo.blockSignals(signals_were_blocked)
+
+    def _game_gpu_changed(self, _index: int) -> None:
+        if self._syncing:
+            return
+        if not self._flush_pending_launch_edit():
+            return
+        app_id = self._current_app_id()
+        if not app_id:
+            return
+        gpu_uuid = str(self.game_gpu_combo.currentData() or "").strip()
+        if len(self._gpu_choices) >= 2 and not gpu_uuid:
+            return
+        result = self.manager.set_game_gpu(app_id, gpu_uuid)
+        hot = self.manager.hot_reapply(app_id) if result.ok else None
+        self._after_apply(app_id, result, extra=hot)
+
     def _sync_all_games_menu(self) -> None:
         """Each bulk action stays clickable only while it would change
         something: no mass-enable when everything is already enabled, no
@@ -962,6 +1036,13 @@ class SteamPanel:
             return
         app_ids = list(self._rows)
         if not app_ids:
+            return
+        if enabled and len(self._gpu_choices) >= 2 and any(
+            not row.setting.gpu_uuid for row in self._rows.values()
+        ):
+            self._sync_status(
+                "Choose a Game GPU for each game before enabling all games."
+            )
             return
         count = len(app_ids)
         games_word = "game" if count == 1 else "games"
@@ -1037,6 +1118,18 @@ class SteamPanel:
             return
         app_id = self._current_app_id()
         if not app_id:
+            return
+        if (
+            checked
+            and len(self._gpu_choices) >= 2
+            and not str(self.game_gpu_combo.currentData() or "").strip()
+        ):
+            signals_were_blocked = self.enabled_checkbox.blockSignals(True)
+            try:
+                self.enabled_checkbox.setChecked(False)
+            finally:
+                self.enabled_checkbox.blockSignals(signals_were_blocked)
+            self._sync_status("Choose a Game GPU before enabling PenguinBurner.")
             return
         result = self.manager.set_game_enabled(app_id, checked)
         hot = self.manager.hot_reapply(app_id) if result.ok else None

--- a/ui/features/integrations/afterburner_import.py
+++ b/ui/features/integrations/afterburner_import.py
@@ -21,6 +21,8 @@ from common.penguin_burner_paths import (
     sync_afterburner_export_tree,
 )
 from drivers.nvidia.hidden_nvapi_vf import create_hidden_vf_curve_reader
+from drivers.nvidia.daemon_gpu import DaemonGpuClient
+from profiles.gpu_identity import normalized_gpu_identity
 from profiles.uv.profile_store import archive_auto_uv_profile
 
 from ui.features.tuning.gpu_selection import runtime_gpu_index
@@ -107,7 +109,14 @@ def persist_afterburner_import_selection(entry: dict) -> dict:
         device_profile_hint=device_profile_relative_path,
     )
     section_info = source.get("section_info", {})
-    reader = create_hidden_vf_curve_reader(gpu_index=runtime_gpu_index(config_path))
+    gpu_index = runtime_gpu_index(config_path)
+    identity = normalized_gpu_identity(
+        DaemonGpuClient(gpu_index).capabilities().identity,
+        index_at_verification=gpu_index,
+    )
+    if not identity.get("uuid"):
+        raise RuntimeError("could not identify the GPU used for this import")
+    reader = create_hidden_vf_curve_reader(gpu_index=gpu_index)
     if reader is None:
         raise RuntimeError("could not open the live Nvidia V/F curve reader")
     try:
@@ -138,6 +147,7 @@ def persist_afterburner_import_selection(entry: dict) -> dict:
         "lock_clock_mhz": int(clock),
         "final_verified": True,
         "verification_status": "imported",
+        "gpu_identity": identity,
         "plan": plan,
         "points": plan,
         "flatten_target": dict(section_info.get("flatten_target") or {}),
@@ -176,7 +186,7 @@ def persist_afterburner_import_selection(entry: dict) -> dict:
 
 def afterburner_fan_curve_payload(afterburner_root: str | Path) -> dict | None:
     try:
-        settings = load_afterburner_fan_settings(afterburner_root)
+        settings = load_afterburner_fan_settings(Path(afterburner_root))
     except Exception:
         return None
     curve_points = fan_curve_points(settings.get("curve", {}).get("points"))
@@ -249,7 +259,7 @@ def afterburner_section_curve_points(section: dict) -> list[tuple[float, float]]
         voltage = point.get("voltage_mv")
         clock = point.get("frequency_mhz", point.get("target_mhz"))
         try:
-            points.append((float(voltage), float(clock)))
+            points.append((float(str(voltage)), float(str(clock))))
         except (TypeError, ValueError):
             continue
     return points

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
 import shlex
+from pathlib import Path
 from typing import Any
 
 from common.penguin_burner_paths import default_user_config_dir
 from curve_editors.uv.vf_curve_manual_editor import editable_anchor_from_profile
 from profiles.uv.memory_offset_edit import editable_memory_offset_from_profile
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR
+from profiles.uv.profile_store import bind_auto_uv_profile_gpu_identity
 from profiles.uv.profile_store import delete_auto_uv_profile_paths
 from profiles.uv.profile_tiers import save_profile_tier_assignment
 from profiles.uv.profile_tiers import save_profile_tier_none_assignment
+from profiles.gpu_identity import (
+    GPU_COMPATIBILITY_LEGACY,
+    GPU_COMPATIBILITY_MATCH,
+    profile_gpu_compatibility,
+    profile_gpu_uuid,
+)
+from profiles.gpu_identity import normalized_gpu_identity
+from drivers.nvidia.daemon_gpu import DaemonGpuClient
 
 from ui.commands import delete_profiles_command
 from ui.commands import profile_verify_command
@@ -104,10 +114,20 @@ class ProfileActionsMixin:
     ) -> None:
         if self._workflow_running():
             return
+        target_gpu_index = self.profile_list.target_gpu_index()
+        target_gpu_uuid = self.profile_list.target_gpu_uuid()
+        if target_gpu_index is None:
+            message = "Choose a target GPU before applying this profile."
+            self.controls.set_status_text(message)
+            self.log_view.append(f"\n{message}\n")
+            return
         profile_id = str(profile_selector or "").strip()
         selected_profile = None
         if adaptive_auto_uv:
-            tiers = adaptive_profile_tier_labels(self.profile_summaries)
+            tiers = adaptive_profile_tier_labels(
+                self.profile_summaries,
+                gpu_uuid=target_gpu_uuid,
+            )
             if not tiers:
                 available = ", ".join(tiers) if tiers else "none"
                 self.errors.show(
@@ -116,7 +136,6 @@ class ProfileActionsMixin:
                     f"profile. Available tiers: {available}.",
                 )
                 return
-            selected_profile = profile_for_selector(self.profile_summaries, "latest")
         else:
             profile_id = profile_id or self.profile_list.selected_profile_id()
             if not profile_id:
@@ -125,6 +144,19 @@ class ProfileActionsMixin:
             selected_profile = profile_for_selector(self.profile_summaries, profile_id)
             if not profile_can_apply(selected_profile or {}):
                 message = "This edited profile must be verified before it can be applied."
+                self.controls.set_status_text(message)
+                self.log_view.append(f"\n{message}\n")
+                return
+            if not self.profile_list.profile_matches_target(selected_profile or {}):
+                compatibility = profile_gpu_compatibility(
+                    selected_profile or {}, target_gpu_uuid
+                )
+                message = (
+                    "This legacy profile must be verified on the selected GPU "
+                    "before it can be applied."
+                    if compatibility == GPU_COMPATIBILITY_LEGACY
+                    else "This profile belongs to a different GPU. Choose its GPU target."
+                )
                 self.controls.set_status_text(message)
                 self.log_view.append(f"\n{message}\n")
                 return
@@ -147,6 +179,30 @@ class ProfileActionsMixin:
             ),
         ):
             return
+        if not self._confirm_runtime_gpu_switch(target_gpu_uuid):
+            return
+        if (
+            selected_profile
+            and profile_gpu_compatibility(selected_profile, target_gpu_uuid)
+            == GPU_COMPATIBILITY_LEGACY
+            and Path(str(selected_profile.get("path") or "")).is_file()
+        ):
+            try:
+                identity = normalized_gpu_identity(
+                    DaemonGpuClient(int(target_gpu_index)).capabilities().identity,
+                    index_at_verification=int(target_gpu_index),
+                )
+                bind_auto_uv_profile_gpu_identity(
+                    str(selected_profile.get("path") or profile_id),
+                    identity,
+                )
+                selected_profile["gpu_identity"] = identity
+            except Exception as exc:
+                self.errors.show(
+                    "GPU profile binding",
+                    f"Could not bind this legacy profile to the selected GPU: {exc}",
+                )
+                return
         # Boot persistence follows the "Apply on startup" toggle: ticked saves
         # the applied profile for boot, unticked applies session-only and
         # clears any saved boot profile. Restore defaults still persists the
@@ -157,7 +213,7 @@ class ProfileActionsMixin:
             profile_selector=profile_id,
             silent_fan_curve=self.profile_list.silent_fan_enabled(),
             adaptive_auto_uv=adaptive_auto_uv,
-            gpu_index=self.gpu_index,
+            gpu_index=int(target_gpu_index),
             persist_on_startup=persist_on_startup,
         )
         self._persist_silent_fan_preference(self.profile_list.silent_fan_enabled())
@@ -177,6 +233,13 @@ class ProfileActionsMixin:
     def _restore_gpu_defaults(self) -> None:
         if self._workflow_running():
             return
+        target_gpu_index = self.profile_list.target_gpu_index()
+        if target_gpu_index is None:
+            self.errors.show(
+                "Restore defaults",
+                "Choose a target GPU before restoring defaults.",
+            )
+            return
         # Elevated work goes through the already-root daemon (NO pkexec): ask it
         # to run the reserved stock runtime. The daemon stops the current profile,
         # resets the GPU to factory, applies no undervolt, and keeps running for
@@ -192,7 +255,7 @@ class ProfileActionsMixin:
             "daemonize",
             profile_selector=STOCK_PROFILE_SELECTOR,
             silent_fan_curve=self.profile_list.silent_fan_enabled(),
-            gpu_index=self.gpu_index,
+            gpu_index=int(target_gpu_index),
             # Stock is the safe state: restoring persists it for boot
             # regardless of the Apply-on-startup toggle.
             persist_on_startup=True,
@@ -302,7 +365,16 @@ class ProfileActionsMixin:
                 "No editable memory offset is available for this profile.",
             )
             return
-        min_mhz, max_mhz = memory_offset_mhz_range(gpu_index=self.gpu_index)
+        target_gpu_index = self.profile_list.target_gpu_index()
+        if target_gpu_index is None:
+            self.errors.show(
+                "Edit Memory Offset",
+                "Choose this profile's GPU before editing its memory offset.",
+            )
+            return
+        min_mhz, max_mhz = memory_offset_mhz_range(
+            gpu_index=int(target_gpu_index)
+        )
 
         def save_edit(new_memory_offset_mhz: int) -> str:
             path, _payload = save_edited_memory_offset_profile(
@@ -374,6 +446,21 @@ class ProfileActionsMixin:
     def _verify_profile(self, profile: dict) -> None:
         if self._workflow_running() or not profile_can_verify(profile):
             return
+        target_gpu_index = self.profile_list.target_gpu_index()
+        target_gpu_uuid = self.profile_list.target_gpu_uuid()
+        if target_gpu_index is None:
+            self.errors.show(
+                "Profile verification",
+                "Choose a target GPU before verifying this profile.",
+            )
+            return
+        compatibility = profile_gpu_compatibility(profile, target_gpu_uuid)
+        if compatibility not in {GPU_COMPATIBILITY_MATCH, GPU_COMPATIBILITY_LEGACY}:
+            self.errors.show(
+                "Profile verification",
+                "This profile belongs to a different GPU. Choose its GPU target.",
+            )
+            return
         label = profile_status_label(
             self.profile_summaries,
             str(profile.get("profile_id", "")),
@@ -397,7 +484,7 @@ class ProfileActionsMixin:
             profile_selector=profile_verify_selector(profile),
             duration_s=duration_s,
             stop_request_path=verify_stop_request_path(),
-            gpu_index=self.gpu_index,
+            gpu_index=int(target_gpu_index),
         )
         workload = workload_label()
         self.header.set_stage("Profile verification")
@@ -591,7 +678,11 @@ class ProfileActionsMixin:
             editable_memory_offset_from_profile(profile) is not None
         )
         apply_action = menu.addAction("Apply")
-        apply_action.setEnabled(not self._workflow_running() and profile_can_apply(profile))
+        apply_action.setEnabled(
+            not self._workflow_running()
+            and profile_can_apply(profile)
+            and self.profile_list.profile_matches_target(profile)
+        )
         verify_action = menu.addAction("Verify")
         verify_action.setEnabled(
             not self._workflow_running() and profile_can_verify(profile)
@@ -634,11 +725,18 @@ class ProfileActionsMixin:
             profile_id = str(profile.get("profile_id") or "").strip()
             for tier, action in tier_actions.items():
                 if chosen == action:
-                    save_profile_tier_assignment(profile_id, tier)
+                    save_profile_tier_assignment(
+                        profile_id,
+                        tier,
+                        gpu_uuid=profile_gpu_uuid(profile),
+                    )
                     self._load_profiles()
                     break
         elif chosen == none_tier_action:
-            save_profile_tier_none_assignment(str(profile.get("profile_id") or ""))
+            save_profile_tier_none_assignment(
+                str(profile.get("profile_id") or ""),
+                gpu_uuid=profile_gpu_uuid(profile),
+            )
             self._load_profiles()
         elif chosen == delete_action:
             self._delete_selected_profiles()
@@ -656,6 +754,27 @@ class ProfileActionsMixin:
             return f"Starting adaptive Auto-UV; Autostart: {autostart}."
         selected = self.profile_list.selected_profile_name() or "none"
         return f"Starting profile: {selected}; Autostart: {autostart}."
+
+    def _confirm_runtime_gpu_switch(self, target_gpu_uuid: str) -> bool:
+        running_info = running_auto_uv_profile_info()
+        running_uuid = str(running_info.get("gpu_uuid") or "").strip()
+        selected_uuid = str(target_gpu_uuid or "").strip()
+        if not running_uuid or not selected_uuid or running_uuid.casefold() == selected_uuid.casefold():
+            return True
+        buttons = (
+            self.QtWidgets.QMessageBox.StandardButton.Yes
+            | self.QtWidgets.QMessageBox.StandardButton.No
+        )
+        answer = self.QtWidgets.QMessageBox.question(
+            self.window,
+            "Switch managed GPU",
+            "Another GPU is currently managed. Switching stops monitoring that GPU. "
+            "Its applied curve, memory offset, or power limit may remain until you "
+            "restore it or the driver resets it.\n\nSwitch to the selected GPU?",
+            buttons,
+            self.QtWidgets.QMessageBox.StandardButton.No,
+        )
+        return answer == self.QtWidgets.QMessageBox.StandardButton.Yes
 
 
 def _manual_curve_control_voltage_mvs(manual_edit) -> tuple[int, ...]:

--- a/ui/features/profiles/profiles.py
+++ b/ui/features/profiles/profiles.py
@@ -95,8 +95,11 @@ def adaptive_profile_tier_keys(
     profiles: list[dict],
     *,
     assignments: dict[str, str] | None = None,
+    gpu_uuid: str = "",
 ) -> list[str]:
-    resolved = resolve_profile_tier_profiles(list(profiles), assignments=assignments)
+    resolved = resolve_profile_tier_profiles(
+        list(profiles), assignments=assignments, gpu_uuid=gpu_uuid
+    )
     return available_adaptive_tiers(resolved)
 
 
@@ -104,12 +107,15 @@ def adaptive_profile_tier_labels(
     profiles: list[dict],
     *,
     assignments: dict[str, str] | None = None,
+    gpu_uuid: str = "",
 ) -> list[str]:
     return [
         label
         for label in (
             profile_tier_label(tier)
-            for tier in adaptive_profile_tier_keys(profiles, assignments=assignments)
+            for tier in adaptive_profile_tier_keys(
+                profiles, assignments=assignments, gpu_uuid=gpu_uuid
+            )
         )
         if label
     ]
@@ -477,6 +483,7 @@ def _daemon_running_profile_info() -> dict[str, object]:
     active_job = payload.get("active_job")
     if isinstance(active_job, dict) and str(active_job.get("runtime_mode") or ""):
         info = _profile_info_from_runtime_summary(active_job)
+        info["gpu_uuid"] = str(active_job.get("gpu_uuid") or "")
         # The Steam tab's per-game override layer: active_job is the live
         # (possibly per-game) spec; game_runtime carries the standing one
         # that returns when the game exits.

--- a/ui/features/tuning/gpu_selection.py
+++ b/ui/features/tuning/gpu_selection.py
@@ -15,6 +15,7 @@ class GpuChoice:
     name: str
     pci_bus_id: str = ""
     uuid: str = ""
+    pci_device_id: str = ""
 
     @property
     def label(self) -> str:
@@ -49,6 +50,7 @@ def gpu_choices_from_nvml_identities(identities) -> list[GpuChoice]:
                 index=index,
                 name=str(getattr(identity, "name", "") or ""),
                 pci_bus_id=str(getattr(identity, "pci_bus_id", "") or ""),
+                pci_device_id=str(getattr(identity, "pci_device_id", "") or ""),
                 uuid=str(getattr(identity, "uuid", "") or ""),
             )
         )

--- a/ui/window.py
+++ b/ui/window.py
@@ -33,7 +33,11 @@ from ui.dialogs.about import show_about_dialog
 from ui.dialogs.final_choice import select_final_candidate
 from ui.dialogs.scan_tuning import select_scan_tuning
 from .error_reporting import ErrorReporter
-from ui.features.tuning.gpu_selection import persist_runtime_gpu_index
+from ui.features.tuning.gpu_selection import (
+    detected_gpu_choices,
+    gpu_choices_with_fallback,
+    persist_runtime_gpu_index,
+)
 from ui.daemon_setup import ensure_daemon_ready_for_privileged_action
 from ui.features.tuning.final_choice_controller import handle_final_choice_request
 from . import theme
@@ -138,6 +142,7 @@ class MainWindow(ProfileActionsMixin):
             QtGui=self.QtGui,
             QtWidgets=self.QtWidgets,
         )
+        self.profile_list.on_target_gpu_changed = self._profile_target_gpu_changed
         self.log_view = LogView(
             QtCore=self.QtCore,
             QtGui=self.QtGui,
@@ -153,10 +158,14 @@ class MainWindow(ProfileActionsMixin):
             QtCore=self.QtCore,
             QtGui=self.QtGui,
             QtWidgets=self.QtWidgets,
-            adaptive_available=lambda: len(
-                adaptive_profile_tier_labels(self.profile_summaries)
+            adaptive_available=lambda gpu_uuid="": len(
+                adaptive_profile_tier_labels(
+                    self.profile_summaries,
+                    gpu_uuid=gpu_uuid,
+                )
             )
             >= 1,
+            gpu_choices=detected_gpu_choices,
         )
 
         self.tabs = self.QtWidgets.QTabWidget()
@@ -756,8 +765,31 @@ class MainWindow(ProfileActionsMixin):
                 or bool(autostart_info["silent_fan_curve"])
             ),
         )
+        gpu_choices, _selected_gpu_index = gpu_choices_with_fallback(
+            selected_index=self.gpu_index
+        )
+        self.profile_list.configure_gpu_targets(
+            self.profile_summaries,
+            gpu_choices,
+            preferred_index=self.gpu_index,
+        )
         self._set_profile_actions_enabled(not self._workflow_running())
         self._refresh_running_status(running_info, autostart_info)
+
+    def _profile_target_gpu_changed(
+        self,
+        gpu_index: int | None,
+        _gpu_uuid: str,
+    ) -> None:
+        if gpu_index is None:
+            return
+        try:
+            self.gpu_index = persist_runtime_gpu_index(int(gpu_index))
+        except Exception as exc:
+            self.errors.show(
+                "GPU selection",
+                f"Could not save selected GPU index: {exc}",
+            )
 
     def _poll_running_status(self) -> None:
         """Gather live daemon/systemd status OFF the GUI thread, then render.


### PR DESCRIPTION
## Summary

- persist verified profile GPU name, UUID, PCI bus ID, PCI device ID, and verification-time index
- resolve saved UUIDs to current daemon indices so device reordering cannot redirect a curve
- add a GPU column and ambiguity-driven target selector to Profiles
- isolate adaptive tier assignments per GPU and migrate legacy tier assignments when a profile is bound
- add a per-game Game GPU selector to Steam only when two or more physical NVIDIA GPUs are detected
- keep legacy/single-GPU workflows one-click and require explicit choice on ambiguous multi-GPU hosts

## Runtime policy

The existing single root daemon and one-active-runtime model remains unchanged. Switching targets is serialized; this PR does not start multiple daemons or infer the gaming GPU from display ownership or load.

## Validation

- `python -m pytest tests/ -q` — 1791 passed
- `scripts/check-feature-static-analysis.sh` — compile/import scans, Ruff, vulture, and diff checks passed; repository-wide Pyright remains advisory with its existing baseline
- focused Pyright over every production file touched by this PR — 0 errors
- `git diff --check`

Live multi-GPU hardware and interactive Qt validation remain to be performed before merge.

Closes #46