### PR TITLE
Let a signalled drainer unlink its own FIFO

### DIFF
--- a/overlay/launcher.py
+++ b/overlay/launcher.py
@@ -218,8 +218,9 @@ def _create_marker_fifo(env: dict[str, str]) -> bool:
 def _sweep_stale_marker_fifos(env: dict[str, str]) -> None:
     """Unlink leftover per-launch marker FIFOs that no drainer reads anymore.
 
-    The drainer unlinks its own FIFO on exit; this catches the crash/SIGKILL
-    leftovers. A non-blocking write-only open of a FIFO fails with ENXIO
+    The drainer unlinks its own FIFO on exit, including when it is signalled;
+    this catches what is left when it cannot -- SIGKILL, a machine losing
+    power. A non-blocking write-only open of a FIFO fails with ENXIO
     exactly when it has no reader -- a live drainer means skip it.
     """
     current = trace_fifo_path(env)

--- a/overlay/telemetry/nvapi_marker_bridge.py
+++ b/overlay/telemetry/nvapi_marker_bridge.py
@@ -32,6 +32,7 @@ two unmeasurable ends (peripheral input and physical scanout/panel).
 from __future__ import annotations
 
 import argparse
+import ctypes
 import json
 import os
 import re
@@ -41,9 +42,12 @@ import socket
 import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
+from types import FrameType
 
 from .sockets import latency_socket_path, latency_socket_paths
 from .. import shim_deploy as _shim_deploy
@@ -101,6 +105,12 @@ _NO_WRITER_GRACE_S = 60.0
 # mis-pairing to a sane click-to-photon magnitude (log timestamps are ms-grained).
 _MAX_OOB_LAG_US = 200_000
 TELEMETRY_SESSION_ENV = "PENGUIN_BURNER_TELEMETRY_SESSION"
+
+_FifoIdentity = tuple[int, int]
+_SignalHandler = int | Callable[[int, FrameType | None], object]
+_SignalMask = set[int | signal.Signals]
+_AT_FDCWD = -100
+_RENAME_NOREPLACE = 1
 
 
 def _socket_targets(env: dict[str, str] | None = None) -> list[Path]:
@@ -585,12 +595,15 @@ def main(argv: list[str] | None = None) -> int:
         liveness = _shim_deploy.SessionLiveness(args.session_pid, session_fd)
         session_alive_fn = liveness.session_alive
         session_quiesced_fn = liveness.steam_reaper_quiesced
-    # A launcher stopping the game kills this drainer along with the rest of
-    # the session, so termination is the ordinary way it ends, not an
-    # exception. Turning the signal into SystemExit lets the cleanup below run
-    # the same way it does on a normal exit.
-    _exit_on_termination()
+    cleanup_identity = _fifo_identity(args.log) if args.cleanup else None
+    installed_handlers: list[tuple[int, _SignalHandler]] = []
     try:
+        # A launcher stopping the game kills this drainer along with the rest
+        # of the session, so termination is the ordinary way it ends. Keep the
+        # handlers scoped to the cleanup-owning invocation: main() is also
+        # called in-process by tests and must not change its caller's signals.
+        if args.cleanup:
+            _install_termination_handlers(installed_handlers)
         run(
             args.log,
             poll_interval_s=args.poll_interval,
@@ -599,47 +612,203 @@ def main(argv: list[str] | None = None) -> int:
             session_quiesced_fn=session_quiesced_fn,
         )
     finally:
