### PR TITLE
Stop the test suite writing the developer's own PenguinBurner config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,29 @@ def write_desktop_rtd3_tree() -> Callable[[Path], tuple[Path, Path]]:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_user_home(monkeypatch, tmp_path_factory):
+    """Keep the suite out of the developer's own PenguinBurner state.
+
+    Every user-visible path (runtime config, saved profiles, caches) hangs off
+    _effective_home(), and PENGUIN_BURNER_HOME overrides it. Without this,
+    anything that reaches a real persistence helper writes the machine it runs
+    on: selecting a GPU in a widget, for instance, calls through to
+    persist_runtime_gpu_index and rewrites [gpu] index in the developer's
+    ~/.config/PenguinBurner/penguin_burner.toml, silently repointing the tool
+    at a different card.
+
+    A test that needs to control the home itself sets the variable after this
+    fixture has run, which wins.
+
+    The directory comes from the factory rather than the test's own tmp_path:
+    several tests assert on the exact contents of tmp_path, and a home planted
+    inside it would show up as a stray entry.
+    """
+    home = tmp_path_factory.mktemp("penguin-burner-home")
+    monkeypatch.setenv("PENGUIN_BURNER_HOME", str(home))
+
+
+@pytest.fixture(autouse=True)
 def _no_detached_launch_processes(monkeypatch):
     """Launcher main()-flow tests must never spawn real detached processes
     (re-front watcher, per-game FIFO drainer): those outlive the test run and

--- a/tests/test_suite_isolation.py
+++ b/tests/test_suite_isolation.py
@@ -50,8 +50,9 @@ def test_persisting_a_gpu_index_cannot_reach_the_real_config() -> None:
     """
     from ui.features.tuning.gpu_selection import persist_runtime_gpu_index
 
+    written = default_runtime_config_path().resolve()
+    assert _real_home() not in written.parents
+
     persist_runtime_gpu_index(1)
 
-    written = default_runtime_config_path().resolve()
     assert written.exists()
-    assert _real_home() not in written.parents

--- a/tests/test_suite_isolation.py
+++ b/tests/test_suite_isolation.py
@@ -1,0 +1,57 @@
+"""The suite must not read or write the developer's own PenguinBurner state.
+
+Every user-visible path hangs off ``_effective_home()``. A test that reaches a
+real persistence helper without noticing would otherwise rewrite the machine it
+runs on, and the damage is silent: the run still passes.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from common.penguin_burner_paths import (
+    default_runtime_config_path,
+    default_saved_uv_dir,
+    default_user_config_dir,
+)
+
+
+def _real_home() -> Path:
+    return Path(os.path.expanduser("~")).resolve()
+
+
+def test_the_home_override_is_set_for_every_test() -> None:
+    override = os.environ.get("PENGUIN_BURNER_HOME", "").strip()
+
+    assert override, "the autouse isolation fixture in conftest.py is not running"
+    assert Path(override).is_dir()
+
+
+def test_user_paths_resolve_outside_the_developers_home() -> None:
+    real = _real_home()
+
+    for path in (
+        default_user_config_dir(),
+        default_runtime_config_path(),
+        default_saved_uv_dir(),
+    ):
+        resolved = Path(path).expanduser().resolve()
+        assert real not in resolved.parents, f"{resolved} is under the real home"
+
+
+def test_persisting_a_gpu_index_cannot_reach_the_real_config() -> None:
+    """The concrete leak this guard was added for.
+
+    Selecting a GPU in the Profiles widget calls through to
+    persist_runtime_gpu_index. Unmocked, that used to rewrite [gpu] index in
+    ~/.config/PenguinBurner/penguin_burner.toml and silently repoint the tool
+    at a different card.
+    """
+    from ui.features.tuning.gpu_selection import persist_runtime_gpu_index
+
+    persist_runtime_gpu_index(1)
+
+    written = default_runtime_config_path().resolve()
+    assert written.exists()
+    assert _real_home() not in written.parents

--- a/tests/test_ui_commands.py
+++ b/tests/test_ui_commands.py
@@ -213,7 +213,14 @@ def test_ui_scan_command_uses_flatpak_host_privilege(
 
 
 def _flatpak_daemon_install_env(monkeypatch, tmp_path) -> None:
-    """Environment for building the elevated flatpak daemon-install command."""
+    """Environment for building the elevated flatpak daemon-install command.
+
+    The host home this command carries is meant to resolve from USER through
+    the getpwnam stub below. PENGUIN_BURNER_HOME outranks both, so the helper
+    clears it and states the environment under test outright, instead of
+    depending on whichever home the run happened to inherit.
+    """
+    monkeypatch.delenv("PENGUIN_BURNER_HOME", raising=False)
     flatpak_info = tmp_path / ".flatpak-info"
     flatpak_info.write_text("[Application]\n", encoding="utf-8")
     monkeypatch.setattr(commands, "FLATPAK_INFO_PATH", flatpak_info)


### PR DESCRIPTION
Running `python -m pytest tests/` rewrites
~/.config/PenguinBurner/penguin_burner.toml on the machine it runs on.

Two tests in test_ui_window_profile_methods.py drive the Profiles widget's GPU combo. That calls through to an unmocked persist_runtime_gpu_index, which writes [gpu] index for real. Seeded with `index = 0`, a single test turns it into `index = 1`: the tool is silently repointed at a different card, and the run still passes, so nothing announces it.

Every user-visible path resolves through _effective_home(), and PENGUIN_BURNER_HOME overrides it, so one autouse fixture closes the whole class of leak rather than mocking helpers case by case. The home comes from tmp_path_factory, not the test's own tmp_path, because several tests assert on the exact contents of tmp_path and a home planted inside would show up as a stray entry. A test that needs to control the home still sets the variable itself, which wins.

That isolation exposed a second, related problem.
test_daemon_migration_command_replays_legacy_boot_intent_host_side asserts the command carries PENGUIN_BURNER_RUNTIME_HOME=/home/desktop-user, which it gets by faking USER and getpwnam -- but PENGUIN_BURNER_HOME outranks both, so the test only passed because the variable happened to be unset. Its helper now clears it and states the environment under test outright.

tests/test_suite_isolation.py locks the guarantee down, including the concrete gpu-index leak; all three of its cases fail if the fixture is removed.

Checks: 1801 passed, 57 skipped (the skips are the unbuilt daemon binary). Verified against a seeded config on a fake home: clean main turns `index = 0` into `index = 1`, this branch leaves it at 0. No new ruff diagnostics; the new file is clean.