### PR TITLE
Prepare PenguinBurner 0.8.0

### DIFF
--- a/burnerd/Cargo.lock
+++ b/burnerd/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "penguin-burnerd"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/burnerd/Cargo.toml
+++ b/burnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penguin-burnerd"
-version = "0.7.9"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.82"
 license = "GPL-3.0-only"

--- a/docs/release-notes-0.8.0.md
+++ b/docs/release-notes-0.8.0.md
@@ -1,0 +1,27 @@
+# PenguinBurner 0.8.0
+
+Thanks to [@Ernold11](https://github.com/Ernold11) for the new **Game Library**,
+bringing **Steam and Lutris** together with background discovery, launcher
+badges and sorting.
+
+**Which launcher should we support next? Heroic?** Tell us what you use in
+[Discussions](https://github.com/jpietek/PenguinBurner/discussions).
+
+- **Smoother Auto-UV curves** stay consistent throughout scanning, final verification and profile saving.
+- **Per-tier controls** expose voltage, target clock, memory offset and power limit for Efficiency, Balanced and Performance.
+- **Lower custom clocks** are tested after voltage descent, with bounded searches for GPUs without preset targets.
+- **Automatic recovery** retries eligible safer settings after failed candidates or final checks while respecting crash blacklists.
+- **Partial results** remain available when a later tier fails.
+- **Adaptive per-game profiles** handle FPS caps more consistently and avoid unnecessary tier increases, thanks again to [@Ernold11](https://github.com/Ernold11).
+
+Other fixes:
+
+- Clearer profile metrics: absolute FPS/clocks; power percentages against the factory limit.
+- Correct live-profile display with the HUD hidden and accurate startup-profile state.
+- Stable Auto-UV tab sizing and adaptive timing independent of overlay refresh rate.
+- Better Q2RTX installation recovery and Lutris NVAPI-shim handling.
+- Preserve game logs and quoted or manually edited launch options.
+- Improved distro packaging checks.
+
+HTML reports cover [local RTX 5080 three-tier verification and the Auto-UV cookbook](https://jpietek.github.io/PenguinBurner/auto-uv-cookbook/)
+and [contributor-provided RTX 5070 Ti verification results and before/after curves](https://jpietek.github.io/PenguinBurner/pr72-curve-comparison/).

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: PenguinBurner contributors
 
 pkgname=penguin-burner
-pkgver=0.7.9
-pkgrel=2
+pkgver=0.8.0
+pkgrel=1
 pkgdesc='NVIDIA GPU automatic undervolting and fine tuning tool'
 arch=('x86_64')
 url='https://github.com/jpietek/PenguinBurner'

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -49,7 +49,7 @@ are never committed to Git.
 From a clean checkout containing the release tag and Debian signing key:
 
 ```bash
-scripts/publish-ppa.sh 0.7.9
+scripts/publish-ppa.sh 0.8.0
 ```
 
 That one command builds and validates the Resolute source package, uploads it

--- a/packaging/flatpak/io.github.jpietek.PenguinBurner.metainfo.xml
+++ b/packaging/flatpak/io.github.jpietek.PenguinBurner.metainfo.xml
@@ -20,6 +20,7 @@
   </developer>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.8.0" date="2026-09-06" />
     <release version="0.7.9-1" date="2026-09-01" />
     <release version="0.7.9" date="2026-08-17" />
     <release version="0.7.8" date="2026-08-08" />

--- a/packaging/rpm/penguin-burner.spec
+++ b/packaging/rpm/penguin-burner.spec
@@ -1,5 +1,5 @@
 Name:           penguin-burner
-Version:        0.7.9
+Version:        0.8.0
 Release:        1%{?dist}
 Summary:        NVIDIA GPU automatic undervolting and fine tuning tool
 
@@ -108,6 +108,10 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.jpietek.Pen
 %{_datadir}/penguin-burner/penguin_burner.sh
 
 %changelog
+* Sun Sep 06 2026 PenguinBurner contributors <noreply@github.com> - 0.8.0-1
+- Add Auto-UV recovery, smooth curves, per-tier targets and clearer profile metrics.
+- Unify the Game Library and improve adaptive switching under frame-rate caps.
+
 * Mon Aug 17 2026 PenguinBurner contributors <noreply@github.com> - 0.7.9-1
 - Add RTD3 sleep handling, resume recovery, telemetry fallback, and partial
   multi-GPU profile support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguin-burner"
-version = "0.7.9"
+version = "0.8.0"
 description = "NVIDIA GPU tuning tool for Linux: automatic and adaptive undervolting, an in-game monitoring overlay with PC latency and pre-frame-generation FPS, plus MSI Afterburner imports and LACT exports"
 requires-python = ">=3.11"
 dynamic = ["readme"]


### PR DESCRIPTION
Prepare PenguinBurner 0.8.0 after merging the Auto-UV and profile-metrics changes. Align Python, daemon, Arch, RPM and Flatpak versions, refresh the PPA command, and add the approved release notes with contributor credits and both GPU reports.

Validation: 2,414 Python tests passed; release-version check and required static-analysis checks passed (repository-wide Pyright still reports 91 advisory diagnostics). This changes release metadata and documentation only; the prior RTX 5080 three-tier verification and contributor RTX 5070 Ti results are linked in the notes.

After packaging CI succeeds, merge this exact head, publish v0.8.0 and build the release packages from that tag.