-        if session_fd is not None:
-            try:
-                os.close(session_fd)
-            except OSError:
-                pass
-        # In the finally, not after the try: a drainer that is signalled or
-        # raises would otherwise leave its FIFO behind, one per game session.
-        # The launcher's stale-FIFO sweep is meant to catch crashes, not to be
-        # the routine cleanup path.
-        if args.cleanup:
-            unlink_fifo(args.log)
+        cleanup_signal_mask = (
+            _block_termination_signals() if installed_handlers else None
+        )
+        try:
+            if session_fd is not None:
+                try:
+                    os.close(session_fd)
+                except OSError:
+                    pass
+            # In the finally, not after the try: a drainer that is signalled or
+            # raises would otherwise leave its FIFO behind, one per game
+            # session. Only unlink the same FIFO this invocation started with;
+            # a replaced path belongs to something else.
+            if args.cleanup:
+                unlink_fifo(
+                    args.log, expected_identity=cleanup_identity
+                )
+        finally:
+            _restore_signal_handlers(installed_handlers)
+            _restore_signal_mask(cleanup_signal_mask)
     return 0
 
 
-def unlink_fifo(path: Path) -> bool:
-    """Remove a per-launch marker FIFO. True when it is gone afterwards."""
+def _fifo_identity(path: Path) -> _FifoIdentity | None:
+    """Identify a real FIFO at path without following a symlink."""
     try:
-        if not stat.S_ISFIFO(path.stat().st_mode):
+        info = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISFIFO(info.st_mode):
+        return None
+    return info.st_dev, info.st_ino
+
+
+def unlink_fifo(
+    path: Path, *, expected_identity: _FifoIdentity | None
+) -> bool:
+    """Atomically capture and remove only the expected per-launch FIFO."""
+    if expected_identity is None:
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            return True
+        except OSError:
             return False
-        path.unlink()
-    except FileNotFoundError:
-        return True
+        return False
+
+    try:
+        quarantine_dir = Path(
+            tempfile.mkdtemp(
+                prefix=".penguin-burner-fifo-cleanup-", dir=path.parent
+            )
+        )
     except OSError:
         return False
-    return True
-
-
-def _exit_on_termination() -> None:
-    def _raise_system_exit(signal_number, _frame):
-        raise SystemExit(128 + int(signal_number))
-
-    for name in ("SIGTERM", "SIGINT", "SIGHUP"):
-        number = getattr(signal, name, None)
-        if number is None:
-            continue
+    quarantined = quarantine_dir / "entry"
+    try:
+        if not _quarantine_can_restore_entries(quarantine_dir):
+            return False
         try:
-            signal.signal(number, _raise_system_exit)
+            # rename() removes the public name and captures whatever occupied
+            # it as one atomic directory operation. Validation and deletion
+            # then happen only under our freshly created private directory, so
+            # a replacement at the public path is never unlinked by cleanup.
+            os.rename(path, quarantined)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+
+        if _fifo_identity(quarantined) != expected_identity:
+            _restore_quarantined_entry(quarantined, path)
+            return False
+        try:
+            quarantined.unlink()
+        except OSError:
+            _restore_quarantined_entry(quarantined, path)
+            return False
+        return True
+    finally:
+        try:
+            quarantine_dir.rmdir()
+        except OSError:
+            # An entry that could not be restored is preserved here rather
+            # than deleted. The random directory name makes it recoverable.
+            pass
+
+
+def _restore_quarantined_entry(quarantined: Path, destination: Path) -> bool:
+    """Restore any entry without overwriting a new destination."""
+    return _rename_noreplace(quarantined, destination)
+
+
+def _rename_noreplace(source: Path, destination: Path) -> bool:
+    """Atomically rename source only when destination does not exist."""
+    try:
+        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+        renameat2.argtypes = (
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        )
+        renameat2.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    return (
+        renameat2(
+            _AT_FDCWD,
+            os.fsencode(source),
+            _AT_FDCWD,
+            os.fsencode(destination),
+            _RENAME_NOREPLACE,
+        )
+        == 0
+    )
+
+
+def _quarantine_can_restore_entries(quarantine_dir: Path) -> bool:
+    """Confirm this filesystem supports atomic no-overwrite restoration."""
+    probe = quarantine_dir / "restore-probe"
+    moved_probe = quarantine_dir / "restore-probe-moved"
+    try:
+        probe.mkdir()
+    except OSError:
+        return False
+    restored_safely = _rename_noreplace(probe, moved_probe)
+    for path in (probe, moved_probe):
+        try:
+            path.rmdir()
+        except OSError:
+            pass
+    return restored_safely
+
+
+def _raise_system_exit(
+    signal_number: int, _frame: FrameType | None
+) -> None:
+    raise SystemExit(128 + int(signal_number))
+
+
+def _install_termination_handlers(
+    installed_handlers: list[tuple[int, _SignalHandler]],
+) -> None:
+    for number in _termination_signal_numbers():
+        try:
+            previous_handler = signal.getsignal(number)
         except (OSError, ValueError):
             # Not the main thread, or the platform refuses this signal: the
             # sweep on the next launch remains the backstop.
             continue
