### PR TITLE
Preserve game logs through the marker drainer

### DIFF
--- a/docs/nvapi-shim.md
+++ b/docs/nvapi-shim.md
@@ -16,6 +16,25 @@ the Vulkan layer cannot see the markers. Deployed by **fronting the prefix's
 `system32\nvapi64.dll`** (generic, no per-game logic). Markers reach the existing
 marker FIFO the bridge drains, so nothing downstream changed.
 
+## The game's own log still reaches the launcher
+
+To catch markers that arrive through wine's debug output, the wrapper redirects
+the game's stderr (fd 2) into the marker FIFO. That would otherwise hide the
+whole Proton/wine log from whatever started the game — Lutris, Steam, or a
+terminal — for as long as `PENGUIN_BURNER` is in the launch command.
+
+The drainer is spawned *before* that redirect, so its own stderr is still the
+launcher's. It forwards every line it drains that is **not** a PenguinBurner
+marker, which puts the game's diagnostics back where they belong. Marker lines
+are dropped rather than echoed: they exist only because we asked dxvk-nvapi to
+emit them, so passing them on would add noise the user never had.
+
+Forwarding is best effort and latches off once the launcher's pipe is gone.
+Draining continues regardless — it is what keeps a full pipe from freezing the
+game. Lines arrive via the drainer rather than directly, so expect them at the
+drainer's poll granularity; content and order are preserved. stdout is never
+redirected and always passes straight through.
+
 ## Why it exists — the vkd3d owner-gate
 
 The Vulkan layer (`overlay/native/latency_layer/`) taps `vkSetLatencyMarkerNV`,

--- a/overlay/telemetry/nvapi_marker_bridge.py
+++ b/overlay/telemetry/nvapi_marker_bridge.py
@@ -79,6 +79,43 @@ _MARKER_NAMES = {
 }
 
 
+class _GameOutputPassthrough:
+    """Hand the game's own stderr back to whoever launched it.
+
+    The wrapper redirects the game's fd 2 into the marker FIFO, so every
+    Proton/wine diagnostic ends up here instead of in the launcher's log --
+    Lutris, Steam, or a terminal all go silent for the whole session. The
+    drainer is deliberately spawned *before* that redirect, so its own stderr
+    is still the launcher's; writing there restores what the redirect took.
+
+    Only lines that are not PenguinBurner markers are forwarded. Marker lines
+    exist solely because we asked dxvk-nvapi to emit them, so echoing them
+    would add noise the user never had.
+
+    Forwarding is best effort: once the launcher's pipe is gone, further
+    writes are pointless, so it latches off. Draining must continue either way
+    -- it is what keeps a full pipe from freezing the game.
+    """
+
+    def __init__(self, stream=None) -> None:
+        self._stream = stream
+        self._failed = False
+
+    def forward(self, line: str) -> None:
+        if self._failed:
+            return
+        stream = sys.stderr if self._stream is None else self._stream
+        try:
+            stream.write(line if line.endswith("\n") else line + "\n")
+            stream.flush()
+        except (OSError, ValueError):
+            self._failed = True
+
+    @property
+    def failed(self) -> bool:
+        return self._failed
+
+
 def _parse_line_with_pid(line: str):
     """Return (frame, nv_marker, t_us, source_pid) for a marker line."""
     m = _MARKER_LOG_RE.search(line)
