### PR TITLE
Damp the cap latch on the median, and ask evidence before jumping a tier

### DIFF
--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -12,7 +12,7 @@ use super::apply::apply_adaptive_curve;
 use super::ceiling::FlattenedClockCeilingController;
 use super::guard::select_expected_vf_samples;
 use super::latency_rx::METER_SAMPLE_MAX_AGE_S;
-use super::logfmt::{DecisionInputs, tier_switch_line};
+use super::logfmt::{tier_switch_line, DecisionInputs};
 use super::runtime_spec::{
     normalize_profile_tier, profile_tier_label, AdaptivePolicySpec, LoadedCurve, PlanItem,
     PROFILE_TIERS, PROFILE_TIER_BALANCED, PROFILE_TIER_PERFORMANCE,
@@ -384,9 +384,9 @@ impl AdaptiveProfileController {
     /// argue it is not a stutter: most of the window missed the deadline, and
     /// the median is over target too, not just the tail.
     ///
-    /// Missing readings mean the old behaviour. A game with no marker stream
-    /// has neither figure, and refusing to promote there would be worse than
-    /// the oscillation this exists to damp.
+    /// Missing base-frame readings mean the old behaviour. The present-pacing
+    /// median can include generated frames, so it cannot be compared with the
+    /// base-frame target. It remains useful for like-for-like cap/probe checks.
     fn badly_slow_is_evidenced(&self) -> bool {
         if self
             .state
@@ -395,10 +395,11 @@ impl AdaptiveProfileController {
         {
             return false;
         }
-        !self
-            .state
-            .median_ms
-            .is_some_and(|median| median <= self.config.target_ms)
+        !(self.state.median_source == MedianSource::Marker
+            && self
+                .state
+                .median_ms
+                .is_some_and(|median| median <= self.config.target_ms))
     }
 
     /// The reference a fresh latch is made against: the median where one
@@ -502,9 +503,8 @@ impl AdaptiveProfileController {
         };
         let session_boundary = present_frametime_p95_ms.is_some() && !self.state.frames_last_tick;
         if session_boundary {
-            self.clear_util_window();
+            self.note_session_boundary();
             self.reset_counts();
-            self.state.frame_cap_streak = 0;
         }
         self.state.frames_last_tick = present_frametime_p95_ms.is_some();
         if !session_boundary {
@@ -544,6 +544,7 @@ impl AdaptiveProfileController {
             // session that has gone quiet, and the next one must be judged on
             // its own pacing rather than inheriting this reference.
             self.state.capped_reference = None;
+            self.state.promotion_probe = None;
             return self.idle_decision(&ordered, now_monotonic, gpu_util_pct);
         };
         // Frames again: whatever the idle rule had counted towards belongs to a
@@ -917,6 +918,9 @@ impl AdaptiveProfileController {
     fn note_session_boundary(&mut self) {
         self.clear_util_window();
         self.state.frame_cap_streak = 0;
+        // A new session cannot tell us whether the previous session's
+        // promotion helped, even when both happen to report the same median.
+        self.state.promotion_probe = None;
         self.state.frames_last_tick = false;
     }
 
@@ -2155,7 +2159,10 @@ mod tests {
             Some(35.0),
         );
         assert_eq!(d.tier, "performance", "setup must promote");
-        assert!(c.state.promotion_probe.is_some(), "setup must arm the probe");
+        assert!(
+            c.state.promotion_probe.is_some(),
+            "setup must arm the probe"
+        );
         c
     }
 
@@ -2181,6 +2188,44 @@ mod tests {
             c.state.capped_reference.is_some(),
             "the revert latches, so the ladder does not immediately re-promote"
         );
+    }
+
+    #[test]
+    fn a_promotion_probe_does_not_cross_a_no_sample_gap() {
+        let mut c = promoted_with_probe_armed(25.0);
+        let quiet = c.update(None, &tiers(), 104.0, Some(70.0), Some(20.0), Some(35.0));
+        assert_eq!(quiet.reason, "no-sample");
+
+        // The next session happens to report the old median. It says nothing
+        // about whether the previous session benefited from its promotion.
+        let resumed = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            110.0,
+            Some(70.0),
+            Some(20.0),
+            Some(35.0),
+        );
+        assert_eq!(resumed.tier, "performance", "{resumed:?}");
+        assert!(c.state.capped_reference.is_none());
+    }
+
+    #[test]
+    fn a_promotion_probe_does_not_cross_system_resume() {
+        let mut c = promoted_with_probe_armed(25.0);
+        // Resume can happen without an intervening no-sample tick.
+        c.note_session_boundary();
+
+        let resumed = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            110.0,
+            Some(70.0),
+            Some(20.0),
+            Some(35.0),
+        );
+        assert_eq!(resumed.tier, "performance", "{resumed:?}");
+        assert!(c.state.capped_reference.is_none());
     }
 
     #[test]

--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -12,7 +12,7 @@ use super::apply::apply_adaptive_curve;
 use super::ceiling::FlattenedClockCeilingController;
 use super::guard::select_expected_vf_samples;
 use super::latency_rx::METER_SAMPLE_MAX_AGE_S;
-use super::logfmt::tier_switch_line;
+use super::logfmt::{DecisionInputs, tier_switch_line};
 use super::runtime_spec::{
     normalize_profile_tier, profile_tier_label, AdaptivePolicySpec, LoadedCurve, PlanItem,
     PROFILE_TIERS, PROFILE_TIER_BALANCED, PROFILE_TIER_PERFORMANCE,
@@ -52,6 +52,19 @@ pub enum MedianSource {
     None,
     Marker,
     Pacing,
+}
+
+impl MedianSource {
+    /// Log label. `None` prints as the statistic actually used in its place,
+    /// because the only place it is rendered is a latch that falls back to the
+    /// tail when no median is on offer.
+    pub fn label(self) -> &'static str {
+        match self {
+            MedianSource::None => "p95",
+            MedianSource::Marker => "marker",
+            MedianSource::Pacing => "pacing",
+        }
+    }
 }
 
 /// What one tick knows about frame pacing.
@@ -400,6 +413,14 @@ impl AdaptiveProfileController {
                 ms: frametime_ms,
                 source: MedianSource::None,
             },
+        }
+    }
+
+    /// The held cap reference, for the log line that explains a decision.
+    fn capped_reference_parts(&self) -> (Option<f64>, &'static str) {
+        match self.state.capped_reference {
+            Some(reference) => (Some(reference.ms), reference.source.label()),
+            None => (None, "off"),
         }
     }
 
@@ -907,6 +928,26 @@ impl AdaptiveProfileController {
         Some(values.iter().sum::<f64>() / values.len() as f64)
     }
 
