### PR TITLE
Declare the test dependencies the suite already needs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,12 @@ scripts/build-daemon.sh   # cargo build --release --locked in burnerd/
 
 ## Tests
 
+The suite needs the test extra; the GUI tests build real windows, so they also
+need a display or `QT_QPA_PLATFORM=offscreen`:
+
 ```bash
-python -m pytest tests/
+python -m pip install --user -e '.[test]'
+QT_QPA_PLATFORM=offscreen python -m pytest tests/
 ```
 
 For changes under `burnerd/`, also run the Rust gates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,14 @@ ui = [
   "colorama>=0.4",
   "pyqtgraph>=0.13",
 ]
+test = [
+  # What `python -m pytest tests/` needs beyond the runtime dependencies.
+  # pytest-qt supplies the qapp/qtbot fixtures the GUI tests build windows on;
+  # without it those tests do not fail, they error at setup with
+  # "fixture 'qapp' not found", which reads like a broken checkout.
+  "pytest>=8",
+  "pytest-qt>=4.4",
+]
 
 [project.urls]
 Homepage = "https://github.com/jpietek/PenguinBurner"


### PR DESCRIPTION
## What changed

Adds a `test` extra to `pyproject.toml` declaring `pytest>=8` and
`pytest-qt>=4.4`, and points the CONTRIBUTING "Tests" section at it.

## Why

`python -m pytest tests/` cannot run on a fresh checkout. Nothing in the repo
says the suite needs pytest at all, and 11 test modules build real `MainWindow`
instances on pytest-qt's `qapp` fixture (3 more use `qtbot`).

The failure mode is what makes this worth fixing rather than documenting in a
comment: without pytest-qt those tests do not *fail*, they **error at setup**
with `fixture 'qapp' not found` — 180 of them at once. That reads like a broken
checkout or a bad merge, not a missing package, and the fix is not discoverable
from the message.

CONTRIBUTING's command also gains `QT_QPA_PLATFORM=offscreen`. The GUI tests
construct real windows, so without it they need a display and pop windows onto
the contributor's desktop mid-run.

## Impact

Developer-facing only. No runtime dependency changes, no packaging output
changes — `pip install penguin-burner` installs exactly what it did before,
since the extra is opt-in via `.[test]`.

## Checks

- Full suite with the extra installed: **1858 passed**
  (`QT_QPA_PLATFORM=offscreen python -m pytest tests/ -q`).
- `pyproject.toml` re-parsed with `tomllib` to confirm the extra resolves.
- No static-analysis run: the change is metadata and docs only, with no code
  touched.
- No hardware or live-game validation: nothing in this change reaches the
  daemon, the GPU, or the overlay.
