### PR TITLE
Run the deferred-signal drainer test in its own interpreter

### DIFF
--- a/tests/test_nvapi_marker_bridge.py
+++ b/tests/test_nvapi_marker_bridge.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
 from overlay.telemetry.nvapi_marker_bridge import (
     NV_MARKER_INPUT_SAMPLE,
     NV_MARKER_OUT_OF_BAND_PRESENT_END,
@@ -581,46 +586,85 @@ def test_drainer_main_cleans_up_when_handler_installation_exits(
     assert not fifo.exists()
 
 
-def test_drainer_cleanup_defers_a_repeated_termination_signal(
-    tmp_path, monkeypatch
-) -> None:
-    import os
-    import signal
-    from pathlib import Path
+# The scenario below asserts on process-global signal delivery: a SIGTERM
+# raised at the test process has to reach the handler that was installed before
+# cleanup started. That is not a property a single interpreter can hold on
+# behalf of a whole suite -- anything else already loaded may have touched
+# termination handling at the C level, where Python's `signal` module cannot
+# see it and pytest cannot undo it. A live QApplication is enough to reproduce
+# it, and Qt is loaded by every GUI test in this suite.
+#
+# So the scenario runs in a fresh interpreter. The child does exactly what the
+# in-process version did and prints its findings; the parent asserts on those.
+_DEFERRED_SIGNAL_CHILD = """
+import os, signal, sys
+from pathlib import Path
 
-    import pytest
+import overlay.telemetry.nvapi_marker_bridge as bridge
 
-    import overlay.telemetry.nvapi_marker_bridge as bridge
+fifo = Path(sys.argv[1])
+os.mkfifo(fifo, 0o600)
+delivered = []
+real_rename = os.rename
 
-    fifo = tmp_path / "nvapi-trace.repeated-signal.fifo"
-    os.mkfifo(fifo, 0o600)
-    delivered = []
-    previous_handler = signal.getsignal(signal.SIGTERM)
-    real_rename = os.rename
 
-    def previous_signal_handler(signal_number, _frame) -> None:
-        delivered.append(signal_number)
+def previous_signal_handler(signal_number, _frame):
+    delivered.append(signal_number)
 
-    def exit_run(*_args, **_kwargs) -> None:
-        raise SystemExit(143)
 
-    def signal_after_capture(source, destination) -> None:
-        real_rename(source, destination)
-        if Path(source) == fifo:
-            os.kill(os.getpid(), signal.SIGTERM)
+def exit_run(*_args, **_kwargs):
+    raise SystemExit(143)
 
-    signal.signal(signal.SIGTERM, previous_signal_handler)
-    monkeypatch.setattr(bridge, "run", exit_run)
-    monkeypatch.setattr(bridge.os, "rename", signal_after_capture)
-    try:
-        with pytest.raises(SystemExit, match="143"):
-            bridge.main(["--log", str(fifo), "--cleanup"])
-    finally:
-        signal.signal(signal.SIGTERM, previous_handler)
 
-    assert delivered == [signal.SIGTERM]
-    assert not fifo.exists()
-    assert not list(tmp_path.glob(".penguin-burner-fifo-cleanup-*"))
+def signal_after_capture(source, destination):
+    real_rename(source, destination)
+    if Path(source) == fifo:
+        os.kill(os.getpid(), signal.SIGTERM)
+
+
+signal.signal(signal.SIGTERM, previous_signal_handler)
+bridge.run = exit_run
+bridge.os.rename = signal_after_capture
+
+exit_code = None
+try:
+    bridge.main(["--log", str(fifo), "--cleanup"])
+except SystemExit as exc:
+    exit_code = exc.code
+finally:
+    bridge.os.rename = real_rename
+
+leftovers = sorted(p.name for p in fifo.parent.glob(".penguin-burner-fifo-cleanup-*"))
+print(f"exit={exit_code}")
+print(f"delivered={delivered}")
+print(f"fifo_exists={fifo.exists()}")
+print(f"leftovers={leftovers}")
+"""
+
+
+def test_drainer_cleanup_defers_a_repeated_termination_signal(tmp_path) -> None:
+    """A signal arriving mid-cleanup waits for it, then reaches the old handler."""
+    completed = subprocess.run(
+        [sys.executable, "-c", _DEFERRED_SIGNAL_CHILD, str(tmp_path / "trace.fifo")],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        # The child's own exit code is part of what this asserts, so a raising
+        # run() would hide the interesting failure behind a CalledProcessError.
+        check=False,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    report = dict(
+        line.split("=", 1) for line in completed.stdout.splitlines() if "=" in line
+    )
+    # The drainer's own exit survives: deferring a signal must not swallow it.
+    assert report["exit"] == "143"
+    # Deferred, not dropped, and handed to the handler that was there before.
+    assert report["delivered"] == f"[{int(signal.SIGTERM)}]"
+    assert report["fifo_exists"] == "False"
+    assert report["leftovers"] == "[]"
 
 
 def test_unlink_fifo_leaves_a_regular_file_alone(tmp_path) -> None:


### PR DESCRIPTION
## The problem

`test_drainer_cleanup_defers_a_repeated_termination_signal` (added in "Harden
drainer FIFO cleanup") passes on its own and fails when a GUI test has run
first in the same interpreter:

```bash
pytest tests/test_steam_panel.py \
  tests/test_nvapi_marker_bridge.py::test_drainer_cleanup_defers_a_repeated_termination_signal
# 1 failed, 19 passed
```

That reproduces on current `main` with nothing else applied. The full suite is
green today only because collection order happens to be kind — I hit it while
adding GUI tests on a branch, where the same test then failed every run.

## Why it is not a product bug

The scenario asserts on **process-global signal delivery**: a `SIGTERM` raised
at the test process has to reach the handler installed before cleanup began.
That is not a property one interpreter can hold on behalf of a whole suite.

A live `QApplication` is enough to reproduce it, and Python's own view of the
process stays identical either way — `signal.getsignal` reports the same
handlers for SIGTERM/SIGINT/SIGHUP, `pthread_sigmask` reports nothing blocked,
and no extra threads are alive. That points at termination handling being
touched below the `signal` module, where neither Python's bookkeeping nor
`monkeypatch` can put it back.

The drainer itself is fine: it runs as a standalone wrapper process with no Qt
anywhere near it. Only the test is exposed, because pytest puts everything in
one process.

## The change

The scenario moves into a fresh interpreter. The child does exactly what the
in-process version did and prints its findings; the parent asserts on those.

Coverage is unchanged — the drainer's own exit code still survives the
deferral, the deferred signal still reaches the previous handler, the FIFO is
still removed, and no quarantine directory is left behind.

## Checks

- The reproduction above now passes.
- **Verified by mutation, not just by going green**: with the cleanup-time
  signal block disabled the isolated test fails; restoring it makes it pass. A
  regression test that survives the bug it was written for would be worthless.
- Full suite: 1879 passed.
- `ruff` reports 20 diagnostics on this file against 24 before; `pyright` 3
  against 21, since the in-process version needed function-local imports that
  no longer exist.

## Note

I could not pin down the exact Qt mechanism, only that a `QApplication` in the
process reproduces it. Isolation is the right fix regardless: an assertion
about process-global signal delivery cannot be made robust from inside a shared
interpreter, whatever the specific neighbour turns out to be.