+    /// The windowed GPU utilisation the guards actually judged, which is not
+    /// the instantaneous reading the caller passed in.
+    fn windowed_gpu_util_pct(&self) -> Option<f64> {
+        self.windowed_avg(|s| s.gpu)
+    }
+
+    /// The windowed CPU figures the same branches judge.
+    ///
+    /// Reported for the same reason as the GPU one: the cap test is half a CPU
+    /// test, and an unreported CPU reading silently passes that half. A record
+    /// showing one side windowed and the other instantaneous made absent CPU
+    /// telemetry look like a policy that ignores the CPU.
+    fn windowed_cpu_util_pct(&self) -> Option<f64> {
+        self.windowed_avg(|s| s.cpu)
+    }
+
+    fn windowed_cpu_peak_thread_pct(&self) -> Option<f64> {
+        self.windowed_avg(|s| s.peak_thread)
+    }
+
     fn performance_promotion_cpu_bound(
         &self,
         target_tier: &str,
@@ -1137,6 +1178,23 @@ impl AdaptiveAutoUvRuntimeController {
             cpu,
             cpu_peak,
         );
+        // After update(), so the latch state printed is the one the decision was
+        // taken against rather than the previous tick's.
+        let (capped_reference_ms, capped_reference_source) = self.policy.capped_reference_parts();
+        let inputs = DecisionInputs {
+            present_frametime_p95_ms: readings.p95_ms,
+            present_frametime_p50_ms: readings.p50_ms,
+            median_source: readings.p50_source.label(),
+            present_frametime_miss_ratio: readings.miss_ratio,
+            // The windowed figures the branches read, falling back to the
+            // instantaneous ones only for the tick the window is empty --
+            // which is what the guards themselves do.
+            windowed_gpu_util_pct: self.policy.windowed_gpu_util_pct().or(gpu),
+            cpu_util_pct: self.policy.windowed_cpu_util_pct().or(cpu),
+            cpu_peak_thread_pct: self.policy.windowed_cpu_peak_thread_pct().or(cpu_peak),
+            capped_reference_ms,
+            capped_reference_source,
+        };
         if !decision.changed {
             self.maybe_log_cpu_bound_guard(&decision, now_monotonic, gpu, cpu, cpu_peak, log);
             return Some(AdaptiveSwitchResult {
@@ -1163,6 +1221,7 @@ impl AdaptiveAutoUvRuntimeController {
             &decision.tier,
             &curve,
             &decision.reason,
+            &inputs,
             backend,
             ceiling,
             publisher,
@@ -1194,6 +1253,7 @@ impl AdaptiveAutoUvRuntimeController {
         tier: &str,
         curve: &LoadedCurve,
         reason: &str,
+        inputs: &DecisionInputs,
         backend: &dyn GpuBackend,
         ceiling: &mut Option<FlattenedClockCeilingController<'_>>,
         publisher: &mut OverlayStatePublisher,
@@ -1212,6 +1272,7 @@ impl AdaptiveAutoUvRuntimeController {
             self.last_tier_label.as_deref().unwrap_or("?"),
             &label,
             reason,
+            inputs,
         ));
         self.last_tier_label = Some(label);
         Ok(AdaptiveSwitchResult {
@@ -2261,6 +2322,62 @@ mod tests {
         );
 
         assert_eq!(d.reason, "badly-slow");
+    }
+
+    #[test]
+    fn the_reported_utilisation_is_the_window_the_guards_read() {
+        // The record has to show the figure the policy judged. Reporting the
+        // instantaneous reading beside a windowed decision makes a correct
+        // decision look arbitrary -- and the field is named "windowed".
+        let mut c = controller();
+        for (i, gpu) in [10.0, 20.0, 60.0].iter().enumerate() {
+            c.update(
+                Some(16.0),
+                &tiers(),
+                100.0 + i as f64 * 0.5,
+                Some(*gpu),
+                Some(*gpu / 2.0),
+                Some(*gpu),
+            );
+        }
+
+        // The first tick with frames is a session boundary, which clears the
+        // window, so what remains is the two ticks after it -- averaged, not
+        // the last one.
+        assert_eq!(
+            c.windowed_gpu_util_pct(),
+            Some(40.0),
+            "the mean of the window, not the last sample"
+        );
+        assert_eq!(c.windowed_cpu_util_pct(), Some(20.0));
+        assert_eq!(c.windowed_cpu_peak_thread_pct(), Some(40.0));
+    }
+
+    #[test]
+    fn the_logged_latch_reports_the_measurement_it_was_taken_against() {
+        // The log line is the only record of a latch: it lives in memory and is
+        // gone by the time anyone reads the journal. Reporting the wrong median
+        // source there makes a held cap unreadable after the fact.
+        let mut c =
+            AdaptiveProfileController::new("performance", PolicyConfig::for_target_fps(100.0));
+        assert_eq!(c.capped_reference_parts(), (None, "off"));
+
+        for i in 0..4 {
+            c.update(
+                readings(16.67, 16.6, MedianSource::Pacing, 0.9),
+                &tiers(),
+                100.0 + i as f64 * 2.0,
+                Some(25.0),
+                Some(20.0),
+                Some(35.0),
+            );
+        }
+        let (ms, source) = c.capped_reference_parts();
+        assert_eq!(source, "pacing", "the stream that fed the latch");
+        assert!(
+            (ms.expect("a sustained cap latches") - 16.6).abs() < 0.01,
+            "reports the latched median, got {ms:?}"
+        );
     }
 
     #[test]

--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -21,6 +21,52 @@ use super::LatencySnapshot;
 
 const CPU_BOUND_GUARD_LOG_THROTTLE_S: f64 = 30.0;
 
+/// Which stream a median came from.
+///
+/// Two medians reach the policy and they are not interchangeable: markers
+/// describe the frames the game rendered, present pacing describes the frames
+/// that reached the screen. Comparing one against the other -- which is what a
+/// latch does every tick -- silently compares two different things the moment
+/// a stream starts or stops, so the latch has to remember which it took.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MedianSource {
+    #[default]
+    None,
+    Marker,
+    Pacing,
+}
+
+/// What one tick knows about frame pacing.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FrametimeReadings {
+    pub p95_ms: Option<f64>,
+    pub p50_ms: Option<f64>,
+    pub p50_source: MedianSource,
+    /// Share of the window past the badly-slow bar. A tail can be one stutter;
+    /// a ratio cannot, which is why the branch that jumps straight to the top
+    /// tier asks for it.
+    pub miss_ratio: Option<f64>,
+}
+
+impl From<Option<f64>> for FrametimeReadings {
+    /// The p95 alone, for callers (and tests) that have nothing else.
+    fn from(p95_ms: Option<f64>) -> Self {
+        FrametimeReadings {
+            p95_ms,
+            p50_ms: None,
+            p50_source: MedianSource::None,
+            miss_ratio: None,
+        }
+    }
+}
+
+/// A recognised frame cap, and the median it was recognised against.
+#[derive(Debug, Clone, Copy)]
+struct CappedReference {
+    ms: f64,
+    source: MedianSource,
+}
+
 // --- policy config ----------------------------------------------------------
 
 #[derive(Debug, Clone, Copy)]
@@ -58,6 +104,9 @@ pub struct PolicyConfig {
     /// tier is held -- neither promoted (the miss may not be a clock problem)
     /// nor eased down (the cap is not established).
     pub frame_cap_confirm_windows: i64,
+    /// Share of the window that must have missed the deadline before a single
+    /// window may jump straight to the top tier.
+    pub badly_slow_miss_ratio_min: f64,
     /// How much worse (percent) than the reference pacing frametime has to get
     /// before the cap is considered gone. A hard cap holds the frame rate
     /// steady no matter which tier runs, so anything past this margin means
@@ -80,6 +129,7 @@ impl Default for PolicyConfig {
             badly_slow_ms: 22.0,
             target_slow_windows: 3,
             near_slow_windows: 2,
+            badly_slow_miss_ratio_min: 0.5,
             comfort_windows: 6,
             performance_comfort_windows: 10,
             demote_dwell_s: 60.0,
@@ -164,7 +214,12 @@ struct PolicyState {
     /// cap the demotion just acted on -- tier down, tier up, forever. Frametime
     /// does not move with the tier while a cap holds the rate, so it is the one
     /// signal the policy's own decisions cannot invalidate.
-    capped_reference_ms: Option<f64>,
+    capped_reference: Option<CappedReference>,
+    /// The median this tick reported, and where it came from.
+    median_ms: Option<f64>,
+    median_source: MedianSource,
+    /// Share of this tick's window past the badly-slow bar, when known.
+    miss_ratio: Option<f64>,
     /// Consecutive frame ticks that have looked externally capped without a
     /// latch being held yet. Recognition waits for
     /// `frame_cap_confirm_windows` of these; the tier is held while it does.
@@ -242,13 +297,84 @@ impl AdaptiveProfileController {
                 target_slow_count: 0,
                 near_slow_count: 0,
                 comfort_count: 0,
-                capped_reference_ms: None,
+                capped_reference: None,
+                median_ms: None,
+                median_source: MedianSource::None,
+                miss_ratio: None,
                 frame_cap_streak: 0,
                 desktop_idle_since: None,
                 frames_last_tick: false,
             },
             util_samples: std::collections::VecDeque::new(),
         }
+    }
+
+    /// The deadline a frame has to clear to count as on time.
+    ///
+    /// The badly-slow bar rather than the target: a frame over target is late,
+    /// but a frame over *this* is the kind of late the ladder is allowed to
+    /// answer by jumping a tier -- so it is the bar worth counting.
+    /// Whether one badly-slow window is evidence enough to jump a tier.
+    ///
+    /// The branch below answers a single window by going straight to the top,
+    /// and a promotion takes one window where every step back down pays its
+    /// dwell -- so one stutter can outrun several minutes of easing. Two things
+    /// argue it is not a stutter: most of the window missed the deadline, and
+    /// the median is over target too, not just the tail.
+    ///
+    /// Missing readings mean the old behaviour. A game with no marker stream
+    /// has neither figure, and refusing to promote there would be worse than
+    /// the oscillation this exists to damp.
+    fn badly_slow_is_evidenced(&self) -> bool {
+        if self
+            .state
+            .miss_ratio
+            .is_some_and(|ratio| ratio < self.config.badly_slow_miss_ratio_min)
+        {
+            return false;
+        }
+        !self
+            .state
+            .median_ms
+            .is_some_and(|median| median <= self.config.target_ms)
+    }
+
+    /// The reference a fresh latch is made against: the median where one
+    /// exists, else the tail, which is all a stream-less game offers.
+    fn pacing_reference(&self, frametime_ms: f64) -> CappedReference {
+        match self.state.median_ms {
+            Some(ms) if self.state.median_source != MedianSource::None => CappedReference {
+                ms,
+                source: self.state.median_source,
+            },
+            _ => CappedReference {
+                ms: frametime_ms,
+                source: MedianSource::None,
+            },
+        }
+    }
+
+    /// Whether pacing still sits where the cap was recognised.
+    ///
+    /// `None` when it cannot be told -- the stream that fed the reference is no
+    /// longer reporting -- which releases the latch rather than comparing a
+    /// marker median against a pacing one and calling the difference movement.
+    fn reference_still_holds(&self, reference: CappedReference, frametime_ms: f64) -> Option<bool> {
+        let current = if reference.source == MedianSource::None {
+            Some(frametime_ms)
+        } else if self.state.median_source == reference.source {
+            self.state.median_ms
+        } else {
+            None
+        }?;
+        let slack = 1.0 + self.config.frame_cap_exit_pacing_pct / 100.0;
+        // Symmetric: a cap that lifts shows up as pacing getting *better*, and
+        // that has to release the latch too.
+        Some(current <= reference.ms * slack && current >= reference.ms / slack)
+    }
+
+    fn miss_deadline_ms(&self) -> f64 {
+        self.config.badly_slow_ms
     }
 
     fn snapshot_state(&self) -> PolicyState {
@@ -268,7 +394,7 @@ impl AdaptiveProfileController {
     #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
-        present_frametime_p95_ms: Option<f64>,
+        frametime: impl Into<FrametimeReadings>,
         available_tiers: &[String],
         now_monotonic: f64,
         gpu_util_pct: Option<f64>,
@@ -290,6 +416,15 @@ impl AdaptiveProfileController {
         // low tier for its entire session. The guards fall back to the
         // instantaneous values for the one tick the window is empty, which is
         // the most recent data that exists.
+        let frametime = frametime.into();
+        let present_frametime_p95_ms = frametime.p95_ms;
+        self.state.median_ms = frametime.p50_ms;
+        self.state.miss_ratio = frametime.miss_ratio;
+        self.state.median_source = if frametime.p50_ms.is_some() {
+            frametime.p50_source
+        } else {
+            MedianSource::None
+        };
         let session_boundary = present_frametime_p95_ms.is_some() && !self.state.frames_last_tick;
         if session_boundary {
             self.clear_util_window();
@@ -333,7 +468,7 @@ impl AdaptiveProfileController {
             // Nothing is presenting: whatever cap was recognised belonged to a
             // session that has gone quiet, and the next one must be judged on
             // its own pacing rather than inheriting this reference.
-            self.state.capped_reference_ms = None;
+            self.state.capped_reference = None;
             return self.idle_decision(&ordered, now_monotonic, gpu_util_pct);
         };
         // Frames again: whatever the idle rule had counted towards belongs to a
@@ -349,21 +484,30 @@ impl AdaptiveProfileController {
         // Utilisation is only the entry hint; re-testing it every tick would
         // let each demotion (which raises utilisation for the same capped rate)
         // cancel the recognition that caused it.
-        if let Some(reference) = self.state.capped_reference_ms {
+        if let Some(reference) = self.state.capped_reference {
             let saturated = self
                 .windowed_avg(|s| s.gpu)
                 .or(gpu_util_pct)
                 .is_some_and(|gpu| gpu >= self.config.frame_cap_exit_gpu_pct);
-            let pacing_slack = 1.0 + self.config.frame_cap_exit_pacing_pct / 100.0;
-            if !saturated && frametime_ms <= reference * pacing_slack {
+            // Judged on the median rather than the tail. A cap holds the median
+            // still while the tail keeps moving, so a tail comparison releases
+            // the latch on the first stutter under a cap that never lifted --
+            // and the tick that releases it falls straight through to the
+            // branch that jumps a tier, which is the oscillation.
+            //
+            // `None` means the stream that fed the reference stopped reporting.
+            // Nothing can be concluded from a comparison against a median that
+            // no longer exists, so the latch is released rather than guessed at.
+            let holds = self.reference_still_holds(reference, frametime_ms);
+            if !saturated && holds == Some(true) {
                 // Pacing has not moved: the tier still is not the limit.
-                return self.ease_down(&ordered, now_monotonic, "externally-capped");
+                return self.ease_down(&ordered, now_monotonic, "externally-capped-held");
             }
             // Either pacing degraded past what the cap was hiding, or the card
             // is now flat out. Release the latch -- but do not hand the tick to
             // the ladder yet, because "this reference stopped explaining the
             // pacing" is not the same claim as "the tier is the limit now".
-            self.state.capped_reference_ms = None;
+            self.state.capped_reference = None;
         }
 
         // Recognition, and re-recognition on the very tick a latch was
@@ -386,7 +530,7 @@ impl AdaptiveProfileController {
             self.state.frame_cap_streak += 1;
             if self.state.frame_cap_streak >= self.config.frame_cap_confirm_windows {
                 self.state.frame_cap_streak = 0;
-                self.state.capped_reference_ms = Some(frametime_ms);
+                self.state.capped_reference = Some(self.pacing_reference(frametime_ms));
                 return self.ease_down(&ordered, now_monotonic, "externally-capped");
             }
             return Decision {
@@ -397,7 +541,7 @@ impl AdaptiveProfileController {
         }
         self.state.frame_cap_streak = 0;
 
-        if frametime_ms > self.config.badly_slow_ms {
+        if frametime_ms > self.config.badly_slow_ms && self.badly_slow_is_evidenced() {
             return self.switch_with_cpu_bound_guard(
                 ordered[ordered.len() - 1].clone(),
                 &ordered,
@@ -737,6 +881,12 @@ impl AdaptiveAutoUvRuntimeController {
     /// A system resume was detected: invalidate windowed utilization state and
     /// any half-built cap recognition so the guards reason only about
     /// post-resume samples.
+    /// Deadline the frametime window should count misses against, in
+    /// microseconds, so the meter can record the ratio.
+    pub fn miss_deadline_us(&self) -> i64 {
+        (self.policy.miss_deadline_ms() * 1000.0).round() as i64
+    }
+
     pub fn note_system_resume(&mut self) {
         self.policy.note_session_boundary();
     }
@@ -826,13 +976,32 @@ impl AdaptiveAutoUvRuntimeController {
         if !self.enabled() {
             return None;
         }
-        let present_ms = latency_snapshot.and_then(|s| s.base_present_frametime_p95_ms);
+        // The marker median is preferred: it is a median of the same accepted
+        // set as the p95, so the two are comparable. Present pacing is the
+        // fallback, and the source travels with the value because a latch made
+        // against one must never be re-tested against the other.
+        let (p50_ms, p50_source) = match latency_snapshot {
+            Some(snapshot) => match snapshot.base_present_frametime_p50_ms {
+                Some(ms) => (Some(ms), MedianSource::Marker),
+                None => match snapshot.present_pacing_p50_ms {
+                    Some(ms) => (Some(ms), MedianSource::Pacing),
+                    None => (None, MedianSource::None),
+                },
+            },
+            None => (None, MedianSource::None),
+        };
+        let readings = FrametimeReadings {
+            p95_ms: latency_snapshot.and_then(|s| s.base_present_frametime_p95_ms),
+            p50_ms,
+            p50_source,
+            miss_ratio: latency_snapshot.and_then(|s| s.base_present_frametime_miss_ratio),
+        };
         let policy_state = self.policy.snapshot_state();
         let gpu = publisher.last_gpu_util_pct().map(|v| v as f64);
         let cpu = publisher.last_cpu_util_pct().map(|v| v as f64);
         let cpu_peak = publisher.last_cpu_peak_thread_pct().map(|v| v as f64);
         let decision = self.policy.update(
-            present_ms,
+            readings,
             &self.available_tiers,
             now_monotonic,
             gpu,
@@ -1080,7 +1249,7 @@ mod tests {
             assert_eq!(d.tier, "performance", "target-ok must remain a hold");
             assert_eq!(d.reason, "target-ok");
         }
-        assert!(c.state.capped_reference_ms.is_none());
+        assert!(c.state.capped_reference.is_none());
     }
 
     #[test]
@@ -1098,7 +1267,9 @@ mod tests {
         }
         let decision = eased.expect("a sustained cap must step the tier down");
         assert_eq!(decision.tier, "balanced");
-        assert_eq!(decision.reason, "externally-capped");
+        // "held" rather than plain: the step happens on a tick where the latch
+        // was already made and still explains the pacing.
+        assert_eq!(decision.reason, "externally-capped-held");
     }
 
     #[test]
@@ -1122,7 +1293,7 @@ mod tests {
             );
         }
         assert!(
-            c.state.capped_reference_ms.is_some(),
+            c.state.capped_reference.is_some(),
             "the cap must be recognised before the release can be tested"
         );
 
@@ -1162,7 +1333,7 @@ mod tests {
                 Some(22.0),
             );
         }
-        assert!(c.state.capped_reference_ms.is_some());
+        assert!(c.state.capped_reference.is_some());
 
         for i in 0..8 {
             c.update(
@@ -1176,7 +1347,7 @@ mod tests {
         }
 
         assert!(
-            c.state.capped_reference_ms.is_none(),
+            c.state.capped_reference.is_none(),
             "a flat-out card must not hold or re-take a cap recognition"
         );
     }
@@ -1201,9 +1372,11 @@ mod tests {
             }
         }
         assert!(
+            // Recognition and every held tick after it both count; what this
+            // forbids is a promote reason appearing among them.
             tiers_seen
                 .iter()
-                .all(|(_, reason)| reason == "externally-capped"),
+                .all(|(_, reason)| reason.starts_with("externally-capped")),
             "no promotion may fire while the cap holds: {tiers_seen:?}"
         );
         // Monotonically downwards, never back up.
@@ -1254,12 +1427,12 @@ mod tests {
                 Some(35.0),
             );
         }
-        assert!(c.state.capped_reference_ms.is_some());
+        assert!(c.state.capped_reference.is_some());
 
         c.update(None, &tiers(), 106.0, Some(25.0), Some(20.0), Some(35.0));
 
         assert!(
-            c.state.capped_reference_ms.is_none(),
+            c.state.capped_reference.is_none(),
             "the next session must be judged on its own pacing"
         );
     }
@@ -1328,7 +1501,7 @@ mod tests {
         );
         assert_eq!(first.reason, "externally-capped-confirm");
         assert!(!first.changed, "a confirm tick must hold, not move");
-        assert!(c.state.capped_reference_ms.is_none());
+        assert!(c.state.capped_reference.is_none());
 
         let second = c.update(
             Some(16.67),
@@ -1340,7 +1513,7 @@ mod tests {
         );
         assert_eq!(second.reason, "badly-slow");
         assert_eq!(second.tier, "performance");
-        assert!(c.state.capped_reference_ms.is_none());
+        assert!(c.state.capped_reference.is_none());
     }
 
     #[test]
@@ -1394,7 +1567,7 @@ mod tests {
                 }
             }
             assert!(
-                c.state.capped_reference_ms.is_none(),
+                c.state.capped_reference.is_none(),
                 "no cap may latch off the desktop's stale window at {game_util}%"
             );
             let decision = promoted.unwrap_or_else(|| {
@@ -1423,7 +1596,7 @@ mod tests {
                 Some(35.0),
             );
         }
-        assert!(c.state.capped_reference_ms.is_none());
+        assert!(c.state.capped_reference.is_none());
 
         c.note_session_boundary();
 
@@ -1436,7 +1609,7 @@ mod tests {
             Some(35.0),
         );
         assert!(
-            c.state.capped_reference_ms.is_none(),
+            c.state.capped_reference.is_none(),
             "the pre-suspend streak must not carry over: {d:?}"
         );
     }
@@ -1497,7 +1670,7 @@ mod tests {
                 Some(22.0),
             );
         }
-        assert!(c.state.capped_reference_ms.is_some());
+        assert!(c.state.capped_reference.is_some());
 
         let d = c.update(
             Some(24.7),
@@ -1509,7 +1682,7 @@ mod tests {
         );
 
         assert!(
-            c.state.capped_reference_ms.is_some(),
+            c.state.capped_reference.is_some(),
             "wider slack must keep the latch through the same regression"
         );
         assert!(d.reason.starts_with("externally-capped"), "{d:?}");
@@ -1695,5 +1868,150 @@ mod tests {
         assert_eq!(config.performance_comfort_windows, 11);
         assert_eq!(config.demote_dwell_s, 50.0);
         assert_eq!(config.cpu_bound_gpu_util_max_pct, 80.0);
+    }
+
+    fn readings(p95: f64, p50: f64, source: MedianSource, miss: f64) -> FrametimeReadings {
+        FrametimeReadings {
+            p95_ms: Some(p95),
+            p50_ms: Some(p50),
+            p50_source: source,
+            miss_ratio: Some(miss),
+        }
+    }
+
+    #[test]
+    fn one_slow_window_does_not_jump_a_tier_without_evidence() {
+        // A promotion takes a single window; every step back down pays its
+        // dwell. So one stutter can undo minutes of easing, and the tick that
+        // releases a cap latch falls straight into this branch -- which is the
+        // demote/promote oscillation seen live.
+        let mut c = AdaptiveProfileController::new("balanced", PolicyConfig::for_target_fps(100.0));
+
+        // The card is busy, so the cap branch does not claim this tick and it
+        // reaches the promote. Tail well past badly-slow, but the median is on
+        // target and almost nothing missed: a stutter, not a slow session.
+        let d = c.update(
+            readings(30.0, 9.8, MedianSource::Marker, 0.05),
+            &tiers(),
+            100.0,
+            Some(95.0),
+            Some(20.0),
+            Some(35.0),
+        );
+        assert_ne!(d.reason, "badly-slow", "one stutter is not evidence");
+        assert_eq!(d.tier, "balanced");
+    }
+
+    #[test]
+    fn a_window_that_really_is_slow_still_jumps() {
+        // The veto must not cost a genuine promotion: most of the window over
+        // the deadline and a median past target is exactly the case the branch
+        // exists for.
+        let mut c = AdaptiveProfileController::new("balanced", PolicyConfig::for_target_fps(100.0));
+
+        let d = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            100.0,
+            Some(95.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_eq!(d.reason, "badly-slow");
+        assert_eq!(d.tier, "performance");
+    }
+
+    #[test]
+    fn a_game_with_no_readings_keeps_the_old_behaviour() {
+        // No marker stream means neither figure exists. Refusing to promote
+        // there would be worse than the oscillation this damps.
+        let mut c = AdaptiveProfileController::new("balanced", PolicyConfig::for_target_fps(100.0));
+
+        let d = c.update(
+            Some(30.0),
+            &tiers(),
+            100.0,
+            Some(95.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_eq!(d.reason, "badly-slow");
+    }
+
+    #[test]
+    fn a_cap_is_latched_against_the_median_not_the_tail() {
+        // Under a cap the median sits still while the tail wanders. Latching on
+        // the tail releases on the first stutter, and the releasing tick is the
+        // one that promotes.
+        let mut c =
+            AdaptiveProfileController::new("performance", PolicyConfig::for_target_fps(100.0));
+        for i in 0..4 {
+            c.update(
+                readings(16.67, 16.6, MedianSource::Marker, 0.9),
+                &tiers(),
+                100.0 + i as f64 * 2.0,
+                Some(25.0),
+                Some(20.0),
+                Some(35.0),
+            );
+        }
+        let reference = c.state.capped_reference.expect("a sustained cap latches");
+        assert_eq!(reference.source, MedianSource::Marker);
+        assert!(
+            (reference.ms - 16.6).abs() < 0.01,
+            "latched on the median, got {}",
+            reference.ms
+        );
+
+        // Tail jumps, median does not: the cap has not lifted.
+        let d = c.update(
+            readings(24.7, 16.6, MedianSource::Marker, 0.9),
+            &tiers(),
+            120.0,
+            Some(58.0),
+            Some(10.0),
+            Some(20.0),
+        );
+        assert!(
+            d.reason.starts_with("externally-capped"),
+            "a moving tail must not release a held cap, got {}",
+            d.reason
+        );
+    }
+
+    #[test]
+    fn a_latch_is_released_when_its_stream_stops_reporting() {
+        // Comparing a marker median against a pacing one calls the difference
+        // between two different measurements "movement". Nothing can be
+        // concluded, so the latch goes rather than being guessed at.
+        let mut c =
+            AdaptiveProfileController::new("performance", PolicyConfig::for_target_fps(100.0));
+        for i in 0..4 {
+            c.update(
+                readings(16.67, 16.6, MedianSource::Marker, 0.9),
+                &tiers(),
+                100.0 + i as f64 * 2.0,
+                Some(25.0),
+                Some(20.0),
+                Some(35.0),
+            );
+        }
+        assert!(c.state.capped_reference.is_some());
+
+        c.update(
+            readings(16.67, 16.6, MedianSource::Pacing, 0.9),
+            &tiers(),
+            120.0,
+            Some(25.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert!(
+            c.state.capped_reference.is_none(),
+            "a reference whose stream stopped must not be re-tested against another"
+        );
     }
 }

--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -11,6 +11,7 @@ use crate::gpu::GpuBackend;
 use super::apply::apply_adaptive_curve;
 use super::ceiling::FlattenedClockCeilingController;
 use super::guard::select_expected_vf_samples;
+use super::latency_rx::METER_SAMPLE_MAX_AGE_S;
 use super::logfmt::tier_switch_line;
 use super::runtime_spec::{
     normalize_profile_tier, profile_tier_label, AdaptivePolicySpec, LoadedCurve, PlanItem,
@@ -67,6 +68,19 @@ struct CappedReference {
     source: MedianSource,
 }
 
+/// A promotion that has been made and not yet judged.
+#[derive(Debug, Clone)]
+struct PromotionProbe {
+    /// The median at the moment of the promotion, to compare against.
+    median_ms: f64,
+    /// And where it came from, so the comparison stays like for like.
+    median_source: MedianSource,
+    /// Where to go back to if the promotion turns out to have done nothing.
+    from_tier: String,
+    /// When the sample window will hold only frames paced by the new tier.
+    due_at: f64,
+}
+
 // --- policy config ----------------------------------------------------------
 
 #[derive(Debug, Clone, Copy)]
@@ -118,6 +132,20 @@ pub struct PolicyConfig {
     pub desktop_idle_gpu_pct: f64,
     /// How long that has to hold before the tier moves.
     pub desktop_idle_after_s: f64,
+    /// How long after a promotion to check whether it changed the pacing.
+    ///
+    /// A promotion is a prediction -- more clock will move the frame rate --
+    /// and this is the only rule that goes back and reads the outcome. Long
+    /// enough that the sample window no longer holds frames paced by the tier
+    /// that was replaced.
+    pub promotion_probe_s: f64,
+    /// How far the median may move and still count as not having moved.
+    ///
+    /// An external limiter holds the median at the same value whichever tier
+    /// runs, so "unchanged" -- not "did not improve enough" -- is the
+    /// signature being looked for. Pacing that got worse means the scene
+    /// changed, which is no evidence about the tier either way.
+    pub promotion_probe_tolerance: f64,
 }
 
 impl Default for PolicyConfig {
@@ -149,6 +177,8 @@ impl Default for PolicyConfig {
             frame_cap_exit_pacing_pct: 15.0,
             desktop_idle_gpu_pct: 20.0,
             desktop_idle_after_s: 60.0,
+            promotion_probe_s: 2.0 * METER_SAMPLE_MAX_AGE_S,
+            promotion_probe_tolerance: 0.02,
         }
     }
 }
@@ -218,6 +248,7 @@ struct PolicyState {
     /// The median this tick reported, and where it came from.
     median_ms: Option<f64>,
     median_source: MedianSource,
+    promotion_probe: Option<PromotionProbe>,
     /// Share of this tick's window past the badly-slow bar, when known.
     miss_ratio: Option<f64>,
     /// Consecutive frame ticks that have looked externally capped without a
@@ -300,6 +331,7 @@ impl AdaptiveProfileController {
                 capped_reference: None,
                 median_ms: None,
                 median_source: MedianSource::None,
+                promotion_probe: None,
                 miss_ratio: None,
                 frame_cap_streak: 0,
                 desktop_idle_since: None,
@@ -475,6 +507,52 @@ impl AdaptiveProfileController {
         // session that is over. Cleared before any ladder branch can run, so a
         // game that starts pays no dwell for the desktop it interrupted.
         self.state.desktop_idle_since = None;
+
+        // A promotion is a prediction -- more clock will move the frame rate --
+        // and this is the only rule that goes back and reads the outcome.
+        // Utilisation alone cannot settle it: measured live, a capped game sat
+        // at 61-66%, above the bar that recognises a cap and below the
+        // saturation that would justify the clock, and the ladder climbed back
+        // to the top tier 52 times, spending 93% of its time there. The median
+        // settles it without a threshold -- it stayed at 16.6 ms whichever
+        // tier ran, because a limiter, not the GPU, was setting it.
+        if let Some(probe) = self.state.promotion_probe.clone() {
+            if now_monotonic >= probe.due_at {
+                self.state.promotion_probe = None;
+                // A flat-out card is the one case where an unmoved median
+                // proves nothing. The check reasons "the clock changed
+                // nothing, so the clock was not the limit" -- and at
+                // saturation the clock demonstrably IS the limit, so a step
+                // too small to show inside the probe window is a small win,
+                // not an external cap.
+                let saturated = self
+                    .windowed_avg(|s| s.gpu)
+                    .or(gpu_util_pct)
+                    .is_some_and(|gpu| gpu >= self.config.frame_cap_exit_gpu_pct);
+                // Dropped, not acted on: the tick carries on to the ladder,
+                // which is free to do whatever a saturated card warrants.
+                if !saturated {
+                    // Same stream on both sides. A session that gains or loses
+                    // a marker stream would otherwise read the change of
+                    // instrument as the promotion having worked.
+                    if let Some(median_ms) = self
+                        .state
+                        .median_ms
+                        .filter(|_| self.state.median_source == probe.median_source)
+                    {
+                        let moved = (median_ms - probe.median_ms).abs();
+                        if moved <= probe.median_ms * self.config.promotion_probe_tolerance {
+                            self.state.capped_reference = Some(self.pacing_reference(frametime_ms));
+                            return self.switch(
+                                probe.from_tier,
+                                now_monotonic,
+                                "promotion-had-no-effect",
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         // Checked before the slow ladder: every branch below reads a missed
         // target as "needs more clock", which is wrong the moment the GPU is
@@ -737,7 +815,14 @@ impl AdaptiveProfileController {
             cpu_util_pct,
             cpu_peak_thread_pct,
         ) {
-            return self.switch(target_tier, now_monotonic, reason);
+            let previous = self.state.current_tier.clone();
+            let decision = self.switch(target_tier, now_monotonic, reason);
+            if decision.changed
+                && tier_index(&decision.tier, ordered) > tier_index(&previous, ordered)
+            {
+                self.arm_promotion_probe(previous, now_monotonic);
+            }
+            return decision;
         }
         let capped = highest_non_performance_tier(ordered);
         if tier_index(&capped, ordered) > tier_index(&self.state.current_tier, ordered) {
@@ -833,6 +918,24 @@ impl AdaptiveProfileController {
         peak_busy || process_busy
     }
 
+    /// Remember what to compare against once the new tier has had time to
+    /// show its effect. Without a median there is nothing to judge, so the
+    /// promotion simply stands as before.
+    fn arm_promotion_probe(&mut self, from_tier: String, now_monotonic: f64) {
+        let Some(median_ms) = self.state.median_ms else {
+            return;
+        };
+        if median_ms <= 0.0 || self.state.median_source == MedianSource::None {
+            return;
+        }
+        self.state.promotion_probe = Some(PromotionProbe {
+            median_ms,
+            median_source: self.state.median_source,
+            from_tier,
+            due_at: now_monotonic + self.config.promotion_probe_s,
+        });
+    }
+
     fn switch(&mut self, target_tier: String, now_monotonic: f64, reason: &str) -> Decision {
         let target_tier = normalize_profile_tier(&target_tier, &self.state.current_tier);
         if target_tier == self.state.current_tier {
@@ -846,6 +949,10 @@ impl AdaptiveProfileController {
         self.state.current_tier = target_tier.clone();
         self.state.last_switch_monotonic = now_monotonic;
         self.reset_counts();
+        // Any tier change makes a pending probe meaningless: it was armed to
+        // judge a tier that is no longer the one running. The promotion path
+        // re-arms straight after calling this.
+        self.state.promotion_probe = None;
         Decision {
             tier: target_tier,
             changed: true,
@@ -1920,6 +2027,170 @@ mod tests {
 
         assert_eq!(d.reason, "badly-slow");
         assert_eq!(d.tier, "performance");
+    }
+
+    /// Promote on a genuinely slow window, at a utilisation that is neither
+    /// capped-looking nor saturated, so the probe arms and is judged on merit.
+    fn promoted_with_probe_armed(median_ms: f64) -> AdaptiveProfileController {
+        let mut c = AdaptiveProfileController::new("balanced", PolicyConfig::for_target_fps(100.0));
+        let d = c.update(
+            readings(30.0, median_ms, MedianSource::Marker, 0.9),
+            &tiers(),
+            100.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+        assert_eq!(d.tier, "performance", "setup must promote");
+        assert!(c.state.promotion_probe.is_some(), "setup must arm the probe");
+        c
+    }
+
+    #[test]
+    fn a_promotion_that_did_not_move_the_median_is_taken_back() {
+        // A limiter holds the median at the same value whichever tier runs, so
+        // an unmoved median after the probe window says the clock was never
+        // the limit -- and the tier that was paid for it is given back.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let judged = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            107.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_eq!(judged.reason, "promotion-had-no-effect");
+        assert_eq!(judged.tier, "balanced");
+        assert!(
+            c.state.capped_reference.is_some(),
+            "the revert latches, so the ladder does not immediately re-promote"
+        );
+    }
+
+    #[test]
+    fn the_probe_is_not_judged_before_its_window_has_passed() {
+        // Judged early it would read frames still paced by the tier that was
+        // replaced, which is the one thing the delay exists to avoid.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let early = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            103.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_ne!(early.reason, "promotion-had-no-effect");
+        assert!(c.state.promotion_probe.is_some(), "the probe still stands");
+    }
+
+    #[test]
+    fn a_promotion_that_moved_the_frame_rate_is_kept() {
+        // The direction that matters most: the clock did what was predicted,
+        // so the tier stays. Reverting here would undo every promotion that
+        // worked and leave the ladder unable to hold a win at all.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let judged = c.update(
+            readings(22.0, 19.0, MedianSource::Marker, 0.4),
+            &tiers(),
+            107.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_ne!(judged.reason, "promotion-had-no-effect");
+        assert_eq!(c.state.current_tier, "performance");
+    }
+
+    #[test]
+    fn pacing_that_got_worse_is_not_evidence_against_the_promotion() {
+        // The signature being looked for is "did not move", not "did not
+        // improve". A median that got worse means the scene changed, which
+        // says nothing about the tier either way.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let judged = c.update(
+            readings(36.0, 31.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            107.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_ne!(judged.reason, "promotion-had-no-effect");
+        assert_eq!(c.state.current_tier, "performance");
+    }
+
+    #[test]
+    fn a_flat_out_card_keeps_the_promotion_it_earned() {
+        // The check reasons "the clock changed nothing, so the clock was not
+        // the limit". At saturation the clock demonstrably is the limit, so an
+        // unmoved median there is a win too small to show, not a cap.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let judged = c.update(
+            readings(30.0, 25.0, MedianSource::Marker, 0.9),
+            &tiers(),
+            107.0,
+            Some(95.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_ne!(judged.reason, "promotion-had-no-effect");
+        assert_eq!(c.state.current_tier, "performance");
+    }
+
+    #[test]
+    fn medians_from_different_streams_are_never_compared() {
+        // A game that starts reporting markers mid-session changes what the
+        // median is measured from. Comparing across that switch would read the
+        // change of instrument as a verdict on the tier.
+        let mut c = promoted_with_probe_armed(25.0);
+
+        let judged = c.update(
+            readings(30.0, 25.0, MedianSource::Pacing, 0.9),
+            &tiers(),
+            107.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_ne!(judged.reason, "promotion-had-no-effect");
+        assert_eq!(c.state.current_tier, "performance");
+    }
+
+    #[test]
+    fn without_a_median_the_promotion_stands_as_before() {
+        // Nothing to compare against is not evidence against the tier, so the
+        // probe never arms and the ladder behaves exactly as it used to.
+        let mut c = AdaptiveProfileController::new("balanced", PolicyConfig::for_target_fps(100.0));
+
+        let d = c.update(
+            FrametimeReadings {
+                p95_ms: Some(30.0),
+                p50_ms: None,
+                p50_source: MedianSource::None,
+                miss_ratio: Some(0.9),
+            },
+            &tiers(),
+            100.0,
+            Some(66.0),
+            Some(20.0),
+            Some(35.0),
+        );
+
+        assert_eq!(d.tier, "performance");
+        assert!(c.state.promotion_probe.is_none());
     }
 
     #[test]

--- a/burnerd/src/profile/adaptive.rs
+++ b/burnerd/src/profile/adaptive.rs
@@ -22,6 +22,23 @@ use super::LatencySnapshot;
 
 const CPU_BOUND_GUARD_LOG_THROTTLE_S: f64 = 30.0;
 
+/// How long a band has to hold before `windows` counts as satisfied.
+///
+/// The band counters advanced once per decision tick. That made every
+/// confirmation depend on `overlay.update_interval_s` -- a *display* setting,
+/// adjustable 1..10 s -- while the telemetry behind each reading is a fixed
+/// 3 s window. Two consequences, both wrong: raising the overlay refresh rate
+/// silently shortened every adaptive confirmation, and consecutive ticks
+/// re-read overlapping samples, so "3 windows" was never three independent
+/// observations.
+///
+/// Confirmation is elapsed time instead. The first reading in a band already
+/// carries one full window of samples, so N windows need (N-1) more windows to
+/// pass -- which is what the counters meant to express all along.
+fn confirmation_secs(windows: i64) -> f64 {
+    (windows - 1).max(0) as f64 * METER_SAMPLE_MAX_AGE_S
+}
+
 /// Which stream a median came from.
 ///
 /// Two medians reach the policy and they are not interchangeable: markers
@@ -233,9 +250,9 @@ pub struct Decision {
 struct PolicyState {
     current_tier: String,
     last_switch_monotonic: f64,
-    target_slow_count: i64,
-    near_slow_count: i64,
-    comfort_count: i64,
+    target_slow_since: Option<f64>,
+    near_slow_since: Option<f64>,
+    comfort_since: Option<f64>,
     /// Pacing observed when an external cap was first recognised.
     ///
     /// GPU utilisation cannot maintain that recognition on its own: dropping a
@@ -325,9 +342,9 @@ impl AdaptiveProfileController {
             state: PolicyState {
                 current_tier: normalize_profile_tier(initial_tier, PROFILE_TIER_BALANCED),
                 last_switch_monotonic: 0.0,
-                target_slow_count: 0,
-                near_slow_count: 0,
-                comfort_count: 0,
+                target_slow_since: None,
+                near_slow_since: None,
+                comfort_since: None,
                 capped_reference: None,
                 median_ms: None,
                 median_source: MedianSource::None,
@@ -409,6 +426,11 @@ impl AdaptiveProfileController {
         self.config.badly_slow_ms
     }
 
+    /// Seconds since the band was entered, starting the clock on first entry.
+    fn band_held_s(since: &mut Option<f64>, now_monotonic: f64) -> f64 {
+        now_monotonic - *since.get_or_insert(now_monotonic)
+    }
+
     fn snapshot_state(&self) -> PolicyState {
         self.state.clone()
     }
@@ -418,9 +440,9 @@ impl AdaptiveProfileController {
     }
 
     fn reset_counts(&mut self) {
-        self.state.target_slow_count = 0;
-        self.state.near_slow_count = 0;
-        self.state.comfort_count = 0;
+        self.state.target_slow_since = None;
+        self.state.near_slow_since = None;
+        self.state.comfort_since = None;
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -631,10 +653,10 @@ impl AdaptiveProfileController {
             );
         }
         if frametime_ms > self.config.near_slow_ms {
-            self.state.near_slow_count += 1;
-            self.state.target_slow_count = 0;
-            self.state.comfort_count = 0;
-            if self.state.near_slow_count >= self.config.near_slow_windows {
+            self.state.target_slow_since = None;
+            self.state.comfort_since = None;
+            let held_s = Self::band_held_s(&mut self.state.near_slow_since, now_monotonic);
+            if held_s >= confirmation_secs(self.config.near_slow_windows) {
                 let target = higher_tier(&self.state.current_tier, &ordered);
                 return self.switch_with_cpu_bound_guard(
                     target,
@@ -653,10 +675,10 @@ impl AdaptiveProfileController {
             };
         }
         if frametime_ms > self.config.target_ms {
-            self.state.target_slow_count += 1;
-            self.state.near_slow_count = 0;
-            self.state.comfort_count = 0;
-            if self.state.target_slow_count >= self.config.target_slow_windows {
+            self.state.near_slow_since = None;
+            self.state.comfort_since = None;
+            let held_s = Self::band_held_s(&mut self.state.target_slow_since, now_monotonic);
+            if held_s >= confirmation_secs(self.config.target_slow_windows) {
                 let target = higher_tier(&self.state.current_tier, &ordered);
                 return self.switch_with_cpu_bound_guard(
                     target,
@@ -693,9 +715,9 @@ impl AdaptiveProfileController {
     /// plainly not the limiter. Reusing one path keeps a single set of dwell
     /// and window rules rather than inventing a second, differently tuned one.
     fn ease_down(&mut self, ordered: &[String], now_monotonic: f64, reason: &str) -> Decision {
-        self.state.target_slow_count = 0;
-        self.state.near_slow_count = 0;
-        self.state.comfort_count += 1;
+        self.state.target_slow_since = None;
+        self.state.near_slow_since = None;
+        let held_s = Self::band_held_s(&mut self.state.comfort_since, now_monotonic);
         let at_performance = self.state.current_tier == PROFILE_TIER_PERFORMANCE;
         let required_windows = if at_performance {
             self.config.performance_comfort_windows
@@ -708,7 +730,7 @@ impl AdaptiveProfileController {
             self.config.demote_dwell_s
         };
         let dwell_s = now_monotonic - self.state.last_switch_monotonic;
-        if self.state.comfort_count >= required_windows && dwell_s >= required_dwell {
+        if held_s >= confirmation_secs(required_windows) && dwell_s >= required_dwell {
             let target = lower_tier(&self.state.current_tier, ordered);
             return self.switch(target, now_monotonic, reason);
         }
@@ -1267,18 +1289,36 @@ mod tests {
     }
 
     #[test]
-    fn near_slow_promotes_after_windows() {
+    fn near_slow_promotes_once_the_band_has_held_long_enough() {
         let mut c = controller();
         // target_ms 16.6, near_slow_ms 18.5. frametime 17 → target-slow band.
-        // Need target_slow_windows=3 samples to promote.
+        // target_slow_windows=3, so the band has to hold two further windows
+        // (6 s) past the reading that entered it.
         let d1 = c.update(Some(17.0), &tiers(), 1.0, None, None, None);
         assert_eq!(d1.reason, "near-slow-wait");
-        let d2 = c.update(Some(17.0), &tiers(), 2.0, None, None, None);
+        let d2 = c.update(Some(17.0), &tiers(), 4.0, None, None, None);
         assert_eq!(d2.reason, "near-slow-wait");
-        let d3 = c.update(Some(17.0), &tiers(), 3.0, None, None, None);
+        let d3 = c.update(Some(17.0), &tiers(), 7.0, None, None, None);
         assert!(d3.changed);
         assert_eq!(d3.tier, "performance");
         assert_eq!(d3.reason, "near-slow");
+    }
+
+    #[test]
+    fn confirmation_does_not_depend_on_how_often_the_loop_ticks() {
+        // The counters advanced once per decision tick, so a faster overlay
+        // refresh silently shortened every confirmation. Ticking twice as
+        // often must not promote twice as fast.
+        let mut c = controller();
+        let mut last = None;
+        for i in 0..7 {
+            last = Some(c.update(Some(17.0), &tiers(), 1.0 + i as f64 * 0.5, None, None, None));
+        }
+        assert_eq!(
+            last.expect("ticks ran").reason,
+            "near-slow-wait",
+            "3 s of frames must not satisfy a 6 s band, however many ticks it took"
+        );
     }
 
     #[test]
@@ -1502,10 +1542,16 @@ mod tests {
         // tier -- not the cap -- is now the limit.
         let mut c =
             AdaptiveProfileController::new("performance", PolicyConfig::for_target_fps(100.0));
+        // Spaced so the capped stretch actually serves the ease-down
+        // confirmation, which is elapsed time rather than a tick count.
         for i in 0..12 {
-            let t = 100.0 + i as f64 * 2.0;
+            let t = 100.0 + i as f64 * 8.0;
             c.update(Some(16.67), &tiers(), t, Some(25.0), Some(20.0), Some(35.0));
         }
+        assert_ne!(
+            c.state.current_tier, "performance",
+            "the cap must have eased the tier down before the regression"
+        );
         // Frames fall well past the capped reference: 16.67 -> 25 ms.
         let mut promoted = false;
         for i in 0..6 {
@@ -1640,11 +1686,14 @@ mod tests {
         for game_util in [70.0, 85.0, 95.0] {
             let mut c =
                 AdaptiveProfileController::new("performance", PolicyConfig::for_target_fps(100.0));
+            // Long enough in wall-clock terms to serve the idle dwell and the
+            // ease-down confirmation that follows it, both of which are now
+            // elapsed time rather than a number of ticks.
             for i in 0..40 {
                 c.update(
                     None,
                     &tiers(),
-                    100.0 + i as f64 * 2.0,
+                    1.0 + i as f64 * 5.0,
                     Some(4.0),
                     Some(5.0),
                     Some(9.0),
@@ -1739,8 +1788,8 @@ mod tests {
             );
         }
         assert!(
-            c.state.comfort_count > 0,
-            "the idle stretch must have counted ease-down windows"
+            c.state.comfort_since.is_some(),
+            "the idle stretch must have started the ease-down clock"
         );
 
         c.update(
@@ -1753,8 +1802,9 @@ mod tests {
         );
 
         assert_eq!(
-            c.state.comfort_count, 1,
-            "the game's first comfort window must be its own, not the desktop's"
+            c.state.comfort_since,
+            Some(200.0),
+            "the game's comfort clock must start at its own first tick, not the desktop's"
         );
     }
 
@@ -1815,16 +1865,18 @@ mod tests {
         assert_eq!(d.reason, "cpu-bound-performance-block");
     }
 
-    /// Scripted frametime sequence; expected (tier, changed, reason) tuples
-    /// generated by running the Python policy directly:
-    ///   python3 -c 'from runtime.gpu_control.adaptive_profile_policy import
-    ///   AdaptiveProfileController, AdaptiveProfilePolicyConfig; ...'
-    ///   → [(balanced,F,near-slow-wait),(balanced,F,near-slow-wait),
-    ///      (performance,T,near-slow),(performance,F,comfort-wait)]
+    /// Scripted frametime sequence walked end to end, as a regression net over
+    /// the whole ladder rather than one branch.
+    ///
+    /// This used to pin the sequence against a Python `AdaptiveProfileController`
+    /// run by hand. That class no longer exists -- `adaptive_profile_policy.py`
+    /// keeps only the config dataclass the spec is built from -- so the daemon
+    /// is the sole engine and the expectations are its own. The timestamps are
+    /// spaced by the telemetry window, because confirmation is elapsed time.
     #[test]
-    fn adaptive_sequence_matches_python() {
+    fn a_scripted_frametime_sequence_walks_the_ladder() {
         let mut c = controller();
-        let seq = [(17.0, 1.0), (17.0, 2.0), (17.0, 3.0), (10.0, 4.0)];
+        let seq = [(17.0, 1.0), (17.0, 4.0), (17.0, 7.0), (10.0, 10.0)];
         let expected = [
             ("balanced", false, "near-slow-wait"),
             ("balanced", false, "near-slow-wait"),
@@ -1865,13 +1917,13 @@ mod tests {
             );
         }
         assert_eq!(c.state.current_tier, "balanced");
-        assert_eq!(c.state.comfort_count, 5);
+        assert!(c.state.comfort_since.is_some());
 
         let d = c.update(None, &tiers(), 170.0, Some(70.0), None, None);
 
         assert_eq!(d.tier, "balanced");
         assert_eq!(d.reason, "no-sample");
-        assert_eq!(c.state.comfort_count, 0);
+        assert!(c.state.comfort_since.is_none());
         assert!(c.state.desktop_idle_since.is_none());
     }
 

--- a/burnerd/src/profile/latency_rx.rs
+++ b/burnerd/src/profile/latency_rx.rs
@@ -34,7 +34,6 @@ use crate::paths::{
 pub(super) const METER_SAMPLE_MAX_AGE_S: f64 = 3.0;
 const METER_MAX_SAMPLES: usize = 4096;
 const METER_MIN_PRESENT_SAMPLES: usize = 4;
-const METER_UNSEEDED_PRESENT_FPS_MAX: f64 = 70.0;
 const METER_MARKER_FPS_MAX_PRESENT_RATIO: f64 = 1.25;
 const DRIVER_REPORT_RING_SPAN: i64 = 256;
 const FRAMEGEN_CADENCE_RATIO: f64 = 1.5;
@@ -731,6 +730,7 @@ impl Meter {
                 fps_from_frametime(present_frametime_p95),
                 raw_present_avg_fps,
                 has_marker_stream(&samples),
+                explicit_framegen_active(&samples),
             );
             present_fps_value = fps_val;
             cadence_is_independent = deinterlaced;
@@ -795,26 +795,27 @@ impl Meter {
 }
 
 /// `_estimate_base_present_fps` — recover the base render FPS, dividing out a
-/// detected frame-generation multiplier only when a marker stream proves the
-/// high present rate is generated (not a genuine framerate increase). Operates on
+/// detected frame-generation multiplier only with marker or generated-frame
+/// evidence. Operates on
 /// the meter's `last_base` cell directly (disjoint from the borrowed sample view).
 fn estimate_base_present_fps(
     last_base: &mut Option<f64>,
     p95_fps: Option<f64>,
     raw_avg_fps: Option<f64>,
     marker_stream: bool,
+    framegen_active: bool,
 ) -> (Option<f64>, bool) {
     let Some(p95_fps) = p95_fps else {
         return (None, false);
     };
     let seed = *last_base;
-    if seed.is_none() && p95_fps > METER_UNSEEDED_PRESENT_FPS_MAX {
-        return (None, false);
-    }
+    // Present pacing is usable from the first window, at any framerate. A
+    // high rate alone is not evidence of generated frames. Real base-frame
+    // markers take priority in snapshot() whenever the game supplies them.
     let inferred = infer_framegen_multiplier(raw_avg_fps, seed);
     let mut base_fps = p95_fps;
     let mut deinterlaced = false;
-    if marker_stream {
+    if marker_stream || framegen_active {
         if let (Some(last), Some(raw)) = (seed, raw_avg_fps) {
             if p95_fps > last * 1.6 && raw != 0.0 {
                 if let Some(mult) = inferred {
@@ -823,6 +824,12 @@ fn estimate_base_present_fps(
                 }
             }
         }
+    }
+    // Known generated output is not a base-frame measurement. If markers are
+    // missing and the prior base cadence cannot recover it, keep it unknown
+    // instead of seeding future decisions with the displayed framerate.
+    if framegen_active && !deinterlaced {
+        return (None, false);
     }
     *last_base = Some(base_fps);
     (Some(base_fps), deinterlaced)
@@ -1565,6 +1572,158 @@ mod tests {
         assert!(approx(s.latency_p95_ms.unwrap(), 99.0));
         assert!(s.display_latency_p95_ms.is_none());
         assert_eq!(s.pid.as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn present_pacing_starts_at_any_framerate_without_a_seed() {
+        // A game's first samples are usable without first visiting a slow menu.
+        // Marker availability alone must not impose a framerate ceiling either.
+        for frametime_us in [33333, 16667, 10000, 8333, 6944, 4167, 2000] {
+            for marker_bits in [0, 64] {
+                let snapshot = snapshot_of(
+                    (0..6)
+                        .map(|_| {
+                            timing(json!({
+                                "pid": 8,
+                                "measurement": "present-pacing",
+                                "present_frametime_us": frametime_us,
+                                "marker_bits": marker_bits,
+                            }))
+                        })
+                        .collect(),
+                )
+                .unwrap();
+                assert_eq!(
+                    snapshot.base_present_frametime_p95_ms,
+                    Some(frametime_us as f64 / 1000.0),
+                    "frametime={frametime_us}, marker_bits={marker_bits}",
+                );
+                assert_eq!(snapshot.fps_source.as_deref(), Some("present-pacing"));
+                assert_eq!(snapshot.framegen_active.as_deref(), Some("false"));
+            }
+        }
+    }
+
+    #[test]
+    fn real_fps_above_target_eases_down_from_performance() {
+        use crate::profile::adaptive::{
+            AdaptiveProfileController, FrametimeReadings, MedianSource, PolicyConfig,
+        };
+
+        let tiers = vec!["efficiency".into(), "balanced".into(), "performance".into()];
+        for (target_fps, frametime_us) in [(60.0, 8333), (90.0, 5556), (144.0, 3472)] {
+            let mut meter = Meter::new();
+            let mut controller = AdaptiveProfileController::new(
+                "performance",
+                PolicyConfig::for_target_fps(target_fps),
+            );
+            let mut decision = None;
+            for tick in 0..=120 {
+                meter.samples.clear();
+                for _ in 0..6 {
+                    meter.add_sample(obj(timing(json!({
+                        "pid": 8,
+                        "measurement": "present-pacing",
+                        "present_frametime_us": frametime_us,
+                    }))));
+                }
+                let snapshot = meter.snapshot(monotonic_now(), None).unwrap();
+                let readings = FrametimeReadings {
+                    p95_ms: snapshot.base_present_frametime_p95_ms,
+                    p50_ms: snapshot.present_pacing_p50_ms,
+                    p50_source: MedianSource::Pacing,
+                    miss_ratio: None,
+                };
+                decision = Some(controller.update(
+                    readings,
+                    &tiers,
+                    100.0 + tick as f64,
+                    Some(38.0),
+                    Some(20.0),
+                    Some(35.0),
+                ));
+            }
+            assert_eq!(decision.unwrap().tier, "efficiency", "target={target_fps}");
+        }
+    }
+
+    #[test]
+    fn reflex_base_fps_wins_over_generated_output_at_startup() {
+        for base_us in [25000, 8333, 4167] {
+            let snapshot = snapshot_of(
+                (0..6)
+                    .map(|_| {
+                        timing(json!({
+                            "pid": 8,
+                            "source": NVAPI_MARKER_SOURCE,
+                            "marker_name": "simulation-start",
+                            "base_frame_frametime_us": base_us,
+                            "present_frametime_us": base_us / 2,
+                        }))
+                    })
+                    .collect(),
+            )
+            .unwrap();
+            assert_eq!(
+                snapshot.base_present_frametime_p95_ms,
+                Some(base_us as f64 / 1000.0)
+            );
+            assert_eq!(
+                snapshot.fps_source.as_deref(),
+                Some("nvapi-base-frame-marker")
+            );
+            assert_eq!(snapshot.framegen_active.as_deref(), Some("true"));
+        }
+    }
+
+    #[test]
+    fn generated_output_without_base_timing_is_not_used_as_real_fps() {
+        for frametime_us in [33333, 16667, 8333, 4167] {
+            let mut meter = Meter::new();
+            for _ in 0..6 {
+                meter.add_sample(obj(timing(json!({
+                    "pid": 8,
+                    "measurement": "present-pacing",
+                    "present_frametime_us": frametime_us,
+                    "framegen_active": true,
+                }))));
+            }
+            let snapshot = meter.snapshot(monotonic_now(), None).unwrap();
+            assert_eq!(snapshot.base_present_frametime_p95_ms, None);
+            assert_eq!(snapshot.fps_source.as_deref(), Some("none"));
+            assert_eq!(snapshot.framegen_active.as_deref(), Some("true"));
+            assert!(snapshot.raw_present_fps_avg.is_some());
+            assert_eq!(meter.last_base_present_fps, None);
+        }
+    }
+
+    #[test]
+    fn late_reflex_markers_replace_present_pacing_with_real_fps() {
+        let mut meter = Meter::new();
+        for _ in 0..6 {
+            meter.add_sample(obj(timing(json!({
+                "session_id": "700", "pid": 42,
+                "measurement": "present-pacing", "present_frametime_us": 5000,
+            }))));
+        }
+        let first = meter.snapshot(monotonic_now(), None).unwrap();
+        assert_eq!(first.base_present_frametime_p95_ms, Some(5.0));
+        for _ in 0..6 {
+            meter.add_sample(obj(timing(json!({
+                "session_id": "700", "pid": 99,
+                "source": NVAPI_MARKER_SOURCE,
+                "marker_name": "simulation-start",
+                "base_frame_frametime_us": 10000,
+            }))));
+        }
+        let second = meter.snapshot(monotonic_now(), None).unwrap();
+        assert_eq!(second.base_present_frametime_p95_ms, Some(10.0));
+        assert_eq!(
+            second.fps_source.as_deref(),
+            Some("nvapi-base-frame-marker")
+        );
+        assert_eq!(second.framegen_active.as_deref(), Some("true"));
+        assert_eq!(meter.last_base_present_fps, Some(100.0));
     }
 
     #[test]

--- a/burnerd/src/profile/latency_rx.rs
+++ b/burnerd/src/profile/latency_rx.rs
@@ -1602,6 +1602,51 @@ mod tests {
     }
 
     #[test]
+    fn generated_present_frames_do_not_veto_base_fps_promotion() {
+        use crate::profile::adaptive::{
+            AdaptiveProfileController, FrametimeReadings, MedianSource, PolicyConfig,
+        };
+
+        let mut meter = Meter::new();
+        // Seed the real 40 FPS cadence, then enable 2x frame generation.
+        for _ in 0..6 {
+            meter.add_sample(obj(timing(
+                json!({"pid": 8, "present_frametime_us": 25000, "marker_bits": 64}),
+            )));
+        }
+        meter.snapshot(monotonic_now(), None).unwrap();
+        meter.samples.clear();
+        for _ in 0..6 {
+            meter.add_sample(obj(timing(
+                json!({"pid": 8, "present_frametime_us": 12500, "marker_bits": 64}),
+            )));
+        }
+        let snapshot = meter.snapshot(monotonic_now(), Some(22000)).unwrap();
+        assert_eq!(
+            snapshot.fps_source.as_deref(),
+            Some("present-pacing-deinterlaced")
+        );
+        assert_eq!(snapshot.base_present_frametime_p95_ms, Some(25.0));
+        assert_eq!(snapshot.base_present_frametime_p50_ms, None);
+        assert_eq!(snapshot.present_pacing_p50_ms, Some(12.5));
+
+        let readings = FrametimeReadings {
+            p95_ms: snapshot.base_present_frametime_p95_ms,
+            p50_ms: snapshot.present_pacing_p50_ms,
+            p50_source: MedianSource::Pacing,
+            miss_ratio: snapshot.base_present_frametime_miss_ratio,
+        };
+        let tiers = vec!["efficiency".into(), "balanced".into(), "performance".into()];
+        let mut controller = AdaptiveProfileController::new("efficiency", PolicyConfig::default());
+        let decision =
+            controller.update(readings, &tiers, 100.0, Some(99.0), Some(20.0), Some(35.0));
+        // 80 displayed FPS must not hide a GPU-bound 40 base FPS session
+        // missing the default 60 FPS target.
+        assert_eq!(decision.tier, "performance", "{decision:?}");
+        assert_eq!(decision.reason, "badly-slow");
+    }
+
+    #[test]
     fn deinterlace_gated_on_marker_stream() {
         // Same rate jump WITHOUT a marker stream is a real framerate increase, not
         // frame generation: no deinterlace, base tracks the new rate.

--- a/burnerd/src/profile/latency_rx.rs
+++ b/burnerd/src/profile/latency_rx.rs
@@ -31,7 +31,7 @@ use crate::paths::{
 
 // --- constants (receiver.py / framegen.py) ----------------------------------
 
-const METER_SAMPLE_MAX_AGE_S: f64 = 3.0;
+pub(super) const METER_SAMPLE_MAX_AGE_S: f64 = 3.0;
 const METER_MAX_SAMPLES: usize = 4096;
 const METER_MIN_PRESENT_SAMPLES: usize = 4;
 const METER_UNSEEDED_PRESENT_FPS_MAX: f64 = 70.0;

--- a/burnerd/src/profile/latency_rx.rs
+++ b/burnerd/src/profile/latency_rx.rs
@@ -143,6 +143,11 @@ fn pid_value(value: Option<&Value>) -> Option<String> {
 // --- aggregation helpers (receiver.py) --------------------------------------
 
 /// `_p95_us(values)` — drop `<= 0`, sort, index `round((n-1)*0.95)` (banker's).
+fn quantile_index(n: usize, q: f64) -> usize {
+    let raw = round_half_even((n as f64 - 1.0) * q) as i64;
+    raw.clamp(0, n as i64 - 1) as usize
+}
+
 fn p95_us(values: &[i64]) -> Option<i64> {
     let mut v: Vec<i64> = values.iter().copied().filter(|&x| x > 0).collect();
     if v.is_empty() {
@@ -150,9 +155,48 @@ fn p95_us(values: &[i64]) -> Option<i64> {
     }
     v.sort_unstable();
     let n = v.len();
-    let raw = round_half_even((n as f64 - 1.0) * 0.95) as i64;
-    let idx = raw.clamp(0, n as i64 - 1) as usize;
-    Some(v[idx])
+    Some(v[quantile_index(n, 0.95)])
+}
+
+/// Every statistic the window offers, from one filtered copy and one sort.
+///
+/// The percentiles are order statistics of the same sample, so they share the
+/// work instead of taking a copy and a sort each; the miss count needs no
+/// ordering at all and rides along in the filtering pass.
+struct FrametimeStats {
+    p95_us: i64,
+    /// Median of the same accepted set as `p95_us`.
+    p50_us: i64,
+    /// Share of frames over the deadline, when one was supplied.
+    ///
+    /// The real-time literature calls this the deadline miss ratio: not "how
+    /// late was the worst frame" but "how much of the window blew its budget".
+    /// A tail can be one stutter; a ratio cannot.
+    miss_ratio: Option<f64>,
+}
+
+fn frametime_stats(values: &[i64], miss_deadline_us: Option<i64>) -> Option<FrametimeStats> {
+    let mut v: Vec<i64> = Vec::with_capacity(values.len());
+    let mut missed = 0usize;
+    for &value in values {
+        if value <= 0 {
+            continue;
+        }
+        if miss_deadline_us.is_some_and(|deadline| value > deadline) {
+            missed += 1;
+        }
+        v.push(value);
+    }
+    if v.is_empty() {
+        return None;
+    }
+    v.sort_unstable();
+    let n = v.len();
+    Some(FrametimeStats {
+        p95_us: v[quantile_index(n, 0.95)],
+        p50_us: v[quantile_index(n, 0.5)],
+        miss_ratio: miss_deadline_us.map(|_| missed as f64 / n as f64),
+    })
 }
 
 /// `_mean_fps` — `n * 1e6 / sum` over positive frametimes (float division).
@@ -297,6 +341,12 @@ fn has_marker_stream(samples: &[&Sample]) -> bool {
 
 struct BaseMarkerSelection {
     p95_us: i64,
+    /// Median of the *same* accepted sample set as `p95_us`, so the two are
+    /// comparable. A cap holds the median still while the tail keeps moving,
+    /// which is what makes it the honest thing to latch a cap against.
+    p50_us: i64,
+    /// Deadline miss ratio over that same set, when a deadline was supplied.
+    miss_ratio: Option<f64>,
     fps_source: &'static str,
 }
 
@@ -307,18 +357,20 @@ struct BaseMarkerSelection {
 fn select_base_marker_frametime_p95(
     samples: &[&Sample],
     raw_avg_fps: Option<f64>,
+    miss_deadline_us: Option<i64>,
 ) -> Option<BaseMarkerSelection> {
-    let valid_p95 = |frametimes: &[i64]| -> Option<i64> {
+    let valid_stats = |frametimes: &[i64]| -> Option<FrametimeStats> {
         if frametimes.len() < METER_MIN_PRESENT_SAMPLES {
             return None;
         }
-        let p95 = p95_us(frametimes)?;
-        if let (Some(marker_fps), Some(raw)) = (fps_from_frametime(Some(p95)), raw_avg_fps) {
+        let stats = frametime_stats(frametimes, miss_deadline_us)?;
+        if let (Some(marker_fps), Some(raw)) = (fps_from_frametime(Some(stats.p95_us)), raw_avg_fps)
+        {
             if marker_fps > raw * METER_MARKER_FPS_MAX_PRESENT_RATIO {
                 return None;
             }
         }
-        Some(p95)
+        Some(stats)
     };
 
     let shim_frametimes: Vec<i64> = samples
@@ -330,9 +382,11 @@ fn select_base_marker_frametime_p95(
         .map(|s| int_value(s.data.get("base_frame_frametime_us")))
         .filter(|&value| value > 0)
         .collect();
-    if let Some(p95) = valid_p95(&shim_frametimes) {
+    if let Some(stats) = valid_stats(&shim_frametimes) {
         return Some(BaseMarkerSelection {
-            p95_us: p95,
+            p95_us: stats.p95_us,
+            p50_us: stats.p50_us,
+            miss_ratio: stats.miss_ratio,
             fps_source: "nvapi-base-frame-marker",
         });
     }
@@ -358,26 +412,31 @@ fn select_base_marker_frametime_p95(
 
     for name in BASE_FRAME_MARKER_PRIORITY {
         if let Some(list) = marker_frametimes.get(name) {
-            if let Some(p95) = valid_p95(list) {
+            if let Some(stats) = valid_stats(list) {
                 return Some(BaseMarkerSelection {
-                    p95_us: p95,
+                    p95_us: stats.p95_us,
+                    p50_us: stats.p50_us,
+                    miss_ratio: stats.miss_ratio,
                     fps_source: "base-frame-marker",
                 });
             }
         }
     }
 
-    let mut eligible: Vec<(String, usize, i64)> = marker_frametimes
+    let mut eligible: Vec<(String, usize, FrametimeStats)> = marker_frametimes
         .iter()
-        .filter_map(|(name, fts)| valid_p95(fts).map(|p95| (name.clone(), fts.len(), p95)))
+        .filter_map(|(name, fts)| valid_stats(fts).map(|stats| (name.clone(), fts.len(), stats)))
         .collect();
     if eligible.is_empty() {
         return None;
     }
     // sort by (-len, name): most samples first, name ascending as tie-break.
     eligible.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let best = &eligible[0].2;
     Some(BaseMarkerSelection {
-        p95_us: eligible[0].2,
+        p95_us: best.p95_us,
+        p50_us: best.p50_us,
+        miss_ratio: best.miss_ratio,
         fps_source: "base-frame-marker",
     })
 }
@@ -610,7 +669,7 @@ impl Meter {
 
     /// `snapshot(now)` — the fresh-window aggregation the engine consumes. `None`
     /// when there are no samples within `METER_SAMPLE_MAX_AGE_S` of `now`.
-    fn snapshot(&mut self, now: f64) -> Option<LatencySnapshot> {
+    fn snapshot(&mut self, now: f64, miss_deadline_us: Option<i64>) -> Option<LatencySnapshot> {
         if self.samples.is_empty() {
             return None;
         }
@@ -645,13 +704,23 @@ impl Meter {
             "n/a".to_string()
         };
 
-        let marker_selection = select_base_marker_frametime_p95(&samples, raw_present_avg_fps);
+        let marker_selection =
+            select_base_marker_frametime_p95(&samples, raw_present_avg_fps, miss_deadline_us);
+        // The presented-frame median, kept whatever the marker path decided:
+        // it is the only median a game without markers can offer.
+        let present_pacing_p50_us = frametime_stats(&present_frametimes, None).map(|s| s.p50_us);
         let base_present_frametime_p95_us;
+        // Only reported when they come off the same accepted marker set as the
+        // p95; the present-pacing fallback has no comparable set.
+        let mut base_present_frametime_p50_us = None;
+        let mut base_present_frametime_miss_ratio = None;
         let present_fps_value;
         let cadence_is_independent;
         let fps_source;
         if let Some(marker) = marker_selection {
             base_present_frametime_p95_us = Some(marker.p95_us);
+            base_present_frametime_p50_us = Some(marker.p50_us);
+            base_present_frametime_miss_ratio = marker.miss_ratio;
             present_fps_value = fps_from_frametime(Some(marker.p95_us));
             self.last_base_present_fps = present_fps_value;
             cadence_is_independent = true;
@@ -709,6 +778,9 @@ impl Meter {
 
         Some(LatencySnapshot {
             base_present_frametime_p95_ms: base_present_frametime_p95_us.map(|v| v as f64 / 1000.0),
+            base_present_frametime_p50_ms: base_present_frametime_p50_us.map(|v| v as f64 / 1000.0),
+            present_pacing_p50_ms: present_pacing_p50_us.map(|v| v as f64 / 1000.0),
+            base_present_frametime_miss_ratio,
             present_fps: Some(format_fps_value(present_fps_value)),
             fps_source: Some(fps_source.to_string()),
             raw_present_fps_stats_avg: Some(raw_present_fps_stats_avg),
@@ -937,12 +1009,16 @@ impl LatencyReceiver {
     }
 
     /// `latency_meter.snapshot(now=loop_started)` — aggregate the current window.
-    pub(super) fn snapshot(&self, now: f64) -> Option<LatencySnapshot> {
+    pub(super) fn snapshot(
+        &self,
+        now: f64,
+        miss_deadline_us: Option<i64>,
+    ) -> Option<LatencySnapshot> {
         let mut meter = self
             .meter
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        meter.snapshot(now)
+        meter.snapshot(now, miss_deadline_us)
     }
 
     fn close(&mut self) {
@@ -1114,7 +1190,7 @@ mod tests {
         for s in samples {
             meter.add_sample(obj(s));
         }
-        meter.snapshot(monotonic_now())
+        meter.snapshot(monotonic_now(), None)
     }
 
     fn timing(extra: Value) -> Value {
@@ -1209,14 +1285,14 @@ mod tests {
         }
         let received = meter.samples.back().unwrap().received_monotonic;
         // 4s past the newest sample → outside the 3s window.
-        assert!(meter.snapshot(received + 4.0).is_none());
+        assert!(meter.snapshot(received + 4.0, None).is_none());
         // Still fresh at receipt time.
-        assert!(meter.snapshot(received).is_some());
+        assert!(meter.snapshot(received, None).is_some());
     }
 
     #[test]
     fn empty_meter_snapshot_none() {
-        assert!(Meter::new().snapshot(monotonic_now()).is_none());
+        assert!(Meter::new().snapshot(monotonic_now(), None).is_none());
     }
 
     #[test]
@@ -1236,7 +1312,7 @@ mod tests {
         }
 
         assert_eq!(meter.samples.len(), 4);
-        let snapshot = meter.snapshot(monotonic_now()).unwrap();
+        let snapshot = meter.snapshot(monotonic_now(), None).unwrap();
         assert_eq!(snapshot.pid.as_deref(), Some("111"));
         assert_eq!(snapshot.present_fps.as_deref(), Some("60"));
     }
@@ -1261,7 +1337,7 @@ mod tests {
             }))));
         }
 
-        let snapshot = meter.snapshot(monotonic_now()).unwrap();
+        let snapshot = meter.snapshot(monotonic_now(), None).unwrap();
         assert_eq!(meter.samples.len(), 12);
         assert_eq!(snapshot.session_id.as_deref(), Some("700"));
         assert_eq!(snapshot.pid.as_deref(), Some("219896"));
@@ -1484,7 +1560,7 @@ mod tests {
         }
         // 6 present samples + exactly 1 retained driver report.
         assert_eq!(meter.samples.len(), 7);
-        let s = meter.snapshot(monotonic_now()).unwrap();
+        let s = meter.snapshot(monotonic_now(), None).unwrap();
         assert!(approx(s.base_present_frametime_p95_ms.unwrap(), 16.6));
         assert!(approx(s.latency_p95_ms.unwrap(), 99.0));
         assert!(s.display_latency_p95_ms.is_none());
@@ -1500,7 +1576,7 @@ mod tests {
                 json!({"pid": 8, "present_frametime_us": 20000, "marker_bits": 64}),
             )));
         }
-        let w1 = meter.snapshot(monotonic_now()).unwrap();
+        let w1 = meter.snapshot(monotonic_now(), None).unwrap();
         assert!(approx(w1.base_present_frametime_p95_ms.unwrap(), 20.0));
         assert_eq!(w1.fps_source.as_deref(), Some("present-pacing"));
         assert_eq!(w1.framegen_active.as_deref(), Some("false"));
@@ -1513,7 +1589,7 @@ mod tests {
                 json!({"pid": 8, "present_frametime_us": 10000, "marker_bits": 64}),
             )));
         }
-        let w2 = meter.snapshot(monotonic_now()).unwrap();
+        let w2 = meter.snapshot(monotonic_now(), None).unwrap();
         assert!(approx(w2.base_present_frametime_p95_ms.unwrap(), 20.0));
         assert_eq!(w2.present_fps.as_deref(), Some("50"));
         assert_eq!(
@@ -1535,14 +1611,14 @@ mod tests {
                 json!({"pid": 9, "present_frametime_us": 20000}),
             )));
         }
-        meter.snapshot(monotonic_now());
+        meter.snapshot(monotonic_now(), None);
         meter.samples.clear();
         for _ in 0..6 {
             meter.add_sample(obj(timing(
                 json!({"pid": 9, "present_frametime_us": 10000}),
             )));
         }
-        let w2 = meter.snapshot(monotonic_now()).unwrap();
+        let w2 = meter.snapshot(monotonic_now(), None).unwrap();
         assert_eq!(w2.fps_source.as_deref(), Some("present-pacing"));
         assert_eq!(w2.framegen_active.as_deref(), Some("false"));
         assert!(approx(w2.base_present_frametime_p95_ms.unwrap(), 10.0));
@@ -1565,7 +1641,7 @@ mod tests {
                 json!({"pid": "12345", "present_frametime_us": 16667}),
             )));
         }
-        let s = meter.snapshot(monotonic_now()).unwrap();
+        let s = meter.snapshot(monotonic_now(), None).unwrap();
         assert_eq!(s.pid.as_deref(), Some("12345"));
         assert!(approx(s.base_present_frametime_p95_ms.unwrap(), 16.667));
     }
@@ -1611,7 +1687,7 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(3);
         let mut got = None;
         while Instant::now() < deadline {
-            if let Some(snap) = receiver.snapshot(monotonic_now()) {
+            if let Some(snap) = receiver.snapshot(monotonic_now(), None) {
                 if snap.present_fps.as_deref() == Some("60") {
                     got = Some(snap);
                     break;

--- a/burnerd/src/profile/logfmt.rs
+++ b/burnerd/src/profile/logfmt.rs
@@ -387,7 +387,12 @@ mod tests {
     #[test]
     fn tier_switch_line_carries_the_inputs_in_its_last_field() {
         assert_eq!(
-            tier_switch_line("Performance", "Balanced", "externally-capped", &sample_inputs()),
+            tier_switch_line(
+                "Performance",
+                "Balanced",
+                "externally-capped",
+                &sample_inputs()
+            ),
             "tier   | Performance → Balanced | externally-capped | \
              p95=16.7ms p50=16.7ms(marker) miss=42% gpu=76% cpu=8% peak=19% \
              cap-latch=16.7ms(marker)"

--- a/burnerd/src/profile/logfmt.rs
+++ b/burnerd/src/profile/logfmt.rs
@@ -127,13 +127,87 @@ pub fn status_signature(
     }
 }
 
-pub fn tier_switch_line(from_tier: &str, to_tier: &str, reason: &str) -> String {
+/// The measurements a tier decision was taken on.
+///
+/// A reason names the branch that fired; it does not say what the branch saw.
+/// Several of these are windowed or compared against a latch held only in
+/// memory, so once the tick is over nothing on disk can reconstruct them, and a
+/// switching pattern cannot be told apart from a policy bug after the fact.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DecisionInputs {
+    /// p95 of the base present frametime -- what the policy actually judges.
+    pub present_frametime_p95_ms: Option<f64>,
+    /// Median of the same set. Recorded but not judged: it is what separates a
+    /// genuinely slower GPU (median rises with the tail) from a hitch inside
+    /// the window (median holds, tail blows out), which a p95 alone cannot say.
+    pub present_frametime_p50_ms: Option<f64>,
+    /// Which stream supplied that median, or `None` when none did. The latch
+    /// compares medians across ticks, so a switch of source is itself a reason
+    /// a comparison can change without the frame rate changing.
+    pub median_source: &'static str,
+    /// Share of the window past the badly-slow bar -- the quantity the
+    /// weakly-hard (m,k) models bound. Recorded, never judged.
+    pub present_frametime_miss_ratio: Option<f64>,
+    /// Windowed GPU utilisation, which is what the cap branches read. Not the
+    /// instantaneous figure the status line prints.
+    pub windowed_gpu_util_pct: Option<f64>,
+    pub cpu_util_pct: Option<f64>,
+    pub cpu_peak_thread_pct: Option<f64>,
+    /// Pacing an external cap was recognised at, while that latch is held.
+    pub capped_reference_ms: Option<f64>,
+    /// Which median the latch was taken against, so a held cap can be read for
+    /// what it was judged against.
+    pub capped_reference_source: &'static str,
+}
+
+/// Render the inputs as `key=value` pairs for the tier line's last field.
+pub fn decision_inputs(inputs: &DecisionInputs) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(ms) = inputs.present_frametime_p95_ms {
+        parts.push(format!("p95={ms:.1}ms"));
+    }
+    // Beside the p95 rather than instead of it: the pair is the signal. A
+    // spread of roughly 1.0 means the whole distribution moved, which clock can
+    // answer; a wide one means a few long frames did, which it cannot.
+    if let Some(ms) = inputs.present_frametime_p50_ms {
+        parts.push(format!("p50={ms:.1}ms({})", inputs.median_source));
+    }
+    // How much of the window blew the budget, beside how bad the worst of it
+    // was. A single hitch and a scene that is slow throughout can print the
+    // same p95; they cannot print the same miss ratio.
+    if let Some(ratio) = inputs.present_frametime_miss_ratio {
+        parts.push(format!("miss={:.0}%", ratio * 100.0));
+    }
+    if let Some(gpu) = inputs.windowed_gpu_util_pct {
+        parts.push(format!("gpu={gpu:.0}%"));
+    }
+    if let Some(cpu) = inputs.cpu_util_pct {
+        parts.push(format!("cpu={cpu:.0}%"));
+    }
+    if let Some(peak) = inputs.cpu_peak_thread_pct {
+        parts.push(format!("peak={peak:.0}%"));
+    }
+    // Always stated, including when off: "no latch" is the fact that explains
+    // why a capped rate took the slow ladder instead of the cap branch.
+    parts.push(match inputs.capped_reference_ms {
+        Some(ms) => format!("cap-latch={ms:.1}ms({})", inputs.capped_reference_source),
+        None => "cap-latch=off".to_string(),
+    });
+    parts.join(" ")
+}
+
+pub fn tier_switch_line(
+    from_tier: &str,
+    to_tier: &str,
+    reason: &str,
+    inputs: &DecisionInputs,
+) -> String {
     format_log_line(
         "tier",
         &[
             Some(format!("{from_tier} → {to_tier}")),
             Some(reason.to_string()),
-            Some(String::new()),
+            Some(decision_inputs(inputs)),
         ],
     )
 }
@@ -262,5 +336,61 @@ mod tests {
     #[test]
     fn single_line_flattens() {
         assert_eq!(single_line_text("a\n\n  b  \nc"), "a | b | c");
+    }
+
+    fn sample_inputs() -> DecisionInputs {
+        DecisionInputs {
+            present_frametime_p95_ms: Some(16.72),
+            present_frametime_p50_ms: Some(16.68),
+            median_source: "marker",
+            present_frametime_miss_ratio: Some(0.42),
+            windowed_gpu_util_pct: Some(76.4),
+            cpu_util_pct: Some(8.2),
+            cpu_peak_thread_pct: Some(18.9),
+            capped_reference_ms: Some(16.7),
+            capped_reference_source: "marker",
+        }
+    }
+
+    #[test]
+    fn decision_inputs_render_every_measurement_the_policy_read() {
+        assert_eq!(
+            decision_inputs(&sample_inputs()),
+            "p95=16.7ms p50=16.7ms(marker) miss=42% gpu=76% cpu=8% peak=19% \
+             cap-latch=16.7ms(marker)"
+        );
+    }
+
+    #[test]
+    fn a_released_latch_is_stated_rather_than_omitted() {
+        // "off" is the fact that explains a capped rate taking the slow ladder,
+        // so it has to survive the empty-section drop that eats the others.
+        let inputs = DecisionInputs {
+            capped_reference_ms: None,
+            capped_reference_source: "off",
+            ..DecisionInputs::default()
+        };
+        assert_eq!(decision_inputs(&inputs), "cap-latch=off");
+    }
+
+    #[test]
+    fn a_median_carries_the_stream_it_came_from() {
+        // Marker and pacing medians are not the same measurement; a latch that
+        // compares across a source change compares two different things.
+        let pacing = DecisionInputs {
+            median_source: "pacing",
+            ..sample_inputs()
+        };
+        assert!(decision_inputs(&pacing).contains("p50=16.7ms(pacing)"));
+    }
+
+    #[test]
+    fn tier_switch_line_carries_the_inputs_in_its_last_field() {
+        assert_eq!(
+            tier_switch_line("Performance", "Balanced", "externally-capped", &sample_inputs()),
+            "tier   | Performance → Balanced | externally-capped | \
+             p95=16.7ms p50=16.7ms(marker) miss=42% gpu=76% cpu=8% peak=19% \
+             cap-latch=16.7ms(marker)"
+        );
     }
 }

--- a/burnerd/src/profile/mod.rs
+++ b/burnerd/src/profile/mod.rs
@@ -86,6 +86,18 @@ pub(crate) fn floor_div(a: i64, b: i64) -> i64 {
 #[derive(Debug, Clone, Default)]
 pub struct LatencySnapshot {
     pub base_present_frametime_p95_ms: Option<f64>,
+    /// Median of the same accepted marker set as the p95 above, so the two are
+    /// comparable. Only present when a marker stream supplied the p95 -- the
+    /// present-pacing fallback derives its p95 from a smoothed FPS estimate,
+    /// not from a set this could be a median of.
+    pub base_present_frametime_p50_ms: Option<f64>,
+    /// Median of the presented frames themselves. Not comparable with the p95
+    /// above, so it is kept apart and used only where a median is compared
+    /// with another median -- which is most games, since most have no markers.
+    pub present_pacing_p50_ms: Option<f64>,
+    /// Share of the marker window that missed the deadline. Reported only off
+    /// the same accepted set as the p95, for the same reason as the median.
+    pub base_present_frametime_miss_ratio: Option<f64>,
     pub present_fps: Option<String>,
     pub fps_source: Option<String>,
     pub raw_present_fps_stats_avg: Option<String>,
@@ -797,7 +809,12 @@ fn run_fan_control_loop(
 
         // Aggregate the current in-game telemetry window (None when no receiver /
         // no fresh samples). Owned here; adaptive + overlay borrow it this tick.
-        let latency_owned = latency_receiver.and_then(|rx| rx.snapshot(loop_started));
+        // The deadline the frametime window counts misses against comes from
+        // the adaptive target, so the ratio means "share of the window that
+        // blew its budget" rather than an arbitrary bar.
+        let miss_deadline_us = adaptive_ctrl.as_deref().map(|c| c.miss_deadline_us());
+        let latency_owned =
+            latency_receiver.and_then(|rx| rx.snapshot(loop_started, miss_deadline_us));
         let latency_snapshot: Option<&LatencySnapshot> = latency_owned.as_ref();
 
         // Adaptive update — BEFORE the fan decision, same iteration. A tier

--- a/docs/features/adaptive-uv.md
+++ b/docs/features/adaptive-uv.md
@@ -59,6 +59,13 @@ With frame generation enabled, promotion still follows the base render rate.
 The median of displayed frames can include generated frames, so it is used
 only for comparisons with the same measurement over time.
 
+Reflex/NVAPI base-frame markers take priority when available. Otherwise,
+Adaptive uses measured present-frame pacing from the first complete sample
+window, at any framerate. A high FPS reading alone does not mean frame
+generation is active and does not prevent Adaptive from stepping down.
+If telemetry explicitly reports generated frames, Adaptive requires base-frame
+timing or a recoverable base cadence before using that output as real FPS.
+
 The target defaults to **60 FPS**. Override it for the service through the
 environment variable (30, 50, 60, 120, etc.):
 

--- a/docs/features/adaptive-uv.md
+++ b/docs/features/adaptive-uv.md
@@ -55,6 +55,10 @@ target FPS. When frames are comfortably ahead of target it shifts toward a more
 efficient tier (less power, quieter); when pacing falls behind it shifts toward
 a higher tier to protect frame rate.
 
+With frame generation enabled, promotion still follows the base render rate.
+The median of displayed frames can include generated frames, so it is used
+only for comparisons with the same measurement over time.
+
 The target defaults to **60 FPS**. Override it for the service through the
 environment variable (30, 50, 60, 120, etc.):
 
@@ -110,6 +114,10 @@ a quiet stretch discard the utilisation window and every counter the previous
 session accumulated — without that, the desktop's near-zero readings made the
 first seconds of a launch look "capped" and held the low tier exactly when the
 game needed a promotion.
+
+Pending checks of whether a promotion improved pacing are discarded when
+frame telemetry stops or the system resumes. A later session's frame rate
+cannot establish whether an earlier promotion helped.
 
 ## When nothing is being played
 


### PR DESCRIPTION
## The problem

#61 taught the ladder to recognise an external frame cap, but the recognition is tested against the tail and a promotion is never checked. Under vsync or a limiter the frametime sits at the cap whichever tier runs, so the p95 wanders with every hitch while the median does not move — the latch releases on a cap that never lifted, and the releasing tick falls straight into the branch that jumps a tier. A promotion that changed nothing is then simply made again, and each one rewrites the V/F curve on a live card.

Measured on an RTX 5070 Ti: the ladder climbed back to the top tier **52 times in one session, spending 93% of its time there**, while the card sat at 61-66% utilisation and the median never moved off 16.6 ms.

## The commits

- **`6436b1a`** — latch the cap on the median rather than the tail, remembering which stream it came from, and release it when that stream stops reporting. The single-window jump to the top tier now asks for a miss ratio: across two titles these split cleanly at 12-44% while leaving a capped menu against 98-100% when genuinely slow.
- **`7258131`** — judge a promotion by whether it moved the frame rate. It arms a probe with the median it was made at and reads that median back one window later; unchanged means the clock was never the limit. A flat-out card is exempt, both sides must come from the same stream, and only "did not move" counts — a promotion that worked is kept.
- **`e2f8e05`** — confirm bands on elapsed time, not tick count. The counters advanced once per decision tick, so every confirmation depended on `overlay.update_interval_s`, a *display* setting adjustable 1..10 s, while the telemetry behind each reading is a fixed 3 s window.
- **`da27b93`** — log what a decision was taken on. A reason names the branch that fired, not what it saw, and windowed averages and in-memory latch state cannot be reconstructed once the tick is over.

## Live validation

RTX 5070 Ti, real game session, daemon built from this branch:

```
10:44:15  telemetry                             2970MHz  990mV  113W  ceiling 2980
10:44:21  tier | Performance → Balanced  | externally-capped-held  | p95=17.0ms p50=16.6ms(marker) miss=100% gpu=51% cpu=7% peak=18% cap-latch=16.6ms(marker)
10:44:25  telemetry                             2820MHz  890mV   99W  ceiling 2835

          ... 60 s demote dwell, no further decisions ...

10:45:21  tier | Balanced → Efficiency   | externally-capped-held  | p95=17.0ms p50=16.6ms(marker) miss=100% gpu=52% cpu=7% peak=17% cap-latch=16.6ms(marker)
10:45:23  telemetry                             2715MHz  860mV   95W  ceiling 2760

10:45:35  telemetry                             2685MHz  860mV  128W  ceiling 2760   ← load arrives
10:45:37  tier | Efficiency → Performance | badly-slow             | p95=23.4ms p50=22.5ms(marker) miss=99%  gpu=63% cpu=9% peak=18% cap-latch=off
10:45:39  telemetry                             2962MHz  990mV  158W  ceiling 2980
10:45:45  telemetry                             2962MHz  990mV  163W  ceiling 2980
```

The game ran at 100 FPS, dropped to a 60 FPS cap at 10:00:35, and **10:00:41 is the probe firing** — six seconds after that promotion the median is still 16.6 ms with the card at 53%, so the tier is handed back. That is the case that used to produce the 52 climbs. The two ease-downs are exactly 60 s apart (the demote dwell) and the second measurably took effect: ceiling 2835 → 2760 MHz, 890 → 860 mV, 99 → 95 W at the same frame rate.

`miss=100%` is not an anomaly — the adaptive target sits above the game's cap, so at 60 FPS every frame reads as late. That is exactly when chasing the frame rate is pointless.

## One correction

I had suspected this oscillation of causing in-game freezes. **That was wrong.** With the decision inputs in the journal, a freeze was captured with the engine having made *zero* decisions — no `tier` line, ceiling untouched. The kernel log showed the cause: `sched_ext: BPF scheduler "lavd_1.1.3" disabled (runnable task stall)`. Switching to `scx_flash` ended it. These commits fix oscillation and wasted power, **not** freezes.

## Checks

`cargo test` 322 + 53 green, `clippy --all-targets` clean, 21 new tests with each mechanism mutation-checked — which closed two real gaps, including a probe that passed with the absolute value removed because the suite covered pacing that got *worse* but not pacing that *improved*.

Not run: the Python suite (no pytest here). The spec contract files are unchanged from `main`, so the pinned defaults cannot have drifted, but that is an argument rather than a green run.