@@ -252,6 +289,10 @@ def _follow_fifo(
         return session_quiesced_fn is not None and session_quiesced_fn()
 
     had_traffic = False
+    # A writer connected and then every writer closed. From that point a quiet
+    # select means "nobody is left to write", not "the writer is idle" -- so
+    # once the session is gone too there is nothing left to wait for.
+    writers_closed = False
     session_over_since: float | None = None
     while not _stop_requested(stop_event):
         try:
@@ -270,10 +311,20 @@ def _follow_fifo(
                 if not readable:
                     if _session_quiesced():
                         return
-                    if had_traffic:
-                        continue
                     if not _session_over():
                         session_over_since = None
+                        continue
+                    if writers_closed:
+                        # Every writer has closed and the launching session is
+                        # gone, so no byte can ever arrive. Exiting promptly
+                        # matters beyond tidiness: this process holds the
+                        # launcher's output pipe, and Lutris waits on that pipe
+                        # for EOF to decide the game has finished. Lingering
+                        # here left the game "running" until stopped by hand.
+                        return
+                    if had_traffic:
+                        # Writers exist and are merely idle -- a wrapped game
+                        # can outlive the session that launched it.
                         continue
                     now = time.monotonic()
                     if session_over_since is None:
@@ -288,7 +339,9 @@ def _follow_fifo(
                 had_traffic = True
                 if not chunk:
                     # Writer closed (game exited): reopen and wait for the next run.
+                    writers_closed = True
                     break
+                writers_closed = False
                 pending += chunk.decode("utf-8", errors="replace")
                 while "\n" in pending:
                     line, pending = pending.split("\n", 1)
@@ -375,8 +428,12 @@ def run(
     stop_event: threading.Event | None = None,
     session_alive_fn=None,
     session_quiesced_fn=None,
+    passthrough: _GameOutputPassthrough | None = None,
 ) -> None:
     env = dict(os.environ) if env is None else env
+    # The wrapper redirected the game's stderr into this FIFO, so the launcher
+    # sees nothing unless the non-marker lines are handed back.
+    passthrough = _GameOutputPassthrough() if passthrough is None else passthrough
     targets = _socket_targets(env)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     # Never block on a slow/full receiver: unix datagram sendto() BLOCKS when
@@ -411,6 +468,9 @@ def run(
         ):
             parsed = _parse_line_with_pid(line)
             if parsed is None:
+                # Not one of ours: it is the game's own diagnostic output,
+                # which belongs in the launcher's log.
+                passthrough.forward(line)
                 continue
             frame, marker, t_us, source_pid = parsed
             sample_pid = source_pid if source_pid is not None else pid

--- a/tests/test_nvapi_marker_bridge.py
+++ b/tests/test_nvapi_marker_bridge.py
@@ -843,3 +843,240 @@ def test_unlink_fifo_is_idempotent(tmp_path) -> None:
     assert unlink_fifo(
         tmp_path / "gone.fifo", expected_identity=(123, 456)
     ) is True
+
+
+class _FakeStream:
+    """Stands in for the launcher's stderr."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.written: list[str] = []
+        self.flushes = 0
+        self._fail = fail
+
+    def write(self, text: str) -> int:
+        if self._fail:
+            raise OSError("launcher pipe is gone")
+        self.written.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+
+def _run_bridge_over(monkeypatch, tmp_path, lines, passthrough):
+    import overlay.telemetry.nvapi_marker_bridge as bridge
+
+    samples: list[dict] = []
+    monkeypatch.setattr(
+        bridge,
+        "_follow",
+        lambda _path, poll_interval_s, from_start, stop_event=None,
+        session_alive_fn=None, session_quiesced_fn=None: iter(lines),
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_send_sample",
+        lambda _sock, _targets, sample: samples.append(sample),
+    )
+    run(tmp_path / "trace.fifo", env={}, pid=999, passthrough=passthrough)
+    return samples
+
+
+_SIM_LINE = (
+    "123.456:0000002a:2def:latency-marker:nvapi64:"
+    "qpcUs=1000000 api=d3d frameID=7 markerType=SIMULATION_START markerValue=0"
+)
+_PRESENT_LINE = (
+    "123.466:0000002a:2def:latency-marker:nvapi64:"
+    "qpcUs=1010000 api=d3d frameID=7 markerType=PRESENT_END markerValue=5"
+)
+
+
+def test_bridge_does_not_echo_its_own_marker_lines(monkeypatch, tmp_path) -> None:
+    """Markers exist only because we asked for them; echoing them adds noise."""
+    from overlay.telemetry.nvapi_marker_bridge import _GameOutputPassthrough
+
+    stream = _FakeStream()
+    _run_bridge_over(
+        monkeypatch, tmp_path, [_SIM_LINE, _PRESENT_LINE], _GameOutputPassthrough(stream)
+    )
+
+    assert stream.written == []
+
+
+def test_bridge_gives_game_output_back_to_the_launcher(monkeypatch, tmp_path) -> None:
+    """The wrapper steals the game's stderr; the drainer must hand it back.
+
+    Without this the whole Proton/wine log vanishes from Lutris, Steam, or a
+    terminal for as long as the wrapper is in the launch command.
+    """
+    from overlay.telemetry.nvapi_marker_bridge import _GameOutputPassthrough
+
+    stream = _FakeStream()
+    lines = [
+        "wine: ordinal not found\n",
+        _SIM_LINE,
+        "err:module:import_dll Library missing\n",
+        _PRESENT_LINE,
+    ]
+
+    samples = _run_bridge_over(
+        monkeypatch, tmp_path, lines, _GameOutputPassthrough(stream)
+    )
+
+    assert stream.written == [
+        "wine: ordinal not found\n",
+        "err:module:import_dll Library missing\n",
+    ]
+    # Still bridged the markers it was there to bridge.
+    assert len(samples) == 1
+
+
+def test_passthrough_keeps_lines_line_terminated() -> None:
+    from overlay.telemetry.nvapi_marker_bridge import _GameOutputPassthrough
+
+    stream = _FakeStream()
+    passthrough = _GameOutputPassthrough(stream)
+
+    passthrough.forward("has newline\n")
+    passthrough.forward("no newline")
+
+    assert stream.written == ["has newline\n", "no newline\n"]
+    assert stream.flushes == 2
+
+
+def test_passthrough_latches_off_when_the_launcher_pipe_dies() -> None:
+    from overlay.telemetry.nvapi_marker_bridge import _GameOutputPassthrough
+
+    stream = _FakeStream(fail=True)
+    passthrough = _GameOutputPassthrough(stream)
+
+    passthrough.forward("anything\n")
+    assert passthrough.failed is True
+
+    # A dead launcher must not keep costing a failed write per drained line;
+    # draining itself has to continue, or a full pipe freezes the game.
+    stream._fail = False
+    passthrough.forward("later\n")
+    assert stream.written == []
+
+
+def _drain_fifo(fifo, *, session_alive, timeout_s=5.0):
+    """Run _follow_fifo in a thread and report whether it returned."""
+    import threading
+
+    from overlay.telemetry.nvapi_marker_bridge import _follow_fifo
+
+    lines: list[str] = []
+    finished = threading.Event()
+
+    def run():
+        # Consumed one at a time on purpose: the tests assert on what has
+        # arrived while the generator is still running, so it must not be
+        # drained in one go.
+        lines.extend(
+            _follow_fifo(fifo, poll_interval_s=0.02, session_alive_fn=session_alive)
+        )
+        finished.set()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return lines, finished, thread
+
+
+def test_drainer_exits_once_writers_closed_and_the_session_is_gone(tmp_path) -> None:
+    """It holds the launcher's output pipe, which Lutris waits on for EOF.
+
+    Reopening after the game's EOF used to leave it spinning forever: with
+    traffic already seen, the quiet path never re-checked whether the session
+    had ended, so the launcher showed the game as still running until stopped
+    by hand.
+    """
+    import os
+    import time
+
+    fifo = tmp_path / "trace.fifo"
+    os.mkfifo(fifo, 0o600)
+    alive = {"value": True}
+
+    lines, finished, thread = _drain_fifo(fifo, session_alive=lambda: alive["value"])
+
+    # A writer connects, emits, then closes -- the game running and exiting.
+    writer = os.open(fifo, os.O_WRONLY)
+    os.write(writer, b"err:module:import_dll something\n")
+    time.sleep(0.2)
+    os.close(writer)
+    # The session is still alive for a moment after the writer goes, which is
+    # what pushed the drainer into the reopen path.
+    time.sleep(0.2)
+    alive["value"] = False
+
+    assert finished.wait(timeout=5.0), "the drainer must exit once nothing can write"
+    thread.join(timeout=1.0)
+    assert lines == ["err:module:import_dll something\n"]
+
+
+def test_drainer_keeps_draining_while_a_writer_is_merely_idle(tmp_path) -> None:
+    """A wrapped game can outlive the session that launched it."""
+    import os
+    import time
+
+    fifo = tmp_path / "trace.fifo"
+    os.mkfifo(fifo, 0o600)
+
+    lines, finished, thread = _drain_fifo(fifo, session_alive=lambda: False)
+
+    writer = os.open(fifo, os.O_WRONLY)
+    try:
+        os.write(writer, b"first\n")
+        time.sleep(0.4)
+        # Session already reported gone, writer still open and quiet: the
+        # drainer must stay for the game that is still holding the pipe.
+        assert not finished.is_set()
+        os.write(writer, b"second\n")
+        time.sleep(0.2)
+        assert lines == ["first\n", "second\n"]
+    finally:
+        os.close(writer)
+
+    assert finished.wait(timeout=5.0)
+    thread.join(timeout=1.0)
+
+
+def test_drainer_keeps_a_reconnected_writer_after_the_session_ends(tmp_path) -> None:
+    """An earlier EOF must not make a later live writer look closed."""
+    import os
+    import time
+
+    fifo = tmp_path / "trace.fifo"
+    os.mkfifo(fifo, 0o600)
+    alive = {"value": True}
+    lines, finished, thread = _drain_fifo(
+        fifo, session_alive=lambda: alive["value"]
+    )
+
+    first = os.open(fifo, os.O_WRONLY)
+    os.write(first, b"first\n")
+    os.close(first)
+    deadline = time.monotonic() + 2.0
+    while lines != ["first\n"] and time.monotonic() < deadline:
+        time.sleep(0.01)
+    # Give the reader time to observe EOF and reopen before the next writer.
+    time.sleep(0.1)
+
+    second = os.open(fifo, os.O_WRONLY)
+    try:
+        os.write(second, b"second\n")
+        deadline = time.monotonic() + 2.0
+        while lines != ["first\n", "second\n"] and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert lines == ["first\n", "second\n"]
+
+        alive["value"] = False
+        time.sleep(0.1)
+        assert not finished.is_set(), "the reconnected writer is still open"
+    finally:
+        os.close(second)
+
+    assert finished.wait(timeout=5.0)
+    thread.join(timeout=1.0)


### PR DESCRIPTION
Completes the runtime/log-forwarding portion of #54 after the core lifecycle repair in #58.

- forward non-marker game stderr lines back to the launcher
- keep marker lines out of normal launcher logs
- stop retrying output after the launcher pipe closes while continuing to drain
- exit after all writers close and the launch session ends
- clear stale writer-closed state when a later writer reconnects

Checks:
- python -m pytest -q tests/test_nvapi_marker_bridge.py (36 passed)
- python -m pytest tests/ -q (1849 passed, 57 skipped)
- scripts/check-feature-static-analysis.sh
- git diff --check

No live game/Lutris session was run for this repair.