### PR TITLE
Compare profile power with factory limits

### DIFF
--- a/docs/features/profile-management.md
+++ b/docs/features/profile-management.md
@@ -14,6 +14,13 @@ FPS, Power W, and Memory offset. Sort by any column to compare runs. Verified
 profiles retain the GPU name, UUID, and PCI identity from verification, so a
 saved curve cannot silently move to another card if driver indices change.
 
+Power shows measured watts and the percentage difference from that GPU's
+factory/default power limit, with lower values in green. This is a comparison
+with the power cap, not measured stock power savings. If the matching GPU or its
+default limit is unavailable, only watts are shown. Other metrics show absolute
+values; their tooltips retain each scan's baseline comparison. Those baselines
+can differ with power and memory settings and do not compare profiles or tiers.
+
 ## Actions
 
 Top bar:

--- a/tests/test_auto_uv_profiles.py
+++ b/tests/test_auto_uv_profiles.py
@@ -227,7 +227,7 @@ def test_profile_table_headers_and_sorting_scope() -> None:
     assert ProfileList.COLUMNS[4] == "Target MHz"
     assert ProfileList.COLUMNS[5] == "Effective MHz"
     assert ProfileList.COLUMNS[6] == "FPS/W"
-    assert ProfileList.COLUMNS[8] == "Power W (vs stock limit)"
+    assert ProfileList.COLUMNS[8] == "Power W"
     assert ProfileList.COLUMNS[9] == "Mem"
     assert ProfileList.COLUMNS[10] == "Tier"
     assert "Autostart" not in ProfileList.COLUMNS

