### PR TITLE
Show the boot checkbox from the daemon, not a preference nothing rewrites

### DIFF
--- a/tests/test_ui_window_profile_methods.py
+++ b/tests/test_ui_window_profile_methods.py
@@ -41,6 +41,15 @@ def win(qapp, monkeypatch):
     monkeypatch.setattr(
         window_mod, "systemd_autostart_profile_info", lambda: {"selector": "", "silent_fan_curve": False}
     )
+    # The mixin holds its own binding, and building the window syncs the boot
+    # checkbox through it. Left unpatched it reached the developer's real
+    # daemon socket, so the checkbox started ticked or not depending on what
+    # that machine happened to have saved for boot.
+    monkeypatch.setattr(
+        actions_mod,
+        "systemd_autostart_profile_info",
+        lambda **_kwargs: {"selector": "", "silent_fan_curve": False},
+    )
     monkeypatch.setattr(
         window_mod, "running_auto_uv_profile_info",
         lambda: {"selector": "", "silent_fan_curve": False, "adaptive_auto_uv": False},
@@ -443,6 +452,105 @@ def test_boot_apply_checkbox_tracks_selected_gpu(win, monkeypatch) -> None:
     window.profile_list.target_gpu_combo.setCurrentIndex(1)
     assert window.profile_list.persist_on_startup_enabled() is True
     assert "GPU-A" in calls and "GPU-B" in calls
+
+
+def test_boot_apply_follows_the_daemon_not_the_saved_preference(
+    win, monkeypatch
+) -> None:
+    """The observed defect: config said on, the daemon had nothing saved.
+
+    `persist_on_startup` is written when the box is ticked but nothing rewrites
+    it when the entry goes away, so a boot with nothing to apply was still
+    shown as "applies at startup".
+    """
+    import cli.runtime_config_file as config_mod
+
+    window, _mp = win
+    # Patched at the source so any import style sees it: the saved preference
+    # claims boot is armed.
+    monkeypatch.setattr(
+        config_mod,
+        "persist_on_startup_from_runtime_config",
+        lambda *_a, **_kw: True,
+    )
+    monkeypatch.setattr(
+        actions_mod,
+        "systemd_autostart_profile_info",
+        lambda **_kwargs: {"selector": "", "main_gpu": False},
+    )
+    window._boot_apply_by_gpu = {}
+    window.profile_list.set_boot_apply_checked(True)
+
+    window._sync_boot_apply_for_target("")
+
+    assert window.profile_list.persist_on_startup_enabled() is False
+
+
+def test_a_boot_entry_that_disappears_unticks_the_box(win, monkeypatch) -> None:
+    """A cached tick must not outlive the entry it described.
+
+    Every apply sends --boot or --clear-boot from this state, so a box stuck ON
+    over a daemon that has nothing is a startup promise nothing will keep.
+    """
+    window, _mp = win
+    saved = {"selector": "profile-a", "main_gpu": False}
+    monkeypatch.setattr(
+        actions_mod, "systemd_autostart_profile_info", lambda **_kwargs: saved
+    )
+    window._boot_apply_by_gpu = {}
+
+    window._sync_boot_apply_for_target("GPU-A")
+    assert window.profile_list.persist_on_startup_enabled() is True
+
+    saved = {"selector": "", "main_gpu": False}
+    window._sync_boot_apply_for_target("GPU-A")
+
+    assert window.profile_list.persist_on_startup_enabled() is False
+
+
+def test_a_fresh_tick_survives_until_an_apply_writes_the_entry(
+    win, monkeypatch
+) -> None:
+    """Ticking arms the next apply; the daemon has nothing to report yet."""
+    window, _mp = win
+    monkeypatch.setattr(
+        actions_mod,
+        "systemd_autostart_profile_info",
+        lambda **_kwargs: {"selector": "", "main_gpu": False},
+    )
+    monkeypatch.setattr(
+        actions_mod, "persist_on_startup_to_runtime_config", lambda _v: None
+    )
+    monkeypatch.setattr(window.profile_list, "target_gpu_uuid", lambda: "GPU-A")
+    window._boot_apply_by_gpu = {}
+    # Start from off with signals blocked, so the tick below is the only
+    # user action in play.
+    window.profile_list.set_boot_apply_checked(False)
+
+    window.profile_list.boot_apply_checkbox.setChecked(True)
+    assert window._boot_apply_by_gpu == {"gpu-a": True}
+    window._sync_boot_apply_for_target("GPU-A")
+
+    assert window.profile_list.persist_on_startup_enabled() is True
+
+
+def test_a_confirmed_entry_drops_the_pending_tick(win, monkeypatch) -> None:
+    """Once the daemon holds the entry the session marker is redundant.
+
+    Left behind, it would keep forcing the box ON after the entry was cleared.
+    """
+    window, _mp = win
+    monkeypatch.setattr(
+        actions_mod,
+        "systemd_autostart_profile_info",
+        lambda **_kwargs: {"selector": "profile-a", "main_gpu": False},
+    )
+    window._boot_apply_by_gpu = {"gpu-a": True}
+
+    window._sync_boot_apply_for_target("GPU-A")
+
+    assert window._boot_apply_by_gpu == {}
+    assert window.profile_list.persist_on_startup_enabled() is True
 
 
 def test_main_gpu_toggle_tracks_target_and_writes_uuid(win, monkeypatch) -> None:

--- a/ui/features/profiles/profile_actions.py
+++ b/ui/features/profiles/profile_actions.py
@@ -4,10 +4,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
-from cli.runtime_config_file import (
-    persist_on_startup_from_runtime_config,
-    persist_on_startup_to_runtime_config,
-)
+from cli.runtime_config_file import persist_on_startup_to_runtime_config
 from common.penguin_burner_paths import default_user_config_dir
 from curve_editors.uv.vf_curve_manual_editor import editable_anchor_from_profile
 from profiles.uv.memory_offset_edit import editable_memory_offset_from_profile
@@ -101,9 +98,13 @@ class ProfileActionsMixin:
             return
         if checked:
             if gpu_uuid:
+                # Intent only: the boot entry itself is written by the next
+                # apply, and _sync_boot_apply_for_target drops this the moment
+                # the daemon reports the entry.
                 self._boot_apply_by_gpu[gpu_uuid.casefold()] = True
-            # Keep the historical single-value preference for one-GPU upgrades;
-            # the per-GPU daemon boot set is authoritative once UUIDs are known.
+            # Records the user's preference, not what boot will do -- the
+            # daemon's boot set answers that, and this is never read back for
+            # it. Kept because it is a documented setting in existing configs.
             persist_on_startup_to_runtime_config(True)
             return
         # Unticking means "nothing applies at boot": clear the selected GPU's
@@ -121,15 +122,26 @@ class ProfileActionsMixin:
             self.errors.show("Apply on startup", message)
             return
         if gpu_uuid:
-            self._boot_apply_by_gpu[gpu_uuid.casefold()] = False
+            self._boot_apply_by_gpu.pop(gpu_uuid.casefold(), None)
         persist_on_startup_to_runtime_config(False)
 
     def _sync_boot_apply_for_target(self, gpu_uuid: str) -> None:
+        """Show what boot will actually do, as the daemon currently has it.
+
+        The daemon's boot set is the only thing that decides what applies at
+        startup, so it is the only thing this reads. The saved preference is
+        written when the box is ticked but nothing rewrites it when the entry
+        goes away, so consulting it here promised a startup apply for a boot
+        that had nothing saved to apply.
+
+        The session cache carries only intent the daemon has not been told
+        about yet -- a freshly ticked box, whose entry the next apply writes.
+        """
         selected_uuid = str(gpu_uuid or "").strip()
         if not selected_uuid:
-            self.profile_list.set_boot_apply_checked(
-                persist_on_startup_from_runtime_config(default=False)
-            )
+            # Without a UUID the daemon still answers for its selected GPU.
+            info = systemd_autostart_profile_info()
+            self.profile_list.set_boot_apply_checked(bool(info.get("selector")))
             self.profile_list.set_main_gpu_state(
                 checked=False,
                 has_boot_profile=False,
@@ -137,12 +149,20 @@ class ProfileActionsMixin:
             return
         key = selected_uuid.casefold()
         info = systemd_autostart_profile_info(gpu_uuid=selected_uuid)
-        if key not in self._boot_apply_by_gpu:
-            self._boot_apply_by_gpu[key] = bool(info.get("selector"))
-        self.profile_list.set_boot_apply_checked(self._boot_apply_by_gpu[key])
+        saved = bool(info.get("selector"))
+        if saved:
+            # Confirmed on the daemon: there is nothing left pending.
+            self._boot_apply_by_gpu.pop(key, None)
+        # OR rather than either alone, which keeps one invariant: the box is
+        # never shown OFF while the daemon holds an entry. Every apply sends
+        # --boot or --clear-boot from this state, so showing OFF over a saved
+        # entry is what let an unrelated apply silently clear a boot profile.
+        self.profile_list.set_boot_apply_checked(
+            saved or self._boot_apply_by_gpu.get(key, False)
+        )
         self.profile_list.set_main_gpu_state(
             checked=bool(info.get("main_gpu")),
-            has_boot_profile=bool(info.get("selector")),
+            has_boot_profile=saved,
         )
 
     def _persist_main_gpu_preference(self, checked: bool) -> None:


### PR DESCRIPTION
"Apply on startup" mixed two sources of truth. The daemon's per-GPU boot set is the only thing that decides what applies at startup; the `[ui] persist_on_startup` preference is written when the box is ticked, but nothing rewrites it when the entry goes away. Reading it back for "what will boot do" could only ever go stale, and it did: a config holding `true` against an empty boot set showed "applies at startup" for a boot with nothing saved to apply.

The per-GPU session cache had the same problem in the other direction. It was seeded once from the daemon and then won for the rest of the session, even though the daemon is re-read on every sync. A cache saying off over a live entry is the damaging case, because every apply sends --boot or --clear-boot from this state. Reachable without touching the GUI's own boot controls:

  1. open the GUI with no boot entry for the selected GPU -- cache seeded off;
  2. run `penguin-burner-cli --restore-stock` (docs/install.md), which writes a boot entry through its own persist_on_startup path;
  3. back in the GUI, the box still reads off, because the cache decided once;
  4. Apply any profile -- --clear-boot silently wipes what step 2 wrote.

The no-UUID branch now asks the daemon, which already answers for its selected GPU. The cache carries only intent the daemon has not been told about yet: a freshly ticked box, whose entry the next apply writes, dropped the moment the daemon reports it. Reading the two together with OR keeps one invariant -- the box is never shown off while the daemon holds an entry -- so --clear-boot can only go out when there is genuinely nothing to clear.

The preference key keeps being written and is documented as what it is: a record of the user's choice, not a statement about boot.

Also closes a test-isolation gap found while writing this. The `win` fixture patched the window module's autostart reader but not the mixin's own binding, so building the window in tests reached the real daemon socket and the boot checkbox started ticked or not depending on what that machine had saved.

Each new test was confirmed to fail against the previous behaviour rather than merely to pass now.