### PR TITLE
Name an edited profile after the point it runs at

### DIFF
--- a/curve_editors/uv/vf_curve_manual_editor.py
+++ b/curve_editors/uv/vf_curve_manual_editor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from auto_uv.domain.user_options import AUTO_UV_CURVE_TUNING
 from auto_uv.persistence.verified_candidate_result_file import artifact_points
+from profiles.uv.profile_store import user_edited_display_name
 
 
 MANUAL_SMOOTH_TRIGGER_CLOCK_BINS = 5
@@ -595,9 +596,10 @@ def user_edited_profile_payload(
     payload.update(
         {
             "profile_source": USER_EDITED_PROFILE_SOURCE,
-            "display_name": (
-                f"User edited {int(edit.anchor_clock_mhz)} MHz "
-                f"{int(edit.anchor_voltage_mv)} mV"
+            "display_name": user_edited_display_name(
+                lock_clock_mhz=int(edit.anchor_clock_mhz),
+                candidate_voltage_mv=int(edit.anchor_voltage_mv),
+                memory_offset_mhz=parent_profile.get("memory_offset_mhz"),
             ),
             "candidate_id": (
                 f"user-edited-{int(edit.anchor_voltage_mv)}mv-"

--- a/profiles/uv/memory_offset_edit.py
+++ b/profiles/uv/memory_offset_edit.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from profiles.uv.profile_store import user_edited_display_name
+
 USER_EDITED_MEMORY_OFFSET_SOURCE = "user-edited"
 
 _EXCLUDED_PARENT_KEYS = {
@@ -45,8 +47,13 @@ def user_edited_memory_offset_profile_payload(
     payload.update(
         {
             "profile_source": USER_EDITED_MEMORY_OFFSET_SOURCE,
-            "display_name": (
-                f"User edited memory offset {int(new_memory_offset_mhz):+d} MT/s"
+            # Name it after the point the profile runs at, in the same
+            # phrasing as the running-profile line and the profile table --
+            # the edited memory offset shows there as memory-clock MHz.
+            "display_name": user_edited_display_name(
+                lock_clock_mhz=parent_profile.get("lock_clock_mhz"),
+                candidate_voltage_mv=parent_profile.get("candidate_voltage_mv"),
+                memory_offset_mhz=int(new_memory_offset_mhz),
             ),
             "memory_offset_mhz": int(new_memory_offset_mhz),
             "final_verified": False,

--- a/profiles/uv/profile_store.py
+++ b/profiles/uv/profile_store.py
@@ -501,6 +501,61 @@ def profile_display_name(profile: dict) -> str:
     return str(profile.get("candidate_id") or profile.get("profile_id") or "")
 
 
+def memory_offset_summary(value) -> str:
+    """`mem +3000 MHz`, or nothing when the profile carries no offset."""
+    text = display_signed_memory_clock(value)
+    if not text or text.startswith("0 "):
+        return ""
+    return f"mem {text}"
+
+
+def clock_voltage_memory_summary(
+    *,
+    lock_clock_mhz=None,
+    candidate_voltage_mv=None,
+    memory_offset_mhz=None,
+) -> str:
+    """`2500 MHz 850 mV, mem +3000 MHz` -- the one phrasing for a tuning point.
+
+    The running-profile line, the profile table and the names given to
+    user-edited profiles all read the same way because they all come through
+    here.
+    """
+    clock = _display_number(lock_clock_mhz, precision=0)
+    voltage = _display_number(candidate_voltage_mv, precision=0)
+    if clock and voltage:
+        text = f"{clock} MHz {voltage} mV"
+    else:
+        text = f"{clock} MHz" if clock else (f"{voltage} mV" if voltage else "")
+    memory = memory_offset_summary(memory_offset_mhz)
+    if text and memory:
+        return f"{text}, {memory}"
+    return text or memory
+
+
+def profile_clock_voltage_memory_summary(profile: dict) -> str:
+    return clock_voltage_memory_summary(
+        lock_clock_mhz=profile.get("lock_clock_mhz"),
+        candidate_voltage_mv=profile.get("candidate_voltage_mv"),
+        memory_offset_mhz=profile.get("memory_offset_mhz"),
+    )
+
+
+def user_edited_display_name(
+    *,
+    lock_clock_mhz=None,
+    candidate_voltage_mv=None,
+    memory_offset_mhz=None,
+) -> str:
+    """Name an edited profile after the point it actually runs at."""
+    summary = clock_voltage_memory_summary(
+        lock_clock_mhz=lock_clock_mhz,
+        candidate_voltage_mv=candidate_voltage_mv,
+        memory_offset_mhz=memory_offset_mhz,
+    )
+    return f"User edited {summary}" if summary else "User edited profile"
+
+
 def _display_date(value) -> str:
     text = str(value or "").strip()
     if not text:

--- a/profiles/uv/profile_store.py
+++ b/profiles/uv/profile_store.py
@@ -541,6 +541,35 @@ def profile_clock_voltage_memory_summary(profile: dict) -> str:
     )
 
 
+# The two shapes the edit dialogs generated before they named a profile after
+# the point it runs at: "User edited memory offset +6000 MT/s" and the
+# memory-less "User edited 2500 MHz 850 mV".
+_LEGACY_USER_EDITED_NAME_RE = re.compile(
+    r"^User edited (?:memory offset [+-]?\d+ MT/s|\d+ MHz \d+ mV)$"
+)
+
+
+def profile_presentation_name(profile: dict) -> str:
+    """The name to show for a saved profile.
+
+    A profile edited before the naming changed still carries the old label in
+    its file. Rewriting saved profiles for the sake of a label would be a
+    silent write to user data, so the refresh happens here on read: a name
+    that is recognisably one the old dialogs generated is recomputed from the
+    profile's own clock, voltage and memory offset. Every other name --
+    Afterburner imports, edited fan curves, anything hand-picked -- is left
+    exactly as saved.
+    """
+    display_name = str(profile.get("display_name", "")).strip()
+    if display_name and _LEGACY_USER_EDITED_NAME_RE.match(display_name):
+        summary = profile_clock_voltage_memory_summary(profile)
+        if summary:
+            return f"User edited {summary}"
+    if display_name:
+        return display_name
+    return profile_display_name(profile)
+
+
 def user_edited_display_name(
     *,
     lock_clock_mhz=None,

--- a/tests/test_manual_curve_editor.py
+++ b/tests/test_manual_curve_editor.py
@@ -717,6 +717,7 @@ def test_user_edited_profile_payload_requires_verification() -> None:
             "path": "/tmp/parent.json",
             "candidate_voltage_mv": 900,
             "lock_clock_mhz": 2550,
+            "memory_offset_mhz": 3000,
             "avg_fps": 120.0,
             "final_verified": True,
         },
@@ -730,6 +731,9 @@ def test_user_edited_profile_payload_requires_verification() -> None:
     assert payload["requires_verification"] is True
     assert payload["candidate_voltage_mv"] == 930
     assert payload["lock_clock_mhz"] == 2595
+    # The edited point plus the inherited memory offset, phrased like the
+    # running-profile line.
+    assert payload["display_name"] == "User edited 2595 MHz 930 mV, mem +1500 MHz"
     assert "avg_fps" not in payload
     assert payload["manual_edit"]["parent_profile_id"] == "parent"
 

--- a/tests/test_memory_offset_edit.py
+++ b/tests/test_memory_offset_edit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from profiles.uv.profile_store import profile_presentation_name
 from profiles.uv.memory_offset_edit import (
     editable_memory_offset_from_profile,
     user_edited_memory_offset_profile_payload,
@@ -72,3 +73,68 @@ def test_user_edited_memory_offset_profile_payload_without_original() -> None:
 def test_user_edited_memory_offset_profile_payload_names_bare_edit() -> None:
     payload = user_edited_memory_offset_profile_payload({}, 0)
     assert payload["display_name"] == "User edited profile"
+
+
+def test_profile_presentation_name_refreshes_legacy_memory_offset_name() -> None:
+    # Saved before the rename: the file still says MT/s, the UI must not.
+    assert (
+        profile_presentation_name(
+            {
+                "display_name": "User edited memory offset +6000 MT/s",
+                "lock_clock_mhz": 2500,
+                "candidate_voltage_mv": 850,
+                "memory_offset_mhz": 6000,
+            }
+        )
+        == "User edited 2500 MHz 850 mV, mem +3000 MHz"
+    )
+
+
+def test_profile_presentation_name_refreshes_legacy_curve_name() -> None:
+    assert (
+        profile_presentation_name(
+            {
+                "display_name": "User edited 2500 MHz 850 mV",
+                "lock_clock_mhz": 2500,
+                "candidate_voltage_mv": 850,
+                "memory_offset_mhz": 6000,
+            }
+        )
+        == "User edited 2500 MHz 850 mV, mem +3000 MHz"
+    )
+
+
+def test_profile_presentation_name_keeps_other_saved_names() -> None:
+    # An edited fan curve, an Afterburner import and anything hand-picked keep
+    # the name in their file.
+    for saved in (
+        "User edited fan curve 2500 MHz 850 mV",
+        "MSI Afterburner Curve 2500 MHz 850 mV",
+        "My quiet profile",
+    ):
+        assert (
+            profile_presentation_name(
+                {
+                    "display_name": saved,
+                    "lock_clock_mhz": 2500,
+                    "candidate_voltage_mv": 850,
+                    "memory_offset_mhz": 6000,
+                }
+            )
+            == saved
+        )
+
+
+def test_profile_presentation_name_falls_back_without_a_saved_name() -> None:
+    assert (
+        profile_presentation_name({"lock_clock_mhz": 2500, "candidate_voltage_mv": 850})
+        == "2500 MHz 850 mV"
+    )
+    # A legacy name with nothing to recompute from stays as saved.
+    assert (
+        profile_presentation_name(
+            {"display_name": "User edited memory offset +0 MT/s"}
+        )
+        == "User edited memory offset +0 MT/s"
+    )
+

--- a/tests/test_memory_offset_edit.py
+++ b/tests/test_memory_offset_edit.py
@@ -37,6 +37,9 @@ def test_user_edited_memory_offset_profile_payload_requires_verification() -> No
 
     assert payload["profile_source"] == "user-edited"
     assert payload["memory_offset_mhz"] == 400
+    # Named like the running-profile line: the tuning point, memory offset in
+    # memory-clock MHz (half the stored MT/s), not "memory offset +400 MT/s".
+    assert payload["display_name"] == "User edited 2550 MHz 900 mV, mem +200 MHz"
     assert payload["final_verified"] is False
     assert payload["verification_status"] == "unverified"
     assert payload["requires_verification"] is True
@@ -64,3 +67,8 @@ def test_user_edited_memory_offset_profile_payload_without_original() -> None:
     )
     assert payload["manual_edit"]["original_memory_offset_mhz"] is None
     assert payload["manual_edit"]["new_memory_offset_mhz"] == 150
+
+
+def test_user_edited_memory_offset_profile_payload_names_bare_edit() -> None:
+    payload = user_edited_memory_offset_profile_payload({}, 0)
+    assert payload["display_name"] == "User edited profile"

--- a/ui/components/profile_list.py
+++ b/ui/components/profile_list.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from math import isfinite
 
-from profiles.uv.profile_store import profile_display_name
+from profiles.uv.profile_store import profile_presentation_name
 from profiles.gpu_identity import (
     profile_gpu_compatibility,
     profile_gpu_label,
@@ -1134,10 +1134,7 @@ def _truthy(value: object) -> bool:
 
 
 def _profile_name(profile: dict) -> str:
-    display_name = str(profile.get("display_name", "")).strip()
-    if display_name:
-        return display_name
-    return profile_display_name(profile)
+    return profile_presentation_name(profile)
 
 
 def _profile_matches_preference(

--- a/ui/features/profiles/profiles.py
+++ b/ui/features/profiles/profiles.py
@@ -7,7 +7,7 @@ import time
 
 from overlay.state import read_overlay_state
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR
-from profiles.uv.profile_store import display_signed_memory_clock
+from profiles.uv.profile_store import profile_clock_voltage_memory_summary
 from profiles.uv.profile_store import profile_display_name
 from profiles.uv.profile_store import read_auto_uv_profile_summaries
 from profiles.uv.profile_tiers import available_adaptive_tiers
@@ -168,26 +168,9 @@ def profile_status_label(profiles: list[dict], selector: str) -> str:
 
 
 def profile_frequency_voltage(profile: dict) -> str:
-    clock = _status_number(profile.get("lock_clock_mhz"), precision=0)
-    voltage = _status_number(profile.get("candidate_voltage_mv"), precision=0)
-    if clock and voltage:
-        text = f"{clock} MHz {voltage} mV"
-    else:
-        text = f"{clock} MHz" if clock else (f"{voltage} mV" if voltage else "")
-    memory = _memory_offset_summary(profile.get("memory_offset_mhz"))
-    if text and memory:
-        return f"{text}, {memory}"
-    return text or memory
-
-
-def _memory_offset_summary(value) -> str:
-    # Match the profile table / Auto-UV dialog (signed memory-clock MHz), but
-    # suppress a no-op +0 MHz so the running-profile line stays clean when the
-    # profile carries no memory offset.
-    text = display_signed_memory_clock(value)
-    if not text or text.startswith("0 "):
-        return ""
-    return f"mem {text}"
+    # Same phrasing as the profile table and the names of user-edited
+    # profiles: one helper owns it.
+    return profile_clock_voltage_memory_summary(profile)
 
 
 def runner_status_parts(
@@ -666,18 +649,6 @@ def _daemon_status_payload() -> dict[str, object]:
     except Exception:
         return {}
     return payload if isinstance(payload, dict) else {}
-
-
-def _status_number(value, *, precision: int) -> str:
-    if value in (None, ""):
-        return ""
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return ""
-    if precision <= 0:
-        return str(int(round(number)))
-    return f"{number:.{int(precision)}f}"
 
 
 def _on_off(value: bool) -> str:

--- a/ui/features/profiles/profiles.py
+++ b/ui/features/profiles/profiles.py
@@ -9,6 +9,7 @@ from overlay.state import read_overlay_state
 from profiles.uv.profile_store import STOCK_PROFILE_SELECTOR
 from profiles.uv.profile_store import profile_clock_voltage_memory_summary
 from profiles.uv.profile_store import profile_display_name
+from profiles.uv.profile_store import profile_presentation_name
 from profiles.uv.profile_store import read_auto_uv_profile_summaries
 from profiles.uv.profile_tiers import available_adaptive_tiers
 from profiles.uv.profile_tiers import profile_tier_label
@@ -162,7 +163,8 @@ def profile_status_label(profiles: list[dict], selector: str) -> str:
         return text or "unknown profile"
     display_name = str(profile.get("display_name", "")).strip()
     if display_name:
-        return display_name
+        # Saved name, with a legacy user-edited one refreshed on read.
+        return profile_presentation_name(profile)
     text = profile_frequency_voltage(profile)
     return text or profile_display_name(profile) or str(profile.get("profile_id", ""))
 


### PR DESCRIPTION
## Name an edited profile after the point it runs at

An edited profile was named by the edit that made it, while every other surface names a profile by the point it runs at. The same profile therefore read two different ways depending on where you looked, in two different memory units:

| where | before |
| --- | --- |
| header, after a memory-offset edit | `User edited memory offset +6000 MT/s` |
| header, any other profile | `2500 MHz 850 mV, mem +3000 MHz` |

Both lines describe the same +3000 MHz memory clock -- the stored offset is an NVML transfer-rate value, so the profile table and the Auto-UV dialog already halve it for display, and only the edited-profile name did not.

### What changed

One helper in `profiles/uv/profile_store.py` now owns that phrasing, and every surface goes through it:

- a memory-offset edit is named with the parent's clock and voltage plus the new offset: `User edited 2500 MHz 850 mV, mem +3000 MHz`;
- a V/F curve edit is named with the edited anchor plus the inherited offset, so the memory part no longer disappears from the name;
- the running-profile line calls the same helper instead of its own copy of the formatting, which is what let the two drift apart to begin with.

Profiles saved before this still carry the old label in their file, so the list and the header would have gone on showing two namings side by side. Rewriting saved profiles for the sake of a label would be a silent write to the user's own data, so the refresh happens on read: a name recognisably generated by the old dialogs is recomputed from the profile's own clock, voltage and memory offset. Every other saved name -- an edited fan curve, an Afterburner import, anything hand-picked -- is shown exactly as saved, and no profile file is touched.

### Impact

- **Users:** an edited profile reads the same in the profile list and in the `Currently running profile` line, with the memory offset in memory-clock MHz everywhere. Existing profiles pick the new name up on the next read; their files are unchanged, so reverting this change restores the old labels with nothing to recover.
- **Developers:** `clock_voltage_memory_summary` / `profile_clock_voltage_memory_summary` / `user_edited_display_name` / `profile_presentation_name` in `profiles/uv/profile_store.py` are the one place that phrases a tuning point. `ui/features/profiles/profiles.py` lost its duplicate `_memory_offset_summary` and `_status_number`.

| where | after |
| --- | --- |
| header, after a memory-offset edit | `User edited 2500 MHz 850 mV, mem +3000 MHz` |
| header, any other profile | `2500 MHz 850 mV, mem +3000 MHz` |

### Checks

- `python -m pytest tests/ -q` -- 2437 passed, rebased on current `main`.
- New tests cover both edited-profile names and the read-time refresh, including the names that must be left alone.
- `ruff` on the touched files: no new diagnostics (one fewer, from the dead helper removed).
- Driven in the real Qt app: reinstalled locally, launched the GUI, saved an edited profile and confirmed the list and the header now read the same, and that previously saved profiles picked the refreshed name up.
- No daemon change, so `burnerd/` was not rebuilt and the running service was left as it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