+        if previous_handler is None:
+            continue
+        # Record first so a signal delivered immediately after signal.signal()
+        # still unwinds through main's finally with enough state to restore it.
+        installed_handlers.append((number, previous_handler))
+        try:
+            signal.signal(number, _raise_system_exit)
+        except (OSError, ValueError):
+            installed_handlers.pop()
+
+
+def _restore_signal_handlers(
+    installed_handlers: list[tuple[int, _SignalHandler]],
+) -> None:
+    for number, previous_handler in reversed(installed_handlers):
+        try:
+            signal.signal(number, previous_handler)
+        except (OSError, ValueError):
+            continue
+
+
+def _termination_signal_numbers() -> tuple[int, ...]:
+    return tuple(
+        number
+        for name in ("SIGTERM", "SIGINT", "SIGHUP")
+        if (number := getattr(signal, name, None)) is not None
+    )
+
+
+def _block_termination_signals() -> _SignalMask | None:
+    try:
+        return signal.pthread_sigmask(
+            signal.SIG_BLOCK, _termination_signal_numbers()
+        )
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _restore_signal_mask(previous_mask: _SignalMask | None) -> None:
+    if previous_mask is None:
+        return
+    try:
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+    except (AttributeError, OSError, ValueError):
+        pass
 
 
 if __name__ == "__main__":

--- a/overlay/telemetry/nvapi_marker_bridge.py
+++ b/overlay/telemetry/nvapi_marker_bridge.py
@@ -36,6 +36,7 @@ import json
 import os
 import re
 import select
+import signal
 import socket
 import stat
 import subprocess
@@ -584,6 +585,11 @@ def main(argv: list[str] | None = None) -> int:
         liveness = _shim_deploy.SessionLiveness(args.session_pid, session_fd)
         session_alive_fn = liveness.session_alive
         session_quiesced_fn = liveness.steam_reaper_quiesced