--- a/tests/test_auto_uv_profiles.py
+++ b/tests/test_auto_uv_profiles.py
@@ -97,10 +97,9 @@ from ui.components.profile_list import (
     PROFILE_SORTABLE_COLUMNS,
     ProfileList,
     _format_number,
-    _format_profile_metric_with_delta,
     _metric_delta_percent,
     _profile_base_metric,
-    _profile_metric_delta_color,
+    _profile_metric_tooltip,
     _profile_sort_values,
     _profile_source_label,
     _profile_tier_label,
@@ -205,44 +204,21 @@ def test_profile_summary_keeps_base_metrics_for_profile_table_delta() -> None:
     assert summary["base_efficiency_fps_per_w"] == 0.50
 
 
-def test_profile_metric_delta_text_and_color_vs_base() -> None:
+def test_profile_metric_tooltip_identifies_its_scan_baseline() -> None:
     assert _metric_delta_percent(0.75, 0.50) == 50.0
-    assert _format_profile_metric_with_delta(0.75, 0.50, precision=2) == (
-        "0.75 (+50.00%)"
+    assert _profile_metric_tooltip(240.0, 300.0, label="Power W") == (
+        "Power W: 240.00\n"
+        "-20.00% vs this scan's baseline: 300.00.\n"
+        "Baselines differ between scans; these percentages do not compare profiles."
     )
-    assert _profile_metric_delta_color(0.75, 0.50) == "#55d27a"
-    assert _format_profile_metric_with_delta(67.161, 64.228, precision=2) == (
-        "67.16 (+4.57%)"
+    assert "+4.57% vs this scan's baseline: 64.23" in _profile_metric_tooltip(
+        67.161, 64.228, label="FPS"
     )
-
-    assert (
-        _format_profile_metric_with_delta(
-            875,
-            1000,
-            precision=0,
-            lower_is_better=True,
-        )
-        == "875 (-12.50%)"
+    assert "baseline: 0.2043" in _profile_metric_tooltip(
+        0.242340, 0.204326, label="FPS/W", precision=4
     )
-    assert (
-        _format_profile_metric_with_delta(
-            2600.0,
-            2650.0,
-            precision=2,
-        )
-        == "2600.00 (-1.89%)"
-    )
-    assert (
-        _format_profile_metric_with_delta(
-            240.0,
-            300.0,
-            precision=2,
-            lower_is_better=True,
-        )
-        == "240.00 (-20.00%)"
-    )
-    assert _profile_metric_delta_color(240.0, 300.0, lower_is_better=True) == "#55d27a"
-    assert _profile_metric_delta_color(330.0, 300.0, lower_is_better=True) == "#ff6b6b"
+    for current, baseline in ((None, 300), (240, None), (240, 0)):
+        assert _profile_metric_tooltip(current, baseline, label="Power W") == ""
 
 
 def test_profile_table_headers_and_sorting_scope() -> None:
@@ -251,7 +227,7 @@ def test_profile_table_headers_and_sorting_scope() -> None:
     assert ProfileList.COLUMNS[4] == "Target MHz"
     assert ProfileList.COLUMNS[5] == "Effective MHz"
     assert ProfileList.COLUMNS[6] == "FPS/W"
-    assert ProfileList.COLUMNS[8] == "Power W"
+    assert ProfileList.COLUMNS[8] == "Power W (vs stock limit)"
     assert ProfileList.COLUMNS[9] == "Mem"
     assert ProfileList.COLUMNS[10] == "Tier"
     assert "Autostart" not in ProfileList.COLUMNS
@@ -406,7 +382,7 @@ def test_profile_non_sort_columns_have_no_sort_keys() -> None:
     assert sort_values[11] == ""
 
 
-def test_profile_table_keeps_regular_font_for_highlight_and_deltas() -> None:
+def test_profile_table_keeps_plain_metrics_and_regular_font_for_highlight() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6")
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -443,20 +419,20 @@ def test_profile_table_keeps_regular_font_for_highlight_and_deltas() -> None:
 
     assert (
         profile_list.table.item(0, profile_list.VOLTAGE_COLUMN).text()
-        == "875 (-12.50%)"
+        == "875"
     )
     assert (
         profile_list.table.item(0, profile_list.EFFECTIVE_MHZ_COLUMN).text()
-        == "2605.25 (-1.69%)"
+        == "2605.25"
     )
     assert profile_list.table.item(0, profile_list.FPSW_COLUMN).text() == (
-        "0.80 (+60.00%)"
+        "0.8000"
     )
     assert profile_list.table.item(0, profile_list.FPS_COLUMN).text() == (
-        "160.00 (+6.67%)"
+        "160.00"
     )
     assert profile_list.table.item(0, profile_list.POWER_COLUMN).text() == (
-        "200.00 (-20.00%)"
+        "200.00"
     )
     # The stored offset is an NVML transfer-rate value (MT/s); the table shows
     # the realized memory clock in MHz (half of it) with a unit suffix.
@@ -467,9 +443,10 @@ def test_profile_table_keeps_regular_font_for_highlight_and_deltas() -> None:
         item = profile_list.table.item(0, column)
         assert item is not None
         assert not item.font().bold()
+        assert item.foreground().style() == QtCore.Qt.BrushStyle.NoBrush
 
 
-def test_profile_table_recalculates_relative_text_and_colors_from_long_values() -> None:
+def test_profile_table_keeps_scan_deltas_in_tooltips_and_sorts_absolute_values() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6")
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -494,26 +471,64 @@ def test_profile_table_recalculates_relative_text_and_colors_from_long_values() 
 
     expected = {
         profile_list.EFFECTIVE_MHZ_COLUMN: (
-            "2888.06 (+5.27%)",
-            "#55d27a",
+            "2888.06",
+            "+5.27%",
         ),
         profile_list.FPSW_COLUMN: (
-            "0.21 (+15.51%)",
-            "#55d27a",
+            "0.2118",
+            "+15.51%",
         ),
         profile_list.FPS_COLUMN: (
-            "67.16 (+4.57%)",
-            "#55d27a",
-        ),
-        profile_list.POWER_COLUMN: (
-            "317.10 (-9.47%)",
-            "#55d27a",
+            "67.16",
+            "+4.57%",
         ),
     }
-    for column, (text, color) in expected.items():
+    for column, (text, delta) in expected.items():
         item = profile_list.table.item(0, column)
         assert item.text() == text
-        assert item.foreground().color().name() == color
+        assert delta in item.toolTip()
+        assert "vs this scan's baseline:" in item.toolTip()
+        assert item.foreground().style() == QtCore.Qt.BrushStyle.NoBrush
+    power_item = profile_list.table.item(0, profile_list.POWER_COLUMN)
+    assert power_item.text() == "317.10"
+    assert "unavailable" in power_item.toolTip()
+    profile_list.set_profiles(
+        [
+            {
+                "profile_id": "efficiency",
+                "gpu_identity": {"uuid": "GPU-A"},
+                "avg_power_w": 247.895,
+                "base_avg_power_w": 300.129,
+                "avg_fps": 60.075,
+                "base_avg_fps": 61.324,
+            },
+            {
+                "profile_id": "balanced",
+                "gpu_identity": {"uuid": "GPU-A"},
+                "avg_power_w": 252.228,
+                "base_avg_power_w": 354.089,
+                "avg_fps": 61.933,
+                "base_avg_fps": 63.018,
+            },
+        ],
+        default_power_limits_w={"gpu-a": 360.0},
+    )
+    profile_list.table.sortItems(
+        profile_list.POWER_COLUMN, QtCore.Qt.SortOrder.AscendingOrder
+    )
+    power_items = [profile_list.table.item(row, profile_list.POWER_COLUMN) for row in range(2)]
+    assert [item.text() for item in power_items] == ["247.90 (-31.14%)", "252.23 (-29.94%)"]
+    for item in power_items:
+        assert "factory/default power limit (360.00 W)" in item.toolTip()
+        assert "not measured stock power savings" in item.toolTip()
+        assert "scan's baseline" not in item.toolTip()
+        assert item.foreground().color().name() == "#55d27a"
+    profile_list.table.sortItems(
+        profile_list.FPS_COLUMN, QtCore.Qt.SortOrder.DescendingOrder
+    )
+    assert [
+        profile_list.table.item(row, profile_list.FPS_COLUMN).text() for row in range(2)
+    ] == ["61.93", "60.08"]
 
 
 def test_profile_table_defaults_to_newest_date_first() -> None:

--- a/tests/test_ui_gpu_and_tuning.py
+++ b/tests/test_ui_gpu_and_tuning.py
@@ -83,28 +83,31 @@ def test_gpu_choices_from_nvml_identities_skips_bad_rows_and_dupes() -> None:
     assert choices[1].pci_bus_id == ""
 
 
-def test_detected_gpu_choices_empty_without_nvml_identities(monkeypatch) -> None:
+def test_detected_gpu_choices_empty_without_daemon_capabilities(monkeypatch) -> None:
     monkeypatch.setattr(
-        gpu_selection.DaemonGpuClient, "discover_identities", lambda: []
+        gpu_selection.DaemonGpuClient, "discover_capabilities", lambda: []
     )
     assert gpu_selection.detected_gpu_choices() == []
 
 
-def test_detected_gpu_choices_reads_nvml_identities(monkeypatch) -> None:
+def test_detected_gpu_choices_keeps_default_power_with_gpu_identity(monkeypatch) -> None:
     monkeypatch.setattr(
         gpu_selection.DaemonGpuClient,
-        "discover_identities",
+        "discover_capabilities",
         lambda: [
             SimpleNamespace(
-                index=2,
-                name="RTX 5090",
-                pci_bus_id="00000000:03:00.0",
-                uuid="GPU-test",
+                identity=SimpleNamespace(
+                    index=2,
+                    name="RTX 5090",
+                    pci_bus_id="00000000:03:00.0",
+                    uuid="GPU-test",
+                ),
+                power=SimpleNamespace(default_w=575.0, current_w=450.0),
             )
         ],
     )
     assert gpu_selection.detected_gpu_choices() == [
-        GpuChoice(2, "RTX 5090", "00000000:03:00.0", "GPU-test")
+        GpuChoice(2, "RTX 5090", "00000000:03:00.0", "GPU-test", power_limit_default_w=575.0)
     ]
 
 

--- a/tests/test_ui_window_profile_methods.py
+++ b/tests/test_ui_window_profile_methods.py
@@ -76,6 +76,49 @@ def win(qapp, monkeypatch):
 PROFILE = {"profile_id": "p1", "path": "/tmp/p1.json", "final_verified": True}
 
 
+def test_profile_power_reference_follows_gpu_identity_and_disappearance(win, monkeypatch) -> None:
+    window, _mp = win
+    choices = [
+        GpuChoice(0, "Card A", uuid="GPU-A", power_limit_default_w=360.0),
+        GpuChoice(1, "Card B", uuid="GPU-B", power_limit_default_w=450.0),
+    ]
+    monkeypatch.setattr(window_mod, "gpu_choices_with_fallback", lambda **_: (choices, 0))
+    monkeypatch.setattr(
+        window_mod, "load_profile_summaries",
+        lambda: [
+            {"profile_id": "a", "gpu_identity": {"uuid": "GPU-A"}, "avg_power_w": 270.0},
+            {"profile_id": "b", "gpu_identity": {"uuid": "GPU-B"}, "avg_power_w": 270.0},
+            {"profile_id": "legacy", "avg_power_w": 270.0},
+        ],
+    )
+
+    def power_cells():
+        table = window.profile_list.table
+        return {
+            table.item(row, 0).data(window.profile_list.PROFILE_ID_ROLE): table.item(
+                row, window.profile_list.POWER_COLUMN
+            )
+            for row in range(table.rowCount())
+        }
+
+    window._load_profiles()
+    assert {key: item.text() for key, item in power_cells().items()} == {
+        "a": "270.00 (-25.00%)", "b": "270.00 (-40.00%)", "legacy": "270.00",
+    }
+    window.profile_list.target_gpu_combo.setCurrentIndex(2)
+    assert power_cells()["a"].text() == "270.00 (-25.00%)"
+
+    choices[:] = [choices[1]]
+    window._load_profiles()
+    cells = power_cells()
+    assert cells["a"].text() == cells["legacy"].text() == "270.00"
+    assert cells["a"].foreground().style() == window.QtCore.Qt.BrushStyle.NoBrush
+    assert cells["b"].text() == "270.00 (-40.00%)"
+    choices.clear()
+    window._load_profiles()
+    assert all(item.text() == "270.00" for item in power_cells().values())
+
+
 def test_edit_fan_curve_no_curve_shows_info(win) -> None:
     window, monkeypatch = win
     monkeypatch.setattr(actions_mod, "profile_fan_curve_points", lambda profile: [])

--- a/ui/components/profile_list.py
+++ b/ui/components/profile_list.py
@@ -33,7 +33,7 @@ class ProfileList:
         "Effective MHz",
         "FPS/W",
         "FPS",
-        "Power W (vs stock limit)",
+        "Power W",
         "Mem",
         "Tier",
         "Source",

--- a/ui/components/profile_list.py
+++ b/ui/components/profile_list.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from math import isfinite
 
 from profiles.uv.profile_store import profile_display_name
 from profiles.gpu_identity import (
@@ -32,7 +33,7 @@ class ProfileList:
         "Effective MHz",
         "FPS/W",
         "FPS",
-        "Power W",
+        "Power W (vs stock limit)",
         "Mem",
         "Tier",
         "Source",
@@ -176,6 +177,7 @@ class ProfileList:
         self,
         profiles: list[dict],
         *,
+        default_power_limits_w: dict[str, float | None] | None = None,
         preferred_candidate_id: str = "",
         preferred_profile_id: str = "",
         select_preferred: bool = False,
@@ -194,6 +196,17 @@ class ProfileList:
         table_signals_blocked = self.table.blockSignals(True)
         try:
             self.table.setRowCount(0)
+            stock_limits = {
+                uuid.strip().casefold(): watts
+                for uuid, watts in (default_power_limits_w or {}).items()
+                if uuid.strip()
+            }
+            metric_columns = {
+                self.VOLTAGE_COLUMN: "candidate_voltage_mv",
+                self.EFFECTIVE_MHZ_COLUMN: "avg_core_clock_mhz",
+                self.FPSW_COLUMN: "efficiency_fps_per_w",
+                self.FPS_COLUMN: "avg_fps",
+            }
             tier_winner_ids = _resolved_tier_winner_ids(
                 profiles,
                 include_legacy_profiles=self.single_physical_gpu(),
@@ -215,37 +228,24 @@ class ProfileList:
                     preferred_candidate_id=preferred_candidate_id,
                     preferred_profile_id=preferred_profile_id,
                 )
+                stock_limit_w = _to_float(
+                    stock_limits.get(profile_gpu_uuid(profile).casefold())
+                )
+                if stock_limit_w is not None and (
+                    stock_limit_w <= 0 or not isfinite(stock_limit_w)
+                ):
+                    stock_limit_w = None
                 values = [
                     _date_text(profile),
                     _profile_name(profile),
                     profile_gpu_label(profile),
-                    _format_profile_metric_with_delta(
-                        profile.get("candidate_voltage_mv"),
-                        _profile_base_metric(profile, "candidate_voltage_mv"),
-                        precision=0,
-                        lower_is_better=True,
-                    ),
+                    _format_number(profile.get("candidate_voltage_mv"), precision=0),
                     _format_number(profile.get("lock_clock_mhz"), precision=0),
+                    _format_number(profile.get("avg_core_clock_mhz"), precision=2),
+                    _format_number(profile.get("efficiency_fps_per_w"), precision=4),
+                    _format_number(profile.get("avg_fps"), precision=2),
                     _format_profile_metric_with_delta(
-                        profile.get("avg_core_clock_mhz"),
-                        _profile_base_metric(profile, "avg_core_clock_mhz"),
-                        precision=2,
-                    ),
-                    _format_profile_metric_with_delta(
-                        profile.get("efficiency_fps_per_w"),
-                        _profile_base_metric(profile, "efficiency_fps_per_w"),
-                        precision=2,
-                    ),
-                    _format_profile_metric_with_delta(
-                        profile.get("avg_fps"),
-                        _profile_base_metric(profile, "avg_fps"),
-                        precision=2,
-                    ),
-                    _format_profile_metric_with_delta(
-                        profile.get("avg_power_w"),
-                        _profile_base_metric(profile, "avg_power_w"),
-                        precision=2,
-                        lower_is_better=True,
+                        profile.get("avg_power_w"), stock_limit_w, precision=2
                     ),
                     _format_signed_memory_clock(
                         profile.get("memory_offset_mhz"),
@@ -278,48 +278,31 @@ class ProfileList:
                         item.setTextAlignment(
                             self.QtCore.Qt.AlignRight | self.QtCore.Qt.AlignVCenter
                         )
-                    if column == self.VOLTAGE_COLUMN:
-                        _paint_profile_delta_item(
-                            item,
-                            self.QtGui,
-                            profile.get("candidate_voltage_mv"),
-                            _profile_base_metric(profile, "candidate_voltage_mv"),
-                            label="mV",
-                            lower_is_better=True,
-                        )
-                    if column == self.EFFECTIVE_MHZ_COLUMN:
-                        _paint_profile_delta_item(
-                            item,
-                            self.QtGui,
-                            profile.get("avg_core_clock_mhz"),
-                            _profile_base_metric(profile, "avg_core_clock_mhz"),
-                            label="Effective MHz",
-                        )
-                    if column == self.FPSW_COLUMN:
-                        _paint_profile_delta_item(
-                            item,
-                            self.QtGui,
-                            profile.get("efficiency_fps_per_w"),
-                            _profile_base_metric(profile, "efficiency_fps_per_w"),
-                            label="FPS/W",
-                        )
-                    if column == self.FPS_COLUMN:
-                        _paint_profile_delta_item(
-                            item,
-                            self.QtGui,
-                            profile.get("avg_fps"),
-                            _profile_base_metric(profile, "avg_fps"),
-                            label="FPS",
+                    metric = metric_columns.get(column)
+                    if metric is not None:
+                        item.setToolTip(
+                            _profile_metric_tooltip(
+                                profile.get(metric),
+                                _profile_base_metric(profile, metric),
+                                label=self.COLUMNS[column],
+                                precision=4 if column == self.FPSW_COLUMN else 2,
+                            )
                         )
                     if column == self.POWER_COLUMN:
-                        _paint_profile_delta_item(
-                            item,
-                            self.QtGui,
-                            profile.get("avg_power_w"),
-                            _profile_base_metric(profile, "avg_power_w"),
-                            label="Power W",
-                            lower_is_better=True,
-                        )
+                        delta = _metric_delta_percent(profile.get("avg_power_w"), stock_limit_w)
+                        if delta is not None and stock_limit_w is not None:
+                            item.setToolTip(
+                                f"{delta:+.2f}% relative to this GPU's factory/default "
+                                f"power limit ({stock_limit_w:.2f} W).\n"
+                                "This compares measured power to a power cap, "
+                                "not measured stock power savings."
+                            )
+                            if delta < 0:
+                                item.setForeground(self.QtGui.QColor(theme.GOOD))
+                        elif stock_limit_w is None:
+                            item.setToolTip(
+                                "Factory/default power limit unavailable for this profile's GPU."
+                            )
                     if is_preferred:
                         item.setBackground(self.QtGui.QColor(theme.PROFILE_SELECTED_BG))
                     self.table.setItem(row, column, item)
@@ -906,6 +889,28 @@ def _metric_delta_percent(
     return (
         (current_number - float(baseline_number)) / float(baseline_number)
     ) * 100.0
+
+
+def _profile_metric_tooltip(
+    current,
+    baseline,
+    *,
+    label: str,
+    precision: int = 2,
+) -> str:
+    delta = _metric_delta_percent(
+        current,
+        baseline,
+    )
+    if delta is None:
+        return ""
+    value_text = _format_number(current, precision=precision)
+    base_text = _format_number(baseline, precision=precision)
+    return (
+        f"{label}: {value_text}\n"
+        f"{delta:+.2f}% vs this scan's baseline: {base_text}.\n"
+        "Baselines differ between scans; these percentages do not compare profiles."
+    )
 
 
 def _format_profile_metric_with_delta(

--- a/ui/features/tuning/gpu_selection.py
+++ b/ui/features/tuning/gpu_selection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from integrations.afterburner.import_fan_curve import write_config
@@ -16,6 +16,7 @@ class GpuChoice:
     pci_bus_id: str = ""
     uuid: str = ""
     pci_device_id: str = ""
+    power_limit_default_w: float | None = None
 
     @property
     def label(self) -> str:
@@ -28,10 +29,16 @@ class GpuChoice:
 
 def detected_gpu_choices() -> list[GpuChoice]:
     try:
-        identities = DaemonGpuClient.discover_identities()
+        capabilities = DaemonGpuClient.discover_capabilities()
     except Exception:
-        identities = []
-    return gpu_choices_from_nvml_identities(identities)
+        return []
+    defaults = {item.identity.index: item.power.default_w for item in capabilities}
+    return [
+        replace(choice, power_limit_default_w=defaults.get(choice.index))
+        for choice in gpu_choices_from_nvml_identities(
+            item.identity for item in capabilities
+        )
+    ]
 
 
 def gpu_choices_from_nvml_identities(identities) -> list[GpuChoice]:

--- a/ui/window.py
+++ b/ui/window.py
@@ -734,6 +734,9 @@ class MainWindow(ProfileActionsMixin):
 
     def _load_profiles(self) -> None:
         self.profile_summaries = load_profile_summaries()
+        gpu_choices, _selected_gpu_index = gpu_choices_with_fallback(
+            selected_index=self.gpu_index
+        )
         autostart_info = systemd_autostart_profile_info()
         running_info = (
             running_auto_uv_profile_info()
@@ -742,6 +745,10 @@ class MainWindow(ProfileActionsMixin):
         )
         self.profile_list.set_profiles(
             self.profile_summaries,
+            default_power_limits_w={
+                choice.uuid: choice.power_limit_default_w for choice in gpu_choices
+                if choice.uuid
+            },
             preferred_candidate_id=self.last_auto_uv_candidate_id,
             select_preferred=bool(self.last_auto_uv_candidate_id),
             # The silent-fan tick is sticky: the user's persisted choice is
@@ -754,9 +761,6 @@ class MainWindow(ProfileActionsMixin):
                 or bool(running_info["silent_fan_curve"])
                 or bool(autostart_info["silent_fan_curve"])
             ),
-        )
-        gpu_choices, _selected_gpu_index = gpu_choices_with_fallback(
-            selected_index=self.gpu_index
         )
         self.profile_list.configure_gpu_targets(
             self.profile_summaries,


### PR DESCRIPTION
Profiles previously showed percentages against each scan's own baseline. With different power or memory settings, a lower FPS could appear as a gain while a higher FPS appeared as a loss, and Efficiency's lower wattage could show a smaller reduction than Balanced.

Show absolute FPS, effective MHz and FPS/W (four decimals). Only power keeps an inline percentage **versus that GPU's factory power limit**, colored green below the cap. The compact “Power W” heading keeps the full reference explanation in the tooltip. On the verified RTX 5080's 360 W reference, the saved profiles display Efficiency **247.90 W (−31.14%)**, Balanced **252.23 W (−29.94%)**, Performance **296.41 W (−17.66%)**. This is a cap comparison, not measured savings versus a stock benchmark.

Reuse factory limits already returned by GPU discovery and match them to saved profiles by UUID. Missing, disconnected or unassigned GPUs show watts alone. Sorting continues to use measured numeric values. Other scan-relative metrics remain in explicitly labeled tooltips.

This PR is stacked on **#72** and changes only GUI presentation and its existing GPU-discovery data path. No scan, scoring, curve, daemon or workload changes; the `638dab2` hardware verification remains applicable.

Validation on `ba412da`: **2,414 Python tests passed**, required feature static analysis, touched-file Ruff and production Pyright passed. Existing tests cover the corrected metrics; a Qt controller test covers two GPU limits, target switching, disappearance and legacy profiles. The installed GUI was exercised with the three saved RTX 5080 profiles and the real factory limit; active GPU and boot profiles were preserved.

Merge order: merge #72 first, then retarget this PR from `agent/smooth-curves` to `main`; the repository’s main-targeted packaging CI will then run.
