### PR TITLE
Document how to keep latency markers with the overlay off

### DIFF
--- a/docs/features/latency-fg.md
+++ b/docs/features/latency-fg.md
@@ -37,6 +37,21 @@ deployed into the Wine or Proton prefix automatically and streams Reflex markers
 to the wrapper's FIFO; native and prefix-less games fall back to the Vulkan
 layer's own marker tap. Opt out with `PB_INGAME_LATENCY=0`.
 
+#### Markers without the overlay
+
+Latency defaults to the overlay's state, so `--pb-overlay=0` turns the marker
+capture off with it. That is the right default for someone who only wanted the
+HUD gone, but it also takes away the pacing signal adaptive tier switching reads.
+To keep the markers while leaving the HUD off, ask for latency explicitly:
+
+```text
+env PB_INGAME_LATENCY=1 PENGUIN_BURNER --pb-overlay=0
+```
+
+The leading `env` is required. Lutris execs the command prefix directly rather
+than through a shell, so a bare `PB_INGAME_LATENCY=1` would be treated as the
+program to run instead of an assignment.
+
 ## What PenguinBurner Can Force
 
 PenguinBurner can load its Vulkan layer, expose the Proton/NVAPI environment,

--- a/docs/nvapi-shim.md
+++ b/docs/nvapi-shim.md
@@ -128,7 +128,11 @@ adaptive gets no pacing at all and holds whatever tier it started on.
 
 For Lutris, set **Game → Configure → System options → Command prefix** to
 `PENGUIN_BURNER --pb-overlay=1`. The launcher supplies `WINEPREFIX`, so no Steam
-game identity or library discovery is required.
+game identity or library discovery is required. To deploy the shim without the
+HUD, ask for latency explicitly — `env PB_INGAME_LATENCY=1 PENGUIN_BURNER
+--pb-overlay=0` — because latency (and with it the shim) otherwise follows the
+overlay's state; Lutris execs the prefix without a shell, so the assignment
+needs the leading `env`.
 
 **Proton clobbers the shim every launch**: prefix setup unconditionally
 `try_copy`s the bundled dxvk-nvapi over `system32\nvapi64.dll` (`os.remove` +
@@ -292,7 +296,8 @@ process), and the shim's ring would drop rather than stall even if it died.
 ## Env vars
 
 - `PENGUIN_BURNER_INGAME_LATENCY` (alias `PB_INGAME_LATENCY`) — `0` opts out;
-  unset defaults to the overlay-enabled state.
+  `1` opts in even with the overlay off; unset defaults to the overlay-enabled
+  state.
 - `PENGUIN_BURNER_NVAPI_LATENCY_DISABLE=1` — skip NVAPI latency capture
   (layer-only). Stops re-deploying the shim; does not un-front an
   already-installed shim.

--- a/tests/test_pb_overlay_launcher.py
+++ b/tests/test_pb_overlay_launcher.py
@@ -147,6 +147,18 @@ def test_overlay_disabled_defaults_ingame_latency_off() -> None:
     assert "PENGUIN_BURNER_LATENCY_DISPLAY" not in env
 
 
+def test_explicit_ingame_latency_survives_the_overlay_being_off() -> None:
+    # The documented way to keep markers (and so the shim, and so adaptive's
+    # pacing signal) while running without the HUD: ask for latency by name.
+    env = {
+        OVERLAY_CONFIG_ENV: "/tmp/does-not-exist-pb-overlay.toml",
+        "PB_OVERLAY": "0",
+        "PB_INGAME_LATENCY": "1",
+    }
+    launcher.configure_penguin_burner_environment(env)
+    assert launcher.ingame_latency_enabled(env)
+
+
 def test_configure_environment_passes_user_dxvk_nvapi_log_env_through() -> None:
     # The old trace escape is gone: a user-set DXVK_NVAPI_LOG_LEVEL no longer
     # disables the shim; the launcher just leaves the user's env untouched.

--- a/tests/test_user_docs.py
+++ b/tests/test_user_docs.py
@@ -13,3 +13,13 @@ def test_latency_guide_documents_lutris_command_prefix() -> None:
     assert "Command prefix" in guide
     assert "PENGUIN_BURNER --pb-overlay=1" in guide
     assert "WINEPREFIX" in guide
+
+
+def test_latency_guide_documents_markers_without_the_overlay() -> None:
+    """Turning the HUD off silently drops markers; the way back must be written
+    down, including the `env` prefix Lutris needs to parse the assignment."""
+    guide = (REPO / "docs" / "features" / "latency-fg.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "env PB_INGAME_LATENCY=1 PENGUIN_BURNER --pb-overlay=0" in guide


### PR DESCRIPTION
## What changed

Documentation (plus two tests that pin it) for a behaviour that currently has no
user-facing explanation: **in-game latency follows the overlay's state**, so
`--pb-overlay=0` turns off the NVAPI marker capture along with the HUD.

- `docs/features/latency-fg.md` — new "Markers without the overlay" subsection
  under the Lutris launch path.
- `docs/nvapi-shim.md` — same note next to the existing Lutris command-prefix
  guidance, and the `PENGUIN_BURNER_INGAME_LATENCY` env-var entry now states
  that `1` opts in even with the overlay off (it only documented `0` and the
  default).

The documented invocation is:

```text
env PB_INGAME_LATENCY=1 PENGUIN_BURNER --pb-overlay=0
```

## Why

`ingame_latency_enabled()` falls back to `_overlay_enabled(env)` when neither
`PENGUIN_BURNER_INGAME_LATENCY` nor `PB_INGAME_LATENCY` is set. That default is
right — turning the overlay on should just give you latency too — but the
inverse is easy to hit by accident: someone who only wanted the HUD gone also
loses the marker stream, and with it the pacing signal adaptive tier switching
reads. The docs described the `0` opt-out but never the `1` opt-in.

The leading `env` matters and is called out explicitly. Lutris execs the command
prefix as argv rather than through a shell, so a bare `PB_INGAME_LATENCY=1`
would be treated as the program to run.

## Impact

Docs only — no behaviour change. Users running without the HUD get a documented
way to keep in-game latency and adaptive's pacing input.

## Checks

- `pytest tests/` — 1908 passed.
- Behaviour verified against the code before writing it down: with the launcher's
  own env ordering, no flags -> latency on; `--pb-overlay=1` -> on;
  `--pb-overlay=0` -> off; `--pb-overlay=0` + `PB_INGAME_LATENCY=1` -> on.
- Ruff on the two touched test files reports 3 findings, all pre-existing on
  `main` (import sorting) and untouched here.
- No live-game validation was run for this change; it is documentation of
  existing behaviour, exercised through the launcher's env configuration.

## Tests added

- `test_explicit_ingame_latency_survives_the_overlay_being_off` — pins the
  opt-in path through `configure_penguin_burner_environment`.
- `test_latency_guide_documents_markers_without_the_overlay` — keeps the
  documented invocation from drifting, alongside the existing command-prefix
  doc test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