+    # A launcher stopping the game kills this drainer along with the rest of
+    # the session, so termination is the ordinary way it ends, not an
+    # exception. Turning the signal into SystemExit lets the cleanup below run
+    # the same way it does on a normal exit.
+    _exit_on_termination()
     try:
         run(
             args.log,
@@ -598,13 +604,42 @@ def main(argv: list[str] | None = None) -> int:
                 os.close(session_fd)
             except OSError:
                 pass
-    if args.cleanup:
-        try:
-            if stat.S_ISFIFO(args.log.stat().st_mode):
-                args.log.unlink()
-        except OSError:
-            pass
+        # In the finally, not after the try: a drainer that is signalled or
+        # raises would otherwise leave its FIFO behind, one per game session.
+        # The launcher's stale-FIFO sweep is meant to catch crashes, not to be
+        # the routine cleanup path.
+        if args.cleanup:
+            unlink_fifo(args.log)
     return 0
+
+
+def unlink_fifo(path: Path) -> bool:
+    """Remove a per-launch marker FIFO. True when it is gone afterwards."""
+    try:
+        if not stat.S_ISFIFO(path.stat().st_mode):
+            return False
+        path.unlink()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _exit_on_termination() -> None:
+    def _raise_system_exit(signal_number, _frame):
+        raise SystemExit(128 + int(signal_number))
+
+    for name in ("SIGTERM", "SIGINT", "SIGHUP"):
+        number = getattr(signal, name, None)
+        if number is None:
+            continue
+        try:
+            signal.signal(number, _raise_system_exit)
+        except (OSError, ValueError):
+            # Not the main thread, or the platform refuses this signal: the
+            # sweep on the next launch remains the backstop.
+            continue
 
 
 if __name__ == "__main__":

--- a/tests/test_nvapi_marker_bridge.py
+++ b/tests/test_nvapi_marker_bridge.py
@@ -286,6 +286,7 @@ def test_drainer_exits_when_session_dead_and_no_writers(tmp_path, monkeypatch) -
     ever connected (e.g. failed exec); after the no-writer grace, run() returns
     instead of tailing a pipe that can never fill."""
     import os
+
     import overlay.telemetry.nvapi_marker_bridge as bridge
 
     monkeypatch.setattr(bridge, "_NO_WRITER_GRACE_S", 0.05)
@@ -302,6 +303,7 @@ def test_drainer_keeps_draining_while_writer_exists(tmp_path) -> None:
     import os
     import threading
     import time
+
     import overlay.telemetry.nvapi_marker_bridge as bridge
 
     fifo = tmp_path / "nvapi-trace.1.fifo"
@@ -348,6 +350,7 @@ def test_drainer_exits_when_steam_reaper_quiesces_after_traffic(tmp_path) -> Non
     import os
     import threading
     import time
+
     import overlay.telemetry.nvapi_marker_bridge as bridge
 
     fifo = tmp_path / "nvapi-trace.1.fifo"
@@ -383,6 +386,7 @@ def test_drainer_exits_when_steam_reaper_quiesces_after_traffic(tmp_path) -> Non
 def test_drainer_main_cleans_up_fifo(tmp_path, monkeypatch) -> None:
     """--cleanup unlinks the per-launch FIFO once the watch ends."""
     import os
+
     import overlay.telemetry.nvapi_marker_bridge as bridge
 
     monkeypatch.setattr(bridge, "_NO_WRITER_GRACE_S", 0.05)
@@ -400,6 +404,7 @@ def test_drainer_main_cleans_up_fifo(tmp_path, monkeypatch) -> None:
 
 def test_spawn_detached_drainer_argv(monkeypatch, tmp_path) -> None:
     import sys
+
     import overlay.telemetry.nvapi_marker_bridge as bridge
 
     captured = {}
@@ -425,3 +430,70 @@ def test_spawn_detached_drainer_argv(monkeypatch, tmp_path) -> None:
     ]
     assert captured["kwargs"]["start_new_session"] is True
     assert captured["kwargs"]["env"] is env
+
+
+# -- the drainer owns its FIFO -------------------------------------------------
+
+
+def test_the_drainer_unlinks_its_fifo_when_signalled(tmp_path) -> None:
+    """A launcher stopping the game kills the drainer, so termination is the
+    ordinary way it ends. Leaving cleanup outside the finally left one stale
+    FIFO in ~/.cache per game session."""
+    import os
+    import signal
+    import subprocess
+    import sys
+    import time
+    from pathlib import Path as _Path
+
+    fifo = tmp_path / "nvapi-trace.test.fifo"
+    os.mkfifo(fifo, 0o600)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_Path(__file__).resolve().parents[1])
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "overlay.telemetry.nvapi_marker_bridge",
+            "--log",
+            str(fifo),
+            "--cleanup",
+        ],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and process.poll() is None:
+            if not fifo.exists():
+                break
+            time.sleep(0.05)
+            process.send_signal(signal.SIGTERM)
+            break
+        process.wait(timeout=10)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+    assert not fifo.exists()
+
+
+def test_unlink_fifo_leaves_a_regular_file_alone(tmp_path) -> None:
+    """--log may point at a real log file; cleanup must not delete data."""
+    from overlay.telemetry.nvapi_marker_bridge import unlink_fifo
+
+    regular = tmp_path / "not-a-fifo.log"
+    regular.write_text("markers", encoding="utf-8")
+
+    assert unlink_fifo(regular) is False
+    assert regular.exists()
+
+
+def test_unlink_fifo_is_idempotent(tmp_path) -> None:
+    from overlay.telemetry.nvapi_marker_bridge import unlink_fifo
+
+    assert unlink_fifo(tmp_path / "gone.fifo") is True

--- a/tests/test_nvapi_marker_bridge.py
+++ b/tests/test_nvapi_marker_bridge.py
@@ -439,6 +439,7 @@ def test_the_drainer_unlinks_its_fifo_when_signalled(tmp_path) -> None:
     """A launcher stopping the game kills the drainer, so termination is the
     ordinary way it ends. Leaving cleanup outside the finally left one stale
     FIFO in ~/.cache per game session."""
+    import errno
     import os
     import signal
     import subprocess
@@ -465,21 +466,161 @@ def test_the_drainer_unlinks_its_fifo_when_signalled(tmp_path) -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+    writer_fd = None
     try:
         deadline = time.monotonic() + 10.0
         while time.monotonic() < deadline and process.poll() is None:
-            if not fifo.exists():
-                break
-            time.sleep(0.05)
-            process.send_signal(signal.SIGTERM)
+            try:
+                writer_fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+            except OSError as error:
+                if error.errno != errno.ENXIO:
+                    raise
+                time.sleep(0.01)
+                continue
             break
+        assert writer_fd is not None, "drainer never opened the FIFO"
+        process.send_signal(signal.SIGTERM)
         process.wait(timeout=10)
     finally:
+        if writer_fd is not None:
+            os.close(writer_fd)
         if process.poll() is None:
             process.kill()
             process.wait(timeout=5)
 
+    assert process.returncode == 128 + signal.SIGTERM
     assert not fifo.exists()
+
+
+def test_drainer_main_restores_termination_handlers(tmp_path, monkeypatch) -> None:
+    import os
+    import signal
+
+    import pytest
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "nvapi-trace.handlers.fifo"
+    os.mkfifo(fifo, 0o600)
+
+    def fail_run(*_args, **_kwargs) -> None:
+        raise RuntimeError("watch failed")
+
+    monkeypatch.setattr(bridge, "run", fail_run)
+
+    signal_numbers = [
+        number
+        for name in ("SIGTERM", "SIGINT", "SIGHUP")
+        if (number := getattr(signal, name, None)) is not None
+    ]
+    previous_handlers = {
+        number: signal.getsignal(number) for number in signal_numbers
+    }
+
+    def sentinel_handler(_signal_number, _frame) -> None:
+        return None
+
+    try:
+        for number in signal_numbers:
+            signal.signal(number, sentinel_handler)
+
+        with pytest.raises(RuntimeError, match="watch failed"):
+            bridge.main(["--log", str(fifo), "--cleanup"])
+        assert all(
+            signal.getsignal(number) is sentinel_handler
+            for number in signal_numbers
+        )
+    finally:
+        for number, handler in previous_handlers.items():
+            signal.signal(number, handler)
+
+    assert not fifo.exists()
+
+
+def test_drainer_main_without_cleanup_does_not_install_handlers(
+    tmp_path, monkeypatch
+) -> None:
+    import pytest
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    monkeypatch.setattr(bridge, "run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        bridge,
+        "_install_termination_handlers",
+        lambda _installed_handlers: pytest.fail(
+            "non-cleanup invocation changed signal handlers"
+        ),
+    )
+
+    assert bridge.main(["--log", str(tmp_path / "markers.log")]) == 0
+
+
+def test_drainer_main_cleans_up_when_handler_installation_exits(
+    tmp_path, monkeypatch
+) -> None:
+    import os
+
+    import pytest
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "nvapi-trace.install-signal.fifo"
+    os.mkfifo(fifo, 0o600)
+
+    def exit_during_install(_installed_handlers) -> None:
+        raise SystemExit(143)
+
+    monkeypatch.setattr(
+        bridge, "_install_termination_handlers", exit_during_install
+    )
+
+    with pytest.raises(SystemExit, match="143"):
+        bridge.main(["--log", str(fifo), "--cleanup"])
+
+    assert not fifo.exists()
+
+
+def test_drainer_cleanup_defers_a_repeated_termination_signal(
+    tmp_path, monkeypatch
+) -> None:
+    import os
+    import signal
+    from pathlib import Path
+
+    import pytest
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "nvapi-trace.repeated-signal.fifo"
+    os.mkfifo(fifo, 0o600)
+    delivered = []
+    previous_handler = signal.getsignal(signal.SIGTERM)
+    real_rename = os.rename
+
+    def previous_signal_handler(signal_number, _frame) -> None:
+        delivered.append(signal_number)
+
+    def exit_run(*_args, **_kwargs) -> None:
+        raise SystemExit(143)
+
+    def signal_after_capture(source, destination) -> None:
+        real_rename(source, destination)
+        if Path(source) == fifo:
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, previous_signal_handler)
+    monkeypatch.setattr(bridge, "run", exit_run)
+    monkeypatch.setattr(bridge.os, "rename", signal_after_capture)
+    try:
+        with pytest.raises(SystemExit, match="143"):
+            bridge.main(["--log", str(fifo), "--cleanup"])
+    finally:
+        signal.signal(signal.SIGTERM, previous_handler)
+
+    assert delivered == [signal.SIGTERM]
+    assert not fifo.exists()
+    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
 
 
 def test_unlink_fifo_leaves_a_regular_file_alone(tmp_path) -> None:
@@ -489,11 +630,172 @@ def test_unlink_fifo_leaves_a_regular_file_alone(tmp_path) -> None:
     regular = tmp_path / "not-a-fifo.log"
     regular.write_text("markers", encoding="utf-8")
 
-    assert unlink_fifo(regular) is False
+    assert unlink_fifo(regular, expected_identity=None) is False
     assert regular.exists()
+
+
+def test_unlink_fifo_leaves_a_symlink_to_a_fifo_alone(tmp_path) -> None:
+    import os
+
+    from overlay.telemetry.nvapi_marker_bridge import (
+        _fifo_identity,
+        unlink_fifo,
+    )
+
+    target = tmp_path / "target.fifo"
+    link = tmp_path / "marker.fifo"
+    os.mkfifo(target, 0o600)
+    link.symlink_to(target)
+
+    assert _fifo_identity(link) is None
+    assert unlink_fifo(link, expected_identity=None) is False
+    assert link.is_symlink()
+    assert target.exists()
+
+
+def test_unlink_fifo_refuses_a_replacement_fifo(tmp_path) -> None:
+    import os
+
+    from overlay.telemetry.nvapi_marker_bridge import (
+        _fifo_identity,
+        unlink_fifo,
+    )
+
+    fifo = tmp_path / "marker.fifo"
+    replacement = tmp_path / "replacement.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = _fifo_identity(fifo)
+    os.mkfifo(replacement, 0o600)
+    os.replace(replacement, fifo)
+
+    assert expected_identity is not None
+    assert unlink_fifo(fifo, expected_identity=expected_identity) is False
+    assert fifo.exists()
+
+
+def test_unlink_fifo_does_not_capture_without_atomic_restore_support(
+    tmp_path, monkeypatch
+) -> None:
+    import os
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "marker.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = bridge._fifo_identity(fifo)
+    monkeypatch.setattr(
+        bridge, "_quarantine_can_restore_entries", lambda _path: False
+    )
+
+    assert expected_identity is not None
+    assert (
+        bridge.unlink_fifo(fifo, expected_identity=expected_identity)
+        is False
+    )
+    assert bridge._fifo_identity(fifo) == expected_identity
+    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
+
+
+def test_unlink_fifo_restores_a_replacement_directory(tmp_path) -> None:
+    import os
+
+    from overlay.telemetry.nvapi_marker_bridge import (
+        _fifo_identity,
+        unlink_fifo,
+    )
+
+    fifo = tmp_path / "marker.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = _fifo_identity(fifo)
+    fifo.unlink()
+    fifo.mkdir()
+    payload = fifo / "keep.txt"
+    payload.write_text("user data", encoding="utf-8")
+
+    assert expected_identity is not None
+    assert unlink_fifo(fifo, expected_identity=expected_identity) is False
+    assert fifo.is_dir()
+    assert payload.read_text(encoding="utf-8") == "user data"
+    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
+
+
+def test_unlink_fifo_restores_a_replacement_that_wins_before_capture(
+    tmp_path, monkeypatch
+) -> None:
+    import os
+    from pathlib import Path
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "marker.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = bridge._fifo_identity(fifo)
+    real_rename = os.rename
+
+    def replace_then_rename(source, destination) -> None:
+        source_path = Path(source)
+        if source_path == fifo:
+            source_path.unlink()
+            source_path.write_text("replacement", encoding="utf-8")
+        real_rename(source, destination)
+
+    monkeypatch.setattr(bridge.os, "rename", replace_then_rename)
+
+    assert expected_identity is not None
+    assert (
+        bridge.unlink_fifo(fifo, expected_identity=expected_identity)
+        is False
+    )
+    assert fifo.read_text(encoding="utf-8") == "replacement"
+    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
+
+
+def test_unlink_fifo_preserves_a_replacement_created_after_capture(
+    tmp_path, monkeypatch
+) -> None:
+    import os
+    from pathlib import Path
+
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    fifo = tmp_path / "marker.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = bridge._fifo_identity(fifo)
+    real_rename = os.rename
+
+    def rename_then_replace(source, destination) -> None:
+        real_rename(source, destination)
+        if Path(source) == fifo:
+            fifo.write_text("replacement", encoding="utf-8")
+
+    monkeypatch.setattr(bridge.os, "rename", rename_then_replace)
+
+    assert expected_identity is not None
+    assert bridge.unlink_fifo(fifo, expected_identity=expected_identity) is True
+    assert fifo.read_text(encoding="utf-8") == "replacement"
+    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
+
+
+def test_unlink_fifo_removes_the_matching_fifo(tmp_path) -> None:
+    import os
+
+    from overlay.telemetry.nvapi_marker_bridge import (
+        _fifo_identity,
+        unlink_fifo,
+    )
+
+    fifo = tmp_path / "marker.fifo"
+    os.mkfifo(fifo, 0o600)
+    expected_identity = _fifo_identity(fifo)
+
+    assert expected_identity is not None
+    assert unlink_fifo(fifo, expected_identity=expected_identity) is True
+    assert not fifo.exists()
 
 
 def test_unlink_fifo_is_idempotent(tmp_path) -> None:
     from overlay.telemetry.nvapi_marker_bridge import unlink_fifo
 
-    assert unlink_fifo(tmp_path / "gone.fifo") is True
+    assert unlink_fifo(
+        tmp_path / "gone.fifo", expected_identity=(123, 456)
+    ) is True


### PR DESCRIPTION
Every wrapped game session leaves one stale FIFO in ~/.cache/penguin-burner. Found by watching a real launch: after the game exited, no drainer process remained, but nvapi-trace.<pid>.fifo did.

The drainer is spawned with --cleanup and does unlink the FIFO -- but the unlink sat after the try block, not in its finally. A launcher stopping a game kills the drainer along with the rest of the session, so termination is the ordinary way it ends, not an exception, and that path skipped the cleanup entirely. The comment in launcher.py already promised "the drainer unlinks its own FIFO on exit"; now it does.

SIGTERM/SIGINT/SIGHUP become SystemExit so the finally runs, and the unlink moves into it. A drainer that cannot install handlers, or that is SIGKILLed, still leaves the launcher's stale-FIFO sweep as the backstop -- which is what that sweep is for, rather than being the routine cleanup path it had become.

unlink_fifo refuses to delete anything that is not a FIFO: --log may point at a real log file, and cleanup must not eat data.

Checks: 1858 Python tests. The new signal test was confirmed to fail against the unfixed code and pass against the fix